### PR TITLE
Keep the lobby's start control on screen

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -629,15 +629,21 @@
         </button>
       </section>
 
-      <section class="duration-row" aria-label="Duration">
-        <button class="duration-button" type="button" data-duration="30">30 min</button>
-        <button class="duration-button selected" type="button" data-duration="45">45 min</button>
-        <button class="duration-button" type="button" data-duration="60">60 min</button>
-      </section>
+      <!-- Sticky: the problem grid is 150 cards tall, so a start control that
+           scrolls with it sits ten screens below the fold and reads as a page
+           with no way to begin. -->
+      <div class="launch-bar">
+        <section class="duration-row" aria-label="Duration">
+          <button class="duration-button" type="button" data-duration="10">10 min</button>
+          <button class="duration-button" type="button" data-duration="30">30 min</button>
+          <button class="duration-button selected" type="button" data-duration="45">45 min</button>
+          <button class="duration-button" type="button" data-duration="60">60 min</button>
+        </section>
 
-      <section class="start-row">
-        <button id="start" class="start-button" type="button">Start interview</button>
-      </section>
+        <section class="start-row">
+          <button id="start" class="start-button" type="button">Start interview</button>
+        </section>
+      </div>
 
       <section id="history" class="history" hidden></section>
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -166,11 +166,24 @@ p {
   font-size: 0.875rem;
 }
 
+.launch-bar {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+  padding: 0.75rem 0;
+  border-top: 1px solid var(--hairline);
+  background: var(--page);
+}
+
 .duration-row {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-top: 1.5rem;
 }
 
 .duration-button,
@@ -202,7 +215,7 @@ p {
 }
 
 .start-row {
-  margin-top: 1rem;
+  margin-left: auto;
 }
 
 .start-button {


### PR DESCRIPTION
The problem grid is 150 cards, which makes the lobby about 7500 pixels tall, and the duration row and "Start interview" sat under all of it at roughly 7400. On a 770 pixel viewport that is ten screens of scrolling past a wall of problems, with nothing above the fold saying there is anything below it, so the page reads as one that offers problems and no way to begin. The button was never disabled; it was unreachable.

A "launch-bar" wrapper holds both sections and sticks to the bottom of the viewport, so picking a problem and starting are visible together from the first screen. It takes the top margin the duration row carried and gives "start-row" a left auto margin, which puts the durations and the button at opposite ends of one bar instead of stacking them.

The bar also offers ten minutes. "MIN_DURATION_MIN" is ten, so it is the shortest interview the server will honour, and the lobby offered nothing below thirty. A shorter run is what trying the thing out wants, and on the free tiers it is the difference between a handful of attempts and a couple. Forty-five stays preselected: the test pinning the lobby's default to "DEFAULT_DURATION_MIN" is guarding a real invariant, since that constant is also what "DEFAULT_RECORDING_MAX_MINUTES" is defined as, and validation refuses a recording cap below the interview length.

## Verification

`./scripts/test.sh` passes, including
`browser_interview_duration_matches_the_server_clamp`, which is the test that
governs this area: it pins the lobby's preselected duration, its `app.js`
initial value, and the `interview.js` fallback to `DEFAULT_DURATION_MIN`, and
checks every offered button against the server's clamp. Ten minutes passes that
check because `MIN_DURATION_MIN` is ten; making it the default would not, which
is why forty-five stays selected.

Sticky positioning was confirmed in a browser at several scroll offsets: the bar
sits at the bottom of the viewport from the first screen down, and the start
button stays hit-testable throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K15tPC2EiCf5Uk7ttY55L
