### PR TITLE
Give the C and C++ preludes their missing headers

### DIFF
--- a/web/compiler-explorer.js
+++ b/web/compiler-explorer.js
@@ -110,7 +110,9 @@ export function mapCompilerResponse(response) {
 }
 
 function cHarness(spec, candidateCode) {
-  return `#include <stdbool.h>
+  return `#include <limits.h>
+#include <math.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -234,20 +236,28 @@ ${spec.cases.map((testCase, index) => cppCase(spec, testCase, index)).join("\n")
 
 function cppPrelude() {
   return `#include <algorithm>
+#include <array>
 #include <chrono>
+#include <climits>
 #include <cmath>
+#include <deque>
 #include <functional>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <list>
 #include <map>
+#include <numeric>
 #include <optional>
 #include <queue>
 #include <set>
 #include <sstream>
+#include <stack>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 using namespace std;


### PR DESCRIPTION
A candidate solving Min Stack in C++ writes `stack<int>` and the compile fails with "'stack' does not name a type", because "cppPrelude" listed seventeen headers and `<stack>` was not among them. The only way through was to type `#include <stack>` at the top of the editor, which is not something a candidate should have to think about while an interviewer watches, and not something the starter code suggests.

`<queue>` was already there, which is what makes the omission look arbitrary rather than deliberate: the two are sibling container adaptors, and on libstdc++ including one does not declare the other. The same gap covers headers whose containers the bank's own problems want. `<set>`, `<map>` and `<unordered_map>` were listed and `<unordered_set>` was not, though five problems reach for it. Eight problems bound an answer with INT_MAX or numeric_limits, and neither `<climits>` nor `<limits>` was there. `<numeric>`, `<deque>`, `<array>` and `<tuple>` round out the set by the same rule: a container or algorithm a solution to something in this bank would naturally use.

C has the identical defect for the identical reason. Its prelude carried stdbool, stdio, stdlib, string and time, so the same eight problems fail on "use of undeclared identifier 'INT_MAX'". `<limits.h>` and `<math.h>` join it.

Java is unaffected: its harness imports "java.util.*", so a wildcard already covers what an explicit list has to keep up with.

Both preludes were checked against the compilers the runner actually asks for rather than a local toolchain, since the point is what godbolt builds: gcc 16.2 at "-std=c++20" and clang 19.1 at "-std=c17". Before, the C++ case failed as reported and the C case failed on INT_MAX. After, a MinStack using "stack", "unordered_set", "deque", "array", "accumulate", "numeric_limits", INT_MAX and "make_tuple" compiles and runs, as does a C solution using INT_MAX and "sqrt".

Reported as sysprog21/codetrial#1.

## Verification

Both preludes were compiled against the compilers `web/runners.js` actually
names, not a local toolchain: `g162` at `-O2 -std=c++20` and `cclang1910` at
`-O2 -std=c17`, through godbolt's own API.

Before, the reported case failed exactly as described:

```
error: 'stack' does not name a type; did you mean 'obstack'?
```

and C failed the same way on `use of undeclared identifier 'INT_MAX'`.

After, a MinStack using `stack`, plus `unordered_set`, `deque`, `array`,
`accumulate`, `numeric_limits`, `INT_MAX` and `make_tuple`, compiles and runs
with the expected output; so does a C solution using `INT_MAX` and `sqrt`.
`./scripts/test.sh` passes (224 browser tests, 0 failures).

## On the other half of the issue

sysprog21/codetrial#1 also reports that Tab moves focus out of the editor. That
one is already fixed on main, by fe22b64 on 2026-08-22, two days before the
issue was filed. Since a fix that predates a report is not evidence on its own,
the current behaviour was checked in a browser against this tree: Tab inserts
four spaces and calls `preventDefault`, Shift+Tab outdents, and Escape then Tab
leaves the editor rather than indenting. The reporter was most likely on a build
from before that commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018K15tPC2EiCf5Uk7ttY55L
