### PR TITLE
Resume the interview when Gemini closes the socket

### DIFF
--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
@@ -15,6 +16,12 @@ use crate::runtime::{RuntimeBootstrap, TOOL_LOG_HINT, TOOL_READ_EDITOR};
 
 const LIVE_WEBSOCKET_ENDPOINT: &str = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent";
 const SETUP_TIMEOUT: Duration = Duration::from_secs(15);
+/// Bounds the socket itself, where `SETUP_TIMEOUT` bounds the exchange over it.
+/// Without this a connect that never answers hangs its caller for as long as
+/// the OS allows, and the caller is `run_room`'s loop: an interview whose
+/// candidate leaves during a stalled reconnect would not notice they had gone,
+/// and its own deadline would not fire either.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 /// Per attempt, so three tries plus backoff stay inside `REPORT_TIMEOUT`.
 const REPORT_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(12);
 const REPORT_RETRY_BACKOFF: [Duration; 2] = [Duration::from_secs(1), Duration::from_secs(3)];
@@ -26,6 +33,12 @@ pub struct GeminiLiveSession {
     writer: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>,
     reader: JoinHandle<()>,
     events: Receiver<GeminiEvent>,
+    /// Shared with the reader task, which is the only writer. Held beside the
+    /// event channel rather than sent through it because it is wanted at
+    /// exactly the moment the channel is finished: after the socket closed and
+    /// the last events were drained, when the caller has to decide whether it
+    /// can resume.
+    resumption: Arc<Mutex<Option<String>>>,
 }
 
 impl GeminiLiveSession {
@@ -62,6 +75,16 @@ impl GeminiLiveSession {
 
     pub async fn next_event(&mut self) -> Option<GeminiEvent> {
         self.events.recv().await
+    }
+
+    /// The most recent resumable checkpoint the server offered, or `None` if
+    /// it never offered one. Valid for two hours after the session ends, so a
+    /// caller that reconnects promptly can hand this straight back.
+    pub fn resumption_handle(&self) -> Option<String> {
+        self.resumption
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone()
     }
 
     pub async fn close(mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -109,7 +132,18 @@ pub async fn open_live_session(
     api_key: &str,
     boot: &RuntimeBootstrap<'_>,
 ) -> Result<GeminiLiveSession, Box<dyn std::error::Error + Send + Sync>> {
-    open_live_session_at(&gemini_live_websocket_url(api_key), boot).await
+    open_live_session_at(&gemini_live_websocket_url(api_key), boot, None).await
+}
+
+/// Continues the session `handle` came from, keeping everything said so far.
+/// The caller must not re-send the greeting after this: the model still
+/// remembers giving it.
+pub async fn resume_live_session(
+    api_key: &str,
+    boot: &RuntimeBootstrap<'_>,
+    handle: &str,
+) -> Result<GeminiLiveSession, Box<dyn std::error::Error + Send + Sync>> {
+    open_live_session_at(&gemini_live_websocket_url(api_key), boot, Some(handle)).await
 }
 
 /// Gemini answers 503 often enough that a single attempt loses reports for a
@@ -193,11 +227,14 @@ async fn generate_report_once(
 async fn open_live_session_at(
     url: &str,
     boot: &RuntimeBootstrap<'_>,
+    resume: Option<&str>,
 ) -> Result<GeminiLiveSession, Box<dyn std::error::Error + Send + Sync>> {
-    let (mut stream, _) = connect_async(url).await?;
+    let (mut stream, _) = tokio::time::timeout(CONNECT_TIMEOUT, connect_async(url))
+        .await
+        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "Gemini connect timed out"))??;
     stream
         .send(Message::Text(
-            serde_json::to_string(&live_setup_message(boot))?.into(),
+            serde_json::to_string(&live_setup_message(boot, resume))?.into(),
         ))
         .await?;
     tokio::time::timeout(SETUP_TIMEOUT, wait_for_setup_complete(&mut stream))
@@ -205,6 +242,12 @@ async fn open_live_session_at(
         .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "Gemini setup timed out"))??;
     let (writer, mut reader) = stream.split();
     let (sender, events) = channel(GEMINI_EVENT_QUEUE);
+
+    // Seeded with the handle we resumed from: the server does not always
+    // re-issue one immediately, and losing it here would turn the next
+    // reconnect into the cold start this exists to avoid.
+    let resumption = Arc::new(Mutex::new(resume.map(str::to_string)));
+    let handles = Arc::clone(&resumption);
     let reader = tokio::spawn(async move {
         while let Some(message) = reader.next().await {
             // Both arms below used to end the session without saying anything.
@@ -234,7 +277,14 @@ async fn open_live_session_at(
             let Some(text) = websocket_message_text(message) else {
                 continue;
             };
-            for event in parse_server_events(&text) {
+            let message = parse_server_message(&text);
+            if let Some(handle) = message.resumption_handle {
+                *handles.lock().unwrap_or_else(|error| error.into_inner()) = Some(handle);
+            }
+            if let Some(time_left) = message.go_away_time_left {
+                eprintln!("Gemini will close this connection in {time_left}; will resume");
+            }
+            for event in message.events {
                 // Bounded on purpose: a stalled main loop must slow the socket
                 // down, not let inbound audio pile up without a ceiling.
                 if sender.send(event).await.is_err() {
@@ -247,6 +297,7 @@ async fn open_live_session_at(
         writer,
         reader,
         events,
+        resumption,
     })
 }
 
@@ -304,7 +355,12 @@ pub fn redact_api_key(text: &str, api_key: &str) -> String {
         .replace(&percent_encode_query_value(api_key), "[REDACTED]")
 }
 
-fn live_setup_message(boot: &RuntimeBootstrap<'_>) -> Value {
+/// `resume` carries a handle from a previous connection's
+/// `sessionResumptionUpdate`. Absent, this asks the server to start a fresh
+/// resumable session; present, it continues the earlier one with its history
+/// intact, which is the difference between a reconnect the candidate hears as
+/// a pause and one they hear as the interviewer starting over.
+fn live_setup_message(boot: &RuntimeBootstrap<'_>, resume: Option<&str>) -> Value {
     json!({
         "setup": {
             "model": format!("models/{}", gemini_model_id(boot.live_model)),
@@ -357,7 +413,15 @@ fn live_setup_message(boot: &RuntimeBootstrap<'_>) -> Value {
             "contextWindowCompression": {
                 "slidingWindow": {}
             },
-            "sessionResumption": {}
+
+            // Solves a different limit from the compression above it. That one
+            // raises the ceiling on a session's length; this one survives the
+            // socket, which the server closes after about ten minutes however
+            // much of the session is left to run.
+            "sessionResumption": match resume {
+                Some(handle) => json!({ "handle": handle }),
+                None => json!({}),
+            }
         }
     })
 }
@@ -460,11 +524,48 @@ fn websocket_message_text(message: Message) -> Option<String> {
     }
 }
 
+/// One inbound frame, split into the parts the interview reacts to and the
+/// connection bookkeeping it only records.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ServerMessage {
+    events: Vec<GeminiEvent>,
+    /// From `sessionResumptionUpdate`, and only once the server marks the
+    /// point resumable. An update that is not resumable carries a handle that
+    /// would be refused on reconnect, so it must not overwrite a good one.
+    resumption_handle: Option<String>,
+    /// From `goAway`: how long this socket has left. Advisory, and logged
+    /// rather than acted on, because the reconnect path is driven by the close
+    /// itself and works whether or not the warning arrives.
+    go_away_time_left: Option<String>,
+}
+
+#[cfg(test)]
 fn parse_server_events(text: &str) -> Vec<GeminiEvent> {
+    parse_server_message(text).events
+}
+
+fn parse_server_message(text: &str) -> ServerMessage {
     let Ok(message) = serde_json::from_str::<Value>(text) else {
-        return Vec::new();
+        return ServerMessage::default();
     };
     let mut events = Vec::new();
+
+    let resumption_handle = message
+        .get("sessionResumptionUpdate")
+        .filter(|update| {
+            update
+                .get("resumable")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .and_then(|update| update.get("newHandle").and_then(Value::as_str))
+        .filter(|handle| !handle.is_empty())
+        .map(str::to_string);
+
+    let go_away_time_left = message
+        .pointer("/goAway/timeLeft")
+        .and_then(Value::as_str)
+        .map(str::to_string);
 
     if let Some(parts) = message
         .pointer("/serverContent/modelTurn/parts")
@@ -535,7 +636,11 @@ fn parse_server_events(text: &str) -> Vec<GeminiEvent> {
         }
     }
 
-    events
+    ServerMessage {
+        events,
+        resumption_handle,
+        go_away_time_left,
+    }
 }
 
 fn percent_encode_query_value(value: &str) -> String {
@@ -579,7 +684,7 @@ mod tests {
         let config = live_config(&[("GEMINI_VOICE", "Kore")]);
         let boot = bootstrap(&config, "interview-fixed", Some("two-sum"), 45);
 
-        let message = live_setup_message(&boot);
+        let message = live_setup_message(&boot, None);
         let setup = &message["setup"];
 
         assert_eq!(setup["model"], "models/gemini-live");
@@ -650,13 +755,77 @@ mod tests {
         assert_eq!(setup["sessionResumption"], json!({}));
     }
 
+    /// The empty object above asks for handles; this is what spends one. A
+    /// setup that drops the handle reconnects into a session with no history,
+    /// which the candidate hears as the interviewer starting the interview
+    /// over ten minutes in.
+    #[test]
+    fn live_setup_carries_the_resumption_handle_when_resuming() {
+        let config = live_config(&[]);
+        let boot = bootstrap(&config, "interview-fixed", Some("two-sum"), 45);
+
+        let setup = live_setup_message(&boot, Some("handle-abc"))["setup"].clone();
+
+        assert_eq!(
+            setup["sessionResumption"],
+            json!({ "handle": "handle-abc" })
+        );
+    }
+
+    #[test]
+    fn resumption_update_is_taken_only_once_the_server_marks_it_resumable() {
+        let resumable = parse_server_message(
+            r#"{"sessionResumptionUpdate":{"newHandle":"handle-abc","resumable":true}}"#,
+        );
+        assert_eq!(resumable.resumption_handle.as_deref(), Some("handle-abc"));
+
+        // Mid-turn updates arrive with `resumable` absent or false. Their
+        // handle is refused on reconnect, so taking one would replace a
+        // working checkpoint with a broken one.
+        let mid_turn = parse_server_message(
+            r#"{"sessionResumptionUpdate":{"newHandle":"handle-mid","resumable":false}}"#,
+        );
+        assert_eq!(mid_turn.resumption_handle, None);
+
+        let unmarked =
+            parse_server_message(r#"{"sessionResumptionUpdate":{"newHandle":"handle-bare"}}"#);
+        assert_eq!(unmarked.resumption_handle, None);
+    }
+
+    #[test]
+    fn go_away_time_left_is_read_and_carries_no_events() {
+        let message = parse_server_message(r#"{"goAway":{"timeLeft":"9.5s"}}"#);
+
+        assert_eq!(message.go_away_time_left.as_deref(), Some("9.5s"));
+        assert!(message.events.is_empty());
+    }
+
+    /// The two halves of one frame: Gemini attaches a resumption update to a
+    /// message that is also carrying speech, so reading either one must not
+    /// cost the other.
+    #[test]
+    fn a_frame_can_carry_both_a_resumption_update_and_content() {
+        let message = parse_server_message(
+            r#"{
+                "serverContent":{"outputTranscription":{"text":"go on"}},
+                "sessionResumptionUpdate":{"newHandle":"handle-abc","resumable":true}
+            }"#,
+        );
+
+        assert_eq!(
+            message.events,
+            vec![GeminiEvent::OutputTranscript("go on".to_string())]
+        );
+        assert_eq!(message.resumption_handle.as_deref(), Some("handle-abc"));
+    }
+
     #[test]
     fn live_setup_accepts_model_names_with_resource_prefix() {
         let config = live_config(&[("GEMINI_LIVE_MODEL", "models/gemini-live")]);
         let boot = bootstrap(&config, "interview-fixed", Some("two-sum"), 45);
 
         assert_eq!(
-            live_setup_message(&boot)["setup"]["model"],
+            live_setup_message(&boot, None)["setup"]["model"],
             "models/gemini-live"
         );
     }
@@ -906,7 +1075,7 @@ mod tests {
             setup
         });
 
-        let session = open_live_session_at(&format!("ws://{address}"), &boot)
+        let session = open_live_session_at(&format!("ws://{address}"), &boot, None)
             .await
             .unwrap();
         let setup: Value = serde_json::from_str(&server.await.unwrap()).unwrap();
@@ -942,7 +1111,7 @@ mod tests {
                 .unwrap();
         });
 
-        let mut session = open_live_session_at(&format!("ws://{address}"), &boot)
+        let mut session = open_live_session_at(&format!("ws://{address}"), &boot, None)
             .await
             .unwrap();
 
@@ -951,6 +1120,85 @@ mod tests {
             Some(GeminiEvent::OutputTranscript("hello".to_string()))
         );
         session.close().await.unwrap();
+        server.await.unwrap();
+    }
+
+    /// The whole point of reading the update: the handle has to still be
+    /// there once the socket is gone, because that is when the caller asks.
+    #[tokio::test]
+    async fn the_reader_keeps_the_latest_handle_after_the_socket_closes() {
+        let config = live_config(&[]);
+        let boot = bootstrap(&config, "interview-fixed", Some("two-sum"), 45);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(socket).await.unwrap();
+            let _ = socket.next().await.unwrap().unwrap();
+            socket
+                .send(Message::Text(r#"{"setupComplete":{}}"#.into()))
+                .await
+                .unwrap();
+            for handle in ["handle-first", "handle-latest"] {
+                socket
+                    .send(Message::Text(
+                        format!(
+                            r#"{{"sessionResumptionUpdate":{{"newHandle":"{handle}","resumable":true}}}}"#
+                        )
+                        .into(),
+                    ))
+                    .await
+                    .unwrap();
+            }
+
+            // Ten minutes, compressed: the server hangs up and the reader task
+            // ends, which is the state the caller reads the handle in.
+            socket.close(None).await.unwrap();
+        });
+
+        let mut session = open_live_session_at(&format!("ws://{address}"), &boot, None)
+            .await
+            .unwrap();
+
+        // Draining to the end of the stream is what puts the reader past both
+        // updates and the close.
+        assert_eq!(session.next_event().await, None);
+        assert_eq!(
+            session.resumption_handle().as_deref(),
+            Some("handle-latest")
+        );
+        server.await.unwrap();
+    }
+
+    /// A resumed connection that is closed before the server re-issues an
+    /// update must still be able to resume, or one failure early in a long
+    /// interview would poison every reconnect after it.
+    #[tokio::test]
+    async fn a_resumed_session_keeps_its_handle_until_a_new_one_arrives() {
+        let config = live_config(&[]);
+        let boot = bootstrap(&config, "interview-fixed", Some("two-sum"), 45);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(socket).await.unwrap();
+            let _ = socket.next().await.unwrap().unwrap();
+            socket
+                .send(Message::Text(r#"{"setupComplete":{}}"#.into()))
+                .await
+                .unwrap();
+            socket.close(None).await.unwrap();
+        });
+
+        let mut session =
+            open_live_session_at(&format!("ws://{address}"), &boot, Some("handle-in"))
+                .await
+                .unwrap();
+
+        assert_eq!(session.next_event().await, None);
+        assert_eq!(session.resumption_handle().as_deref(), Some("handle-in"));
         server.await.unwrap();
     }
 }

--- a/src/livekit.rs
+++ b/src/livekit.rs
@@ -70,7 +70,7 @@ const CANDIDATE_ABSENCE_LIMIT: Duration = Duration::from_secs(90);
 
 use crate::gemini::{
     GeminiEvent, GeminiFunctionCall, GeminiLiveSession, generate_report, open_live_session,
-    redact_api_key,
+    redact_api_key, resume_live_session,
 };
 use crate::runtime::{
     AGENT_NAME, RuntimeBootstrap, TOOL_LOG_HINT, TOOL_READ_EDITOR, TOPIC_REPORT,
@@ -85,6 +85,11 @@ const GEMINI_VIDEO_MIME_TYPE: &str = "image/jpeg";
 const GEMINI_VIDEO_FRAME_INTERVAL: Duration = Duration::from_secs(1);
 const GEMINI_VIDEO_JPEG_QUALITY: u8 = 75;
 const GEMINI_OUTPUT_AUDIO_SAMPLE_RATE: u32 = 24_000;
+/// Gemini closes a connection roughly every ten minutes, so the longest
+/// interview this offers needs about nine resumptions. The ceiling is here to
+/// stop a socket that fails immediately from spinning, not to bound a healthy
+/// interview; past it the supervisor restart takes over as before.
+const GEMINI_RESUME_LIMIT: usize = 16;
 const LIVEKIT_OUTPUT_CHANNELS: u32 = 1;
 const LIVEKIT_OUTPUT_QUEUE_MS: u32 = 100;
 const LIVEKIT_OUTPUT_FRAME_QUEUE: usize = 6_000;
@@ -152,6 +157,33 @@ fn interview_packet<'a>(
         return None;
     }
     Some((topic, serde_json::from_slice(payload).ok()?))
+}
+
+/// Decides whether a closed Gemini socket may be continued, and spends one of
+/// the budgeted attempts when it may.
+///
+/// This is the half of resuming that can be judged. `cargo test` cannot open a
+/// Gemini session, but every rule about when not to try one is arithmetic over
+/// a counter and an `Option`, so it lives here where tests can reach it rather
+/// than inside the reconnect it authorises.
+///
+/// Refuses when the server never offered a resumable checkpoint, and once the
+/// ceiling is reached. Both leave the caller to end the room, which is what
+/// happened for every close before resuming existed at all.
+fn take_resume_attempt(resumed: &mut usize, handle: Option<String>) -> Result<String, String> {
+    if *resumed >= GEMINI_RESUME_LIMIT {
+        return Err(format!("already resumed {resumed} times"));
+    }
+    let Some(handle) = handle else {
+        return Err("no resumption handle was offered".to_string());
+    };
+
+    // Spent before the reconnect rather than after it. A socket that fails to
+    // come back is the case the ceiling exists for, and counting only the
+    // successes would let an endpoint failing instantly be retried without
+    // bound.
+    *resumed += 1;
+    Ok(handle)
 }
 
 pub async fn run_room(
@@ -239,6 +271,8 @@ pub async fn run_room(
     gemini.send_text(&boot.greeting).await?;
     turn.activity.mark_speaking();
 
+    let mut resumed = 0usize;
+
     let mut watch = tokio::time::interval(Duration::from_secs_f64(WATCH_TICK_S));
 
     // Checked on the watch tick rather than given its own timer arm: the tick
@@ -297,7 +331,17 @@ pub async fn run_room(
                     return Ok(());
                 }
                 if let Some(prompt) = turn.activity.watch_prompt(&turn.state, Instant::now()) {
-                    gemini.send_text(&prompt).await?;
+                    // Not `?`. Every write below is one the reader may be
+                    // about to explain: a socket Gemini has closed fails the
+                    // next send long before `next_event` drains and reports
+                    // it, and audio flushes every hundred milliseconds, so
+                    // propagating here is how a closed socket ended the
+                    // interview from the write side without the arm that
+                    // resumes it ever running.
+                    if let Err(error) = gemini.send_text(&prompt).await {
+                        eprintln!("Gemini nudge failed ({error}); waiting for the close to be reported");
+                        continue;
+                    }
                     turn.activity.mark_speaking();
                 }
             }
@@ -307,16 +351,21 @@ pub async fn run_room(
                     gemini.close().await?;
                     return Ok(());
                 };
-                if handle_media_event(
+                match handle_media_event(
                     &mut media,
                     &mut gemini,
                     &candidate_identity,
                     config.gemini_candidate_video_enabled,
                     &event,
                 )
-                .await?
+                .await
                 {
-                    continue;
+                    Ok(true) => continue,
+                    Ok(false) => {}
+                    Err(error) => {
+                        eprintln!("Gemini media attach failed ({error}); waiting for the close to be reported");
+                        continue;
+                    }
                 }
                 let mut context = turn.context(&mut output_audio, &mut gemini, media.identity.as_deref());
                 if handle_room_event(&room, &mut context, &mut presence, interview, &ids, event)
@@ -328,16 +377,58 @@ pub async fn run_room(
             }
             event = gemini.next_event() => {
                 let Some(event) = event else {
-                    // The interview ends here whenever Gemini hangs up, which
-                    // from the candidate's side is the interviewer stopping
-                    // mid-sentence with the transcript cut at the same word.
-                    // The reason came over the socket and is logged by the
-                    // reader task; this line is what ties that to the room.
-                    eprintln!(
-                        "Gemini session ended; ending interview room={room_name} and letting the supervisor restart"
-                    );
-                    close_room(&room).await;
-                    return Ok(());
+                    // Gemini hung up. Usually that is the ten-minute cap on a
+                    // single connection rather than anything wrong, so the
+                    // session continues on a new socket instead of ending the
+                    // interview. The reason came over the socket and is logged
+                    // by the reader task; these lines tie that to the room.
+                    //
+                    // The reconnect sits here rather than behind a function of
+                    // its own because everything decidable about it is in
+                    // `take_resume_attempt`, which is tested. What is left is
+                    // two awaits nothing in `cargo test` can reach, and a name
+                    // wrapping only those would add a mutant no test can kill
+                    // to a gate that is worth keeping honest.
+                    let resumed_session = match take_resume_attempt(&mut resumed, gemini.resumption_handle()) {
+                        Ok(handle) => {
+                            // The socket is already gone; this closes the
+                            // writer half and the reader task. A close on a
+                            // dead socket errors, and that error says nothing
+                            // the caller can act on.
+                            let _ = gemini.shutdown().await;
+                            resume_live_session(&config.google_api_key, &boot, &handle)
+                                .await
+                                .map_err(|error| error.to_string())
+                        }
+                        Err(refused) => Err(refused),
+                    };
+                    match resumed_session {
+                        Ok(session) => {
+                            gemini = session;
+                            eprintln!(
+                                "Gemini session resumed ({resumed} so far); the interview continues where it left off"
+                            );
+
+                            // Whatever was mid-flight died with the socket. The
+                            // turn ids have to close here for the same reason
+                            // an interruption closes them: left open, the next
+                            // thing either party says appends to an utterance
+                            // that was cut off, and the panel and the report
+                            // both read the two as one.
+                            let mut context = turn.context(&mut output_audio, &mut gemini, media.identity.as_deref());
+                            cut_off_turn(context.activity, context.output_audio);
+                            close_turns(&room, &mut context).await?;
+                            set_agent_state(&room, &mut turn.agent_state, AGENT_STATE_LISTENING).await?;
+                            continue;
+                        }
+                        Err(error) => {
+                            eprintln!(
+                                "Gemini session ended and could not be resumed ({error}); ending interview room={room_name} and letting the supervisor restart"
+                            );
+                            close_room(&room).await;
+                            return Ok(());
+                        }
+                    }
                 };
                 let mut context = turn.context(&mut output_audio, &mut gemini, media.identity.as_deref());
                 handle_gemini_event(&room, &mut context, event, Interruptible::Yes).await?;
@@ -350,10 +441,19 @@ pub async fn run_room(
                 set_agent_state(&room, &mut turn.agent_state, AGENT_STATE_LISTENING).await?;
             }
             frame = next_audio_frame(&mut media.audio), if media.audio.is_some() => {
-                pump_audio(&mut media, &mut gemini, frame).await?;
+                // The fastest writer in the loop, and so the one that reaches a
+                // closed socket first: a flush leaves every hundred
+                // milliseconds of speech. Dropping the frame costs a tenth of a
+                // second of audio the resumed session did not need; propagating
+                // cost the interview.
+                if let Err(error) = pump_audio(&mut media, &mut gemini, frame).await {
+                    eprintln!("Gemini audio write failed ({error}); waiting for the close to be reported");
+                }
             }
             frame = next_video_frame(&mut media.video), if media.video.is_some() => {
-                pump_video(&mut media, &mut gemini, frame).await?;
+                if let Err(error) = pump_video(&mut media, &mut gemini, frame).await {
+                    eprintln!("Gemini video write failed ({error}); waiting for the close to be reported");
+                }
             }
         }
     }
@@ -2972,6 +3072,60 @@ mod tests {
         assert_eq!(pixel[3], 255, "alpha belongs in byte 3, got {pixel:?}");
     }
 }
+/// The ceiling is a boundary, so both sides of it are named. One attempt short
+/// of the limit still resumes; the limit itself does not, and neither does the
+/// count past it that a wrong comparison would let through.
+#[test]
+fn the_resume_ceiling_admits_the_last_attempt_and_refuses_the_one_after() {
+    let mut last = GEMINI_RESUME_LIMIT - 1;
+    assert_eq!(
+        take_resume_attempt(&mut last, Some("handle-abc".to_string())),
+        Ok("handle-abc".to_string()),
+        "the attempt below the ceiling is the one the longest interview needs"
+    );
+    assert_eq!(last, GEMINI_RESUME_LIMIT);
+
+    let mut at_limit = GEMINI_RESUME_LIMIT;
+    assert!(take_resume_attempt(&mut at_limit, Some("handle-abc".to_string())).is_err());
+    assert_eq!(
+        at_limit, GEMINI_RESUME_LIMIT,
+        "a refused attempt is not a spent one"
+    );
+}
+
+/// A socket that never reached a resumable checkpoint cannot be continued, and
+/// asking anyway would restart the interview from the greeting. Refusing must
+/// also leave the budget alone, or a handleless close would eat the attempts a
+/// later one needs.
+#[test]
+fn a_missing_handle_refuses_without_spending_an_attempt() {
+    let mut resumed = 2;
+
+    assert!(take_resume_attempt(&mut resumed, None).is_err());
+
+    assert_eq!(resumed, 2);
+}
+
+/// Exactly one attempt per resume. Started away from zero on purpose: at zero a
+/// counter that multiplied instead of adding would look identical to one that
+/// added.
+#[test]
+fn each_resume_spends_one_attempt_and_hands_back_its_own_handle() {
+    let mut resumed = 3;
+
+    assert_eq!(
+        take_resume_attempt(&mut resumed, Some("handle-first".to_string())),
+        Ok("handle-first".to_string())
+    );
+    assert_eq!(resumed, 4);
+
+    assert_eq!(
+        take_resume_attempt(&mut resumed, Some("handle-second".to_string())),
+        Ok("handle-second".to_string())
+    );
+    assert_eq!(resumed, 5);
+}
+
 #[test]
 fn observer_is_not_the_candidate() {
     assert!(candidate_identity_matches(


### PR DESCRIPTION
Gemini closes a Live connection after about ten minutes whatever the session has left to run, and the interview ended with it: `run_room` logged the hang-up, closed the room, and let the supervisor restart. The restart sends `boot.greeting` unconditionally against a session with no history, so a candidate twenty minutes into a forty-five minute interview was greeted a second time by an interviewer that had forgotten the first ten. The prompt already forbids a second greeting, but it says "in this conversation", and the new session is not that conversation.

The setup message had asked for `sessionResumption` since it was written. That half is only a request for handles; nothing read the `sessionResumptionUpdate` frames carrying them, and nothing could have spent one, because `open_live_session` had nowhere to put it. The feature looked present at the call site and did nothing on the wire.

`parse_server_message` now returns the handle and the `goAway` warning beside the events, and the reader task keeps the handle in an `Arc<Mutex<..>>` the session exposes. It is held there rather than sent through the event channel because of when it is wanted: after the socket closed and the last events drained, when the channel is finished and the caller has to decide whether it can resume at all.

A handle is taken only from an update the server marked `resumable`. Mid-turn updates carry one that is refused on reconnect, so accepting those would replace a working checkpoint with a broken one. A resumed connection also seeds itself with the handle it resumed from, since the server does not always re-issue one straight away and losing it would turn the next close into the cold start this exists to prevent.

The reconnect does not re-send the greeting, and closes the turn ids first, for the reason an interruption closes them: left open, the next thing either party says appends to an utterance that was cut off, and the panel and the report both read the two as one.

## What the first push got wrong

Reading the close is not enough on its own. Every arm of the loop that writes to Gemini propagated its error, and a socket the server has closed fails the next send long before `next_event` drains and reports it. Audio flushes every hundred milliseconds, so in practice the write side always won: the interview ended from a `?` on a dropped frame, and the arm that resumes it never ran. The first version of this PR would not have fixed the reported bug. Those four writes now log and carry on, leaving the close to the one arm that can explain it. A tenth of a second of audio is the cost.

`connect_async` had no timeout either, where the exchange over it had `SETUP_TIMEOUT`. A connect that never answers hangs `run_room`'s loop, which is also how the interview notices its candidate leaving and how its own deadline fires, so a stalled reconnect could strand a room that should have ended. `CONNECT_TIMEOUT` bounds the socket the way `SETUP_TIMEOUT` bounds what crosses it.

Both of these came from @cubic-dev-ai's review on the first push. Thanks.

## Testing

`take_resume_attempt` holds the part of resuming that can be judged: `cargo test` cannot open a Gemini session, but the ceiling and the counter are arithmetic. Three tests name both sides of the boundary, that a refusal spends nothing, and that a resume spends exactly one — counting from three, so a multiply could not pass for an add. The reconnect itself stays inline in `run_room`, which `.cargo/mutants.toml` already excludes, rather than behind a name that would add a mutant no test can kill.

The mutation gate is why: the first push missed four mutants, all of them in the function that held this logic, which is a fair report of it having had no test at all.

## Verification

`cargo mutants --in-place --in-diff` on this diff, at the 27.1.0 the workflow pins: 14 mutants, 11 caught, 3 unviable, 0 missed. `./scripts/test.sh` passes (224 browser tests, 0 failures). `cargo test` is green, 91 in the library and 258 across the integration suites, nine of them new here. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean. `check-gemini` was run against the live API, since this changes the setup message and that is a real regression risk.

Not verified end to end: an actual ten-minute close followed by a resume. That needs a real interview long enough to hit the cap. The wire format, the reader and the budget are covered by tests, but the reconnect itself has not been watched happening. A run past ten minutes should log `Gemini session resumed (1 so far)` and greet only once.

Reported as #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K15tPC2EiCf5Uk7ttY55L
