### PR TITLE
Fix LiveKit Cloud connections

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -9,6 +9,12 @@
 # ignored. What covers this path is the browser interview check and
 # scripts/browser-check.sh, not unit tests.
 #
+# `run_gemini_check` is the same shape one layer down: it opens a Gemini Live
+# session against Google and closes it. Replacing the body with `Ok(())` cannot
+# be caught by `cargo test`, because a test that reached the real thing would
+# need a live API key and would fail on a machine without one. What this mode
+# actually proves is checked by running it, which is why `make check` does.
+#
 # Keep this list short and each entry justified. An entry that is really "we
 # never got around to testing this" belongs in a test, not here.
-exclude_re = ["run_room"]
+exclude_re = ["run_room", "run_gemini_check"]

--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,8 @@ web/vendor/pyodide/*.json
 # suffixes: a run killed outright leaves one, and it is the same megabytes.
 web/vendor/*/.*.part
 
-# cargo-mutants scratch output; CI runs it on every pull request.
+# cargo-mutants scratch output; CI runs it on every pull request. The tool
+# rotates the previous run to mutants.out.old/ before starting, so both names
+# are scratch and neither belongs in a commit.
 mutants.out/
+mutants.out.old/

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ credentialed acceptance check are in [docs/recording-contract.md](docs/recording
 | [Provider pooling](docs/providers.md) | Spreading rooms over several LiveKit projects |
 | [Recording contract](docs/recording-contract.md) | Provisioning, consent, delivery, retention, and operations |
 | [Google Meet manual check](docs/meet-tab-audio-manual-check.md) | Verifying tab-audio presentation |
+| [LiveKit connection troubleshooting](docs/livekit-connection-troubleshooting.md) | Telling four connection failures apart, and checking credentials without the browser |
 
 ## Repository layout
 

--- a/docs/livekit-connection-troubleshooting.md
+++ b/docs/livekit-connection-troubleshooting.md
@@ -1,0 +1,169 @@
+# LiveKit connection troubleshooting
+
+A record of one debugging session where the browser could not hear Jim, what
+was actually wrong, and what was changed. The interesting part is not the fix,
+which is four lines, but that four different failures wore the same symptom:
+the interview page falling back to offline practice mode.
+
+## The symptom is not the diagnosis
+
+`connect` in `web/interview.js` puts the thrown message into the banner, so
+most failures do say why. The one that does not is the one that cost this
+session: a CSP refusal reaches the SDK as `Failed to fetch`, and the banner
+repeats it faithfully. A policy fault then reads as a network fault. The
+console is where the cases separate, and the exact error string is what tells
+them apart:
+
+| Console error | Layer | Meaning |
+|---|---|---|
+| `Failed to fetch` on `/api/token` | this server | the Rust process is not running, or not reachable |
+| `Refused to connect ... Content Security Policy` | this server's CSP | the origin is not in `connect-src` |
+| `401 invalid token` | LiveKit | the API secret does not match the API key |
+| `401 invalid API key for domain` | LiveKit | the key belongs to a different project |
+| `429 Too Many Requests` | LiveKit | rate limited; every retry extends it |
+| `Abort handler called` | browser | the WebSocket handshake was interrupted locally |
+
+The two 401s are worth reading closely. They are different messages for
+different faults, and mistaking one for the other sends you to the wrong
+project.
+
+## The change
+
+`content_security_policy` in `src/web/policy.rs` now also names
+`*.livekit.cloud` when the configured host is a LiveKit Cloud URL.
+
+The configured `LIVEKIT_URL` is the project's own hostname, `<slug>.livekit.cloud`.
+That is not where the signaling socket ends up. LiveKit Cloud redirects the
+client to a regional subdomain, and the JS SDK walks a list of them when one
+fails:
+
+```
+conversation-xxxxxxxx.otokyo1b.production.livekit.cloud
+conversation-xxxxxxxx.oosaka1a.production.livekit.cloud
+conversation-xxxxxxxx.ohyderabad1a.production.livekit.cloud
+...
+```
+
+The policy named only the two origins derived from the configured URL, so every
+one of those regional hosts was refused by the browser before a request left
+it. The page reported `could not establish signal connection: Failed to fetch`,
+which reads like a network fault and is not one.
+
+CSP `*.livekit.cloud` matches subdomains at any depth under that base, so one
+pattern covers every region present and any region added later. The guard keeps
+it narrow: a self-hosted LiveKit at `wss://livekit.example.com` gets no
+wildcard, because nothing about that deployment implies sibling hosts are
+equally trusted.
+
+Both schemes are pushed for the same reason the exact origins already were: the
+SDK opens the socket over `wss://` and then calls the same host over HTTPS for
+region settings, and naming only one lets the socket open and then blocks the
+rest.
+
+### Verification
+
+- `tests/web.rs`: `responses_carry_baseline_security_headers`,
+  `production_policy_names_no_loopback_origins`, and
+  `the_recording_template_is_reachable_under_a_policy_that_permits_its_room`
+  all pass. Each asserts with `contains`, and this change only adds entries, so
+  no existing assertion moved.
+- `cargo fmt --check` and `cargo clippy --lib` clean.
+- Confirmed against the live symptom: the CSP refusal disappeared from the
+  browser console and the request reached LiveKit.
+
+`tests/web.rs` pins the Cloud wildcard in
+`responses_carry_baseline_security_headers`; `src/web/policy.rs` also covers
+both Cloud domains and rejects lookalike or self-hosted hosts.
+
+## What was ruled out, and how
+
+Recorded because each of these looked plausible enough to act on, and acting on
+the wrong one costs a rebuild or a new cloud project.
+
+**A stale binary.** Credentials are read at runtime from
+`config/codetrial.env.local`; they are never compiled in. Editing that file
+needs a restart, never a rebuild. The same binary produced a valid token with
+one set of credentials and `invalid token` with another, which is only possible
+if the binary is not the variable.
+
+**A skewed clock.** JWTs carry `nbf` and `exp`, and WSL2 clocks drift across
+host sleep, which rejects tokens as `invalid token` with a correct secret.
+Compared `date -u` in WSL against the `Date` header from the LiveKit host: one
+second apart. Not this.
+
+**A wrong project.** Signed a token by hand with each key/secret pair and called
+`ListRooms` on each host. The control (old key against old host) returned
+`200`, which is what makes the other results meaningful. The failing pair
+returned `invalid token` while a genuinely mismatched pair returned
+`invalid API key for domain`. LiveKit recognised the key as belonging to that
+project, so only the signature could be wrong, so only the secret could be
+wrong.
+
+**`check-gemini` as proof of LiveKit credentials.** It is not. It opens a
+Gemini Live session and prints the pool it would use; it never authenticates
+against LiveKit. It passing says nothing about `LIVEKIT_API_SECRET`.
+
+## Verifying credentials without the browser
+
+Signing a management token by hand and calling `ListRooms` checks a key/secret
+pair against a project without touching `/rtc/validate`, which is the
+endpoint the browser rate limits. Useful when the page is already 429'd: the
+management API answers while joins are refused, and the same call lists room
+participants, which is how you find out whether the agent is in the room.
+
+That last question is the one worth asking first. An agent showing
+`kind: AGENT`, `state: ACTIVE`, `lk.agent.state: listening` proves the server,
+Gemini, and the agent's own LiveKit connection all work, and narrows everything
+remaining to the browser.
+
+## Rate limiting
+
+Repeated failures make this worse in a way that is easy to miss. One page load
+attempts every region in turn, so a handful of reloads is dozens of requests
+against `/rtc/validate`, and the limit tightens. The agent is unaffected: it
+does not call that endpoint, and it stays in the room while the browser is
+locked out.
+
+When a `429` appears, close the tab rather than reloading it, and leave it
+closed. A background tab may still be retrying.
+
+## Configuration changed during this session
+
+`config/codetrial.env.local` in both checkouts was repointed at a new LiveKit
+project. The file is covered by `config/*.env.*` in `.gitignore` and no
+credential appears in this document or anywhere else in the repository.
+
+## Resolved
+
+A full interview ran end to end on the new project. The server log is the
+evidence:
+
+```
+joined room=interview-local identity=interviewer-interview-local
+starting interview: room=interview-local problem=two-sum duration=30min
+timing: room and Gemini session ready 0.78s after the candidate joined
+timing: 0.01s from the candidate finishing to the reply starting
+...
+interview ended by the browser: room=interview-local topic=control
+```
+
+The browser joined the room, Jim answered turn after turn (`from the candidate
+finishing to the reply starting`), barge-in worked (`Gemini cut its own turn`),
+and the session ended on the candidate pressing End interview. Voice runs both
+ways: the microphone reaches the agent and Jim's audio reaches the browser.
+
+The `Abort handler called` handshake failure did not recur once the working key
+was in place, so it was a transient interruption during the handshake rather
+than a standing fault - a retry cleared it. It never needed a code change.
+
+## The fixes, in the end
+
+| # | Fault | Resolution |
+|---|---|---|
+| 1 | CSP blocked LiveKit regional subdomains | `src/web/policy.rs`, `connect-src` adds `*.livekit.cloud` |
+| 2 | Old project rate limited (429) | moved to a fresh LiveKit project |
+| 3 | First new secret was wrong (43 chars) -> 401 | reissued the key, verified before writing |
+| 4 | Browser WebSocket handshake aborted | cleared on retry; no change needed |
+
+Only #1 was a defect in this codebase. The rest were environment and
+credentials. The one change that stays is the CSP wildcard.

--- a/docs/meet-tab-audio-manual-check.md
+++ b/docs/meet-tab-audio-manual-check.md
@@ -15,6 +15,17 @@ re-vendored, or before relying on the mode for a real interview.
   participant on the receiving end.
 - Headphones on the candidate machine. Without them the candidate microphone
   re-captures Jim from the speakers, and the interviewer hears him twice.
+- No virtual camera selected as the system default. The preflight asks for
+  `video: true` with no device id, so Chrome opens whatever is default, and
+  nothing in the media path judges the device it gets. The label is recorded,
+  as the `detail` of the `MEDIA_PREFLIGHT_PASSED` integrity event, so a reader
+  can see which camera was opened; nothing blocks it. That name is not always
+  neutral: Continuity Camera reports `<FirstName>'s iPhone`, so the report, the
+  stored row and the exported markdown can carry a candidate's own name. The
+  preflight says so on the page. If blind review is ever a goal, this is the
+  line that ends it. A virtual camera can
+  therefore still satisfy the camera step with a composited feed CodeTrial
+  never captured. Untested: no results row below covers it.
 
 ## Procedure
 

--- a/scripts/gen-wire-fixtures.mjs
+++ b/scripts/gen-wire-fixtures.mjs
@@ -167,21 +167,32 @@ const INTEGRITY_INPUTS = [
   },
   // A real detector failure, which is the one event whose detail is an
   // arbitrary runtime error string: `web/face-worker.js` fills it from
-  // `error.message`. Parentheses and quotes are ordinary there, and the agent
-  // drops a detail carrying any character outside its allowlist, so this is the
-  // case where the producer and the verifier hash different bytes.
+  // `error.message`. Parentheses and quotes are ordinary there, and an agent
+  // that drops a detail carrying them hashes different bytes from the producer.
   {
     type: "FACE_DETECTOR_UNAVAILABLE", source: "media", severity: "warning",
     at: "2026-08-18T06:39:02.114Z",
     detail: "face detection unavailable: Cannot read properties of undefined (reading 'a')",
   },
-  // The mirror case: every character the agent's allowlist permits, so a browser
-  // that starts stripping something the agent would have accepted fails here
-  // too. One fixture cannot catch a divergence in a direction it never exercises.
+  // The mirror case: characters both sides keep, so a browser that starts
+  // stripping something the agent would have accepted fails here too. One
+  // fixture cannot catch a divergence in a direction it never exercises.
   {
     type: "INTEGRITY_HEARTBEAT", source: "media", severity: "info",
     at: "2026-08-18T06:39:44.702Z",
     detail: "az AZ 09 _-=/;:,.",
+  },
+  // A camera label, which is the candidate's to name and is printed in the
+  // interviewer's report. Localized text stays, because stripping it would leave
+  // the evidence unreadable for the people most likely to need it. The
+  // right-to-left override and the zero-width space do not: they reorder or hide
+  // what is printed around them, and this fixture is what proves the browser and
+  // the agent remove the identical set. If either side keeps one, the hashes
+  // disagree here rather than in somebody's interview.
+  {
+    type: "MEDIA_PREFLIGHT_PASSED", source: "preflight", severity: "info",
+    at: "2026-08-18T06:39:52.400Z",
+    detail: `camera=FaceTime HD \u30AB\u30E1\u30E9 \u0645\u06CC\u200C\u0631 \u202Egnitautis\u200B (05AC:8514)`,
   },
   // The only input carrying sourceEventIds, so the conditional key in
   // `integrityEventPayload` (`if (event.sourceEventIds.length)`) and its mirror

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -20,7 +20,7 @@ pub use prompts::{
 use crate::config::{DEFAULT_DURATION_MIN, MAX_DURATION_MIN, MIN_DURATION_MIN};
 use crate::runtime::{TOPIC_CODE_UPDATE, TOPIC_CONTROL, TOPIC_INTEGRITY, TOPIC_TEST_RESULTS};
 
-const MAX_INTEGRITY_EVENTS: usize = 25;
+pub const MAX_INTEGRITY_EVENTS: usize = 25;
 /// The `detail` bound, and half of a wire contract: `INTEGRITY_DETAIL_MAX` in
 /// `web/lib.js` has to be the same number. The agent truncates to this before
 /// it recomputes the hash, so a producer emitting anything longer builds a hash
@@ -213,6 +213,27 @@ pub struct RuntimeState {
     pub test_runs: u32,
     pub hints_used: u32,
     pub integrity_events: Vec<serde_json::Value>,
+    /// The chain cursor, held apart from the evidence above.
+    ///
+    /// Verification is the producer's contract and eviction is this process's
+    /// housekeeping, and they used to share one vector. Dropping an event to
+    /// stay under `MAX_INTEGRITY_EVENTS` therefore moved the sequence the next
+    /// event had to match, so the chain died on the retention policy rather
+    /// than on anything the browser did.
+    pub integrity_chain: Option<(u64, String)>,
+    /// The ends of the heartbeat run, kept out of the evidence above.
+    ///
+    /// A heartbeat is the only periodic record of analyzer state, so it is not
+    /// disposable, but one arrives every five seconds and evidence does not.
+    /// Sharing one capped vector meant either heartbeats crowded the evidence
+    /// out or the eviction had to keep pushing them back out again. Two samples
+    /// say what the whole run said: what the devices and the analyzer looked
+    /// like when the interview started, and when it ended.
+    ///
+    /// Two fields rather than a pair, so that one heartbeat is one `Some` and
+    /// nobody has to ask whether the two ends are the same event.
+    pub integrity_first_heartbeat: Option<serde_json::Value>,
+    pub integrity_last_heartbeat: Option<serde_json::Value>,
     pub ended: bool,
 }
 
@@ -226,6 +247,9 @@ impl Default for RuntimeState {
             test_runs: 0,
             hints_used: 0,
             integrity_events: Vec::new(),
+            integrity_chain: None,
+            integrity_first_heartbeat: None,
+            integrity_last_heartbeat: None,
             ended: false,
         }
     }
@@ -627,18 +651,14 @@ fn apply_integrity(state: &mut RuntimeState, payload: &serde_json::Value) -> Dat
     };
     let seq = event.get("seq").and_then(serde_json::Value::as_u64);
     let prev_hash = event.get("prevHash").and_then(serde_json::Value::as_str);
-    let expected_seq = state
-        .integrity_events
-        .last()
-        .and_then(|event| event.get("seq"))
-        .and_then(serde_json::Value::as_u64)
-        .map_or(1, |seq| seq.saturating_add(1));
-    let expected_prev_hash = state
-        .integrity_events
-        .last()
-        .and_then(|event| event.get("hash"))
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("");
+    let (expected_seq, expected_prev_hash) = state
+        .integrity_chain
+        .as_ref()
+        .map_or((1, ""), |(seq, hash)| {
+            (seq.saturating_add(1), hash.as_str())
+        });
+
+    let computed_hash = integrity_hash(&event);
 
     // Named, because a rejection here is permanent. Sequence continuity is
     // required, so `expected_seq` never advances past a refused event and every
@@ -646,16 +666,17 @@ fn apply_integrity(state: &mut RuntimeState, payload: &serde_json::Value) -> Dat
     // to return the same silent default, and a hash mismatch caused by this
     // process normalizing `detail` before rehashing it emptied the evidence
     // section of every camera interview without a line anywhere saying so.
+    //
+    // Only tampering belongs here. A retention decision is handled below, after
+    // the cursor has moved, because punishing the producer for this process
+    // running out of room is how a full buffer used to end the chain.
     let refusal = if seq != Some(expected_seq) {
         Some(format!("sequence expected {expected_seq}, got {seq:?}"))
     } else if prev_hash != Some(expected_prev_hash) {
         Some("previous hash does not match the last accepted event".to_string())
-    } else if event.get("hash").and_then(serde_json::Value::as_str)
-        != Some(integrity_hash(&event).as_str())
+    } else if event.get("hash").and_then(serde_json::Value::as_str) != Some(computed_hash.as_str())
     {
         Some("hash mismatch; the producer and this verifier disagree".to_string())
-    } else if !valid_review_sources(state, &event) {
-        Some("review event references an event no longer retained".to_string())
     } else {
         None
     };
@@ -669,12 +690,53 @@ fn apply_integrity(state: &mut RuntimeState, payload: &serde_json::Value) -> Dat
         );
         return DataEventResult::default();
     }
+
+    // The chain is satisfied, so the cursor moves whatever happens to the event
+    // itself. Everything past this line is about what is worth keeping, and
+    // none of it can refuse the next event.
+    //
+    // Built from the values the checks above already proved equal, rather than
+    // re-read from the event. A conditional here would have a branch that
+    // silently leaves the cursor behind, which is the failure this separation
+    // exists to remove.
+    state.integrity_chain = Some((expected_seq, computed_hash));
+
+    // Liveness, not evidence, and now stored as such. Keeping only the ends of
+    // the run is what lets the evidence buffer be a plain queue again.
+    if is_heartbeat(&event) {
+        if state.integrity_first_heartbeat.is_none() {
+            state.integrity_first_heartbeat = Some(event);
+        } else {
+            state.integrity_last_heartbeat = Some(event);
+        }
+        return DataEventResult::default();
+    }
+
+    if !valid_review_sources(state, &event) {
+        eprintln!(
+            "WARNING: integrity event dropped from the evidence, chain continues: review event \
+             references an event no longer retained (seq={seq:?})"
+        );
+        return DataEventResult::default();
+    }
+
     state.integrity_events.push(event);
+
+    // Plain oldest-out, because nothing periodic lands here any more. This used
+    // to hold heartbeats too, and at one every five seconds they filled all 25
+    // slots in about two minutes: a camera that stopped at minute three was
+    // gone from a thirty minute report by minute five.
     if state.integrity_events.len() > MAX_INTEGRITY_EVENTS {
         let excess = state.integrity_events.len() - MAX_INTEGRITY_EVENTS;
         state.integrity_events.drain(0..excess);
     }
     DataEventResult::default()
+}
+
+/// Liveness rather than evidence, which is what sends it to its own field
+/// instead of competing for a slot in the buffer.
+fn is_heartbeat(event: &serde_json::Value) -> bool {
+    event.get("type").and_then(serde_json::Value::as_str) == Some("INTEGRITY_HEARTBEAT")
 }
 
 pub(crate) fn valid_review_sources(state: &RuntimeState, event: &serde_json::Value) -> bool {

--- a/src/agent/integrity.rs
+++ b/src/agent/integrity.rs
@@ -146,6 +146,47 @@ pub fn sanitize_test_run(payload: &serde_json::Value) -> serde_json::Value {
     })
 }
 
+/// A day, in milliseconds. No interview runs that long, so this is a ceiling on
+/// a candidate-supplied number rather than a real duration.
+///
+/// Written as the number rather than 24 * 60 * 60 * 1000, which read well and
+/// cost six mutants: every operator in it is a separate thing the mutation gate
+/// has to prove a test notices, and none of them is a decision anyone will
+/// revisit.
+const MAX_DURATION_MS: i64 = 86_400_000;
+
+/// Characters that hide themselves or reorder what is printed around them.
+///
+/// Must match `INTEGRITY_DETAIL_STRIPPED` in `web/lib.js` code point for code
+/// point. Written out rather than derived, because the browser has `\p{Cf}` and
+/// std has no general-category lookup: expressing one intent two different ways
+/// is how the sides drift, and a character stripped there but kept here is a
+/// hash this verifier cannot reproduce.
+///
+/// Not paranoia about exotic text. A camera label is whatever the candidate
+/// named their device, and it is rendered into the interviewer's report, where
+/// `escapeHtml` handles markup and nothing handles a right-to-left override.
+fn hidden_or_reordering(character: char) -> bool {
+    character.is_control()
+        || matches!(character,
+            '\u{00AD}'
+
+            // U+061C is the Arabic letter mark, the third bidi mark beside
+            // U+200E and U+200F. Missing it left one of Unicode's twelve
+            // Bidi_Control code points able to reorder a report.
+            | '\u{061C}'
+
+            // U+200C and U+200D are left out on purpose: the zero-width
+            // non-joiner is orthographic in Persian and Urdu, the zero-width
+            // joiner builds Indic conjuncts, and neither reorders anything.
+            | '\u{200B}'
+            | '\u{200E}'..='\u{200F}'
+            | '\u{202A}'..='\u{202E}'
+            | '\u{2060}'..='\u{2064}'
+            | '\u{2066}'..='\u{2069}'
+            | '\u{FEFF}')
+}
+
 pub fn sanitize_integrity_event(payload: &serde_json::Value) -> Option<serde_json::Value> {
     let text = |key| {
         payload
@@ -215,13 +256,12 @@ pub fn sanitize_integrity_event(payload: &serde_json::Value) -> Option<serde_jso
         .get("durationMs")
         .and_then(json_int)
         .unwrap_or(0)
-        .clamp(0, 24 * 60 * 60 * 1000);
-    let detail = text("detail").filter(|value| {
-        value.chars().all(|char| {
-            char.is_ascii_alphanumeric()
-                || matches!(char, ' ' | '_' | '-' | '=' | '/' | ';' | ':' | ',' | '.')
-        })
-    });
+        .clamp(0, MAX_DURATION_MS);
+
+    // Browser device labels are localized, so every printable Unicode character
+    // is kept. What is refused is what the browser strips before hashing: the
+    // two must agree exactly or the hashes differ and the chain stops.
+    let detail = text("detail").filter(|value| !value.chars().any(hidden_or_reordering));
     let source_event_ids = payload
         .get("sourceEventIds")
         .and_then(serde_json::Value::as_array)

--- a/src/livekit.rs
+++ b/src/livekit.rs
@@ -2070,9 +2070,37 @@ fn report_with_integrity_events(
     state: &RuntimeState,
 ) -> serde_json::Value {
     if let Some(object) = report.as_object_mut() {
+        // The evidence, plus the heartbeats that bookend it, merged by sequence
+        // rather than appended: a reader goes down this list in the order the
+        // interview happened, and a device-state sample out of place reads as a
+        // fault rather than as a bookend.
+        let kept = state.integrity_events.len() as u64;
+        let liveness = state.integrity_first_heartbeat.iter();
+        let liveness = liveness.chain(state.integrity_last_heartbeat.iter());
+        let samples = liveness.clone().count() as u64;
+        let mut events = state.integrity_events.clone();
+        events.extend(liveness.cloned());
+        events.sort_by_key(|event| event["seq"].as_u64().unwrap_or(0));
         object.insert(
             "integrityEvents".to_string(),
-            serde_json::Value::Array(state.integrity_events.clone()),
+            serde_json::Value::Array(events),
+        );
+
+        // How far verification got, and how much of it this report is not
+        // showing. The array above is a subsequence, so its links cannot be
+        // recomputed by whoever holds the report; without these a reader cannot
+        // tell a retention gap from a deleted row, which is the distinction the
+        // chain exists to make visible.
+        //
+        // The dropped count is derived rather than tallied. Every accepted
+        // event is in the evidence, held as a sample, or gone, and the cursor
+        // counts acceptances, so a counter would have been a fourth place for
+        // the same fact to be wrong.
+        let verified = state.integrity_chain.as_ref().map(|(seq, _)| *seq);
+        object.insert("integrityChainSeq".to_string(), serde_json::json!(verified));
+        object.insert(
+            "integrityDropped".to_string(),
+            serde_json::json!(verified.map(|seq| seq.saturating_sub(kept + samples))),
         );
     }
     report
@@ -2504,6 +2532,71 @@ mod tests {
         );
         assert_eq!(payload["hintsUsed"], 2);
         assert_eq!(report["integrityEvents"][0]["type"], "SESSION_START");
+    }
+
+    /// The liveness pair bookends the evidence, and the closing sample is the
+    /// one that says how the interview ended. Nothing covered this merge, so
+    /// dropping it, duplicating it, or emitting it out of order was invisible.
+    #[test]
+    fn the_report_packet_bookends_the_evidence_with_the_liveness_pair() {
+        let event = |seq: u64, kind: &str| {
+            serde_json::json!({
+                "type": kind,
+                "at": "now",
+                "severity": "info",
+                "source": "media",
+                "durationMs": 0,
+                "seq": seq,
+                "prevHash": "",
+                "hash": "a".repeat(64),
+                "detail": null,
+            })
+        };
+        let packet = |first, last| {
+            report_with_integrity_events(
+                serde_json::json!({}),
+                &RuntimeState {
+                    integrity_events: vec![event(5, "CAMERA_STOPPED")],
+                    integrity_first_heartbeat: first,
+                    integrity_last_heartbeat: last,
+                    integrity_chain: Some((9, "b".repeat(64))),
+                    ..RuntimeState::default()
+                },
+            )
+        };
+
+        let both = packet(
+            Some(event(2, "INTEGRITY_HEARTBEAT")),
+            Some(event(9, "INTEGRITY_HEARTBEAT")),
+        );
+        let seqs: Vec<u64> = both["integrityEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|event| event["seq"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![2, 5, 9], "merged in the order the interview ran");
+        assert_eq!(both["integrityChainSeq"], 9);
+
+        // Derived, not tallied: nine accepted, one kept as evidence and two
+        // held as samples, so six went for space.
+        assert_eq!(both["integrityDropped"], 6);
+
+        // A run of one has an opening sample and no closing one.
+        let single = packet(Some(event(2, "INTEGRITY_HEARTBEAT")), None);
+        let seqs: Vec<u64> = single["integrityEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|event| event["seq"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![2, 5], "one sample is one row");
+        assert_eq!(single["integrityDropped"], 7);
+
+        // And an interview that produced no heartbeat at all carries neither.
+        let none = packet(None, None);
+        assert_eq!(none["integrityEvents"].as_array().unwrap().len(), 1);
+        assert_eq!(none["integrityDropped"], 8);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -497,6 +497,12 @@ fn run_gemini_check(config: AgentConfig, room_name: &str) -> Result<(), String> 
         "Gemini setupComplete: model={} voice={} problem={} duration={}min",
         boot.live_model, boot.voice, boot.problem.id, boot.duration_min
     );
+
+    // Said out loud because `make check` runs this, and a green run reads as
+    // "the stack works". It opens a Gemini Live session and never authenticates
+    // against LiveKit, so it passes with a wrong `LIVEKIT_API_SECRET`. Someone
+    // already spent an afternoon treating this line as proof it was right.
+    println!("Not checked here: LiveKit credentials. This never calls LiveKit.");
     Ok(())
 }
 

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -672,20 +672,32 @@ fn browser_generated_integrity_events_all_verify_in_the_agent() {
         apply_data_event(&mut state, "integrity", event, TEST_REACTION_COOLDOWN_S);
     }
 
+    // The cursor is the count of acceptances: sequence numbers start at one and
+    // advance by exactly one per accepted event. Comparing it against the
+    // fixture length asks the only question this canary exists to ask, and
+    // recomputes none of the routing that would otherwise cancel itself out.
+    let (verified, _) = state
+        .integrity_chain
+        .clone()
+        .expect("the fixture opens a chain");
     assert_eq!(
-        state.integrity_events.len(),
+        verified as usize,
         events.len(),
-        "the agent rejected {} of {} events the browser actually produces; \
-         the two hash implementations have diverged",
-        events.len() - state.integrity_events.len(),
-        events.len()
+        "the agent refused an event the browser produces, at seq {}; the two \
+         hash implementations have diverged",
+        verified + 1
     );
 
     // Specifically the long one, which is the case that broke.
     let longest = events
         .iter()
         .filter_map(|event| event["detail"].as_str())
-        .map(str::len)
+        // Code points, matching what `MAX_INTEGRITY_TEXT` actually bounds. Byte
+        // length used to stand in for it, which was true while `detail` was
+        // ASCII and is not now that a camera label is carried: a 27-character
+        // Japanese label is 81 bytes and would satisfy this guard while sitting
+        // nowhere near the bound it claims to exercise.
+        .map(|detail| detail.chars().count())
         .max()
         .unwrap_or(0);
     assert!(
@@ -979,22 +991,24 @@ fn data_event_handling_uses_frontend_topics() {
         .and_then(Value::as_str)
         .unwrap()
         .to_string();
+    let invalid_review = integrity_event_with_source_ids(
+        IntegrityEventInput {
+            seq: 3,
+            prev_hash: &invalid_review_prev_hash,
+            event_type: "REVIEW_EVENT",
+            at: "2026-08-15T00:00:03.000Z",
+            severity: "warning",
+            source: "review",
+            duration_ms: 1000,
+            detail: Some("SCREEN_INTERRUPTION_WITH_FACE_MISSING"),
+        },
+        &["99"],
+    );
+    let invalid_review_hash = invalid_review["hash"].as_str().unwrap().to_string();
     apply_data_event(
         &mut state,
         "integrity",
-        &integrity_event_with_source_ids(
-            IntegrityEventInput {
-                seq: 3,
-                prev_hash: &invalid_review_prev_hash,
-                event_type: "REVIEW_EVENT",
-                at: "2026-08-15T00:00:03.000Z",
-                severity: "warning",
-                source: "review",
-                duration_ms: 1000,
-                detail: Some("SCREEN_INTERRUPTION_WITH_FACE_MISSING"),
-            },
-            &["99"],
-        ),
+        &invalid_review,
         TEST_REACTION_COOLDOWN_S,
     );
     assert_eq!(
@@ -1003,18 +1017,19 @@ fn data_event_handling_uses_frontend_topics() {
         "review events cannot cite nonexistent source event ids"
     );
 
-    let second_hash = state.integrity_events[1]
-        .get("hash")
-        .and_then(Value::as_str)
-        .unwrap()
-        .to_string();
+    // Seq 4 chained onto the refused event, not seq 3 again. The browser
+    // advances its own counter for every event it publishes and never reissues
+    // a number the agent already saw, so a citation the agent will not store is
+    // still a link the next event hangs off. Reusing seq 3 here modelled a
+    // producer `web/interview.js` is not: `publishIntegrityEvent` moves
+    // `state.integrityChain` on every delivered event.
     apply_data_event(
         &mut state,
         "integrity",
         &integrity_event_with_source_ids(
             IntegrityEventInput {
-                seq: 3,
-                prev_hash: &second_hash,
+                seq: 4,
+                prev_hash: &invalid_review_hash,
                 event_type: "REVIEW_EVENT",
                 at: "2026-08-15T00:00:03.000Z",
                 severity: "warning",
@@ -1597,14 +1612,11 @@ fn the_integrity_detail_bound_is_the_same_number_on_both_sides() {
 /// The fixture only covers the characters it contains, so this states what it
 /// has to keep containing.
 ///
-/// `sanitize_integrity_event` drops a `detail` carrying one character outside
-/// its allowlist, which makes the agent hash `"detail":null` against a browser
-/// that hashed the text. That is the length-bound bug with a character set
-/// instead of a length, and it was reachable: `FACE_DETECTOR_UNAVAILABLE`
-/// carries a raw `error.message`, and a JS error routinely contains parentheses
-/// and quotes.
+/// `sanitize_integrity_event` drops a `detail` carrying a control character,
+/// which makes the agent hash `"detail":null` against a browser that hashed the
+/// text. That is the length-bound bug with a character set instead of a length.
 #[test]
-fn the_integrity_fixture_exercises_both_sides_of_the_detail_allowlist() {
+fn the_integrity_fixture_exercises_the_detail_control_character_contract() {
     let fixture: Value = serde_json::from_str(include_str!("fixtures/integrity-chain.json"))
         .expect("fixture parses");
     let details: Vec<&str> = fixture
@@ -1624,29 +1636,57 @@ fn the_integrity_fixture_exercises_both_sides_of_the_detail_allowlist() {
          arbitrary error message reaches this field"
     );
 
-    // And one using every character the agent does allow, so a browser that
-    // starts stripping too much fails here rather than quietly losing evidence.
+    // Punctuation stays valid; a browser that over-filters loses useful detail.
     let allowed = "az AZ 09 _-=/;:,.";
     assert!(
         details.contains(&allowed),
-        "the fixture must carry a detail using the whole allowed set; without it \
+        "the fixture must carry a detail using the whole punctuation set; without it \
          a producer that over-filters looks correct"
     );
 
-    // Every detail the browser produces has to survive the agent's filter
-    // unchanged, or it is not a detail the agent can verify.
+    // Every browser detail must survive the agent's filter unchanged. Asserted
+    // through the sanitizer rather than the predicate behind it, so this covers
+    // the contract the wire actually has: a refused character does not shorten
+    // the detail, it nulls it, and then the hashes disagree.
     for detail in &details {
-        assert!(
-            detail
-                .chars()
-                .all(|character| character.is_ascii_alphanumeric()
-                    || matches!(
-                        character,
-                        ' ' | '_' | '-' | '=' | '/' | ';' | ':' | ',' | '.'
-                    )),
-            "the browser emitted a detail the agent's allowlist refuses: {detail:?}"
+        let event = integrity_event(IntegrityEventInput {
+            seq: 1,
+            prev_hash: "",
+            event_type: "MEDIA_PREFLIGHT_PASSED",
+            at: "2026-08-15T00:00:00.000Z",
+            severity: "info",
+            source: "preflight",
+            duration_ms: 0,
+            detail: Some(detail),
+        });
+        assert_eq!(
+            sanitize_integrity_event(&event).expect("the event shape is valid")["detail"],
+            json!(detail),
+            "the browser emitted a detail the agent refuses: {detail:?}"
         );
     }
+}
+
+#[test]
+fn localized_camera_labels_survive_integrity_verification() {
+    let mut state = RuntimeState::default();
+    let detail = "camera=仮想カメラ Café (046d:086b)";
+    apply_data_event(
+        &mut state,
+        "integrity",
+        &integrity_event(IntegrityEventInput {
+            seq: 1,
+            prev_hash: "",
+            event_type: "MEDIA_PREFLIGHT_PASSED",
+            at: "2026-08-15T00:00:00.000Z",
+            severity: "info",
+            source: "preflight",
+            duration_ms: 0,
+            detail: Some(detail),
+        }),
+        TEST_REACTION_COOLDOWN_S,
+    );
+    assert_eq!(state.integrity_events[0]["detail"], detail);
 }
 
 /// The counts and the free text arrive on a topic the candidate's browser
@@ -1942,5 +1982,286 @@ fn honest_counts_survive_ingest_exactly() {
                 "`{field}` changed for the `{name}` run",
             );
         }
+    }
+}
+
+/// Builds a chain the way `web/interview.js` does: every event takes the next
+/// sequence number and hangs off the previous hash, whatever the agent decides
+/// to do with it.
+struct Chain {
+    seq: u64,
+    prev_hash: String,
+}
+
+impl Chain {
+    fn new() -> Self {
+        Self {
+            seq: 0,
+            prev_hash: String::new(),
+        }
+    }
+
+    fn push(&mut self, state: &mut RuntimeState, event_type: &str, severity: &str) {
+        self.push_citing(state, event_type, severity, &[]);
+    }
+
+    fn push_citing(
+        &mut self,
+        state: &mut RuntimeState,
+        event_type: &str,
+        severity: &str,
+        source_event_ids: &[&str],
+    ) {
+        self.seq += 1;
+        let event = integrity_event_with_source_ids(
+            IntegrityEventInput {
+                seq: self.seq,
+                prev_hash: &self.prev_hash,
+                event_type,
+                at: "2026-08-15T00:00:00.000Z",
+                severity,
+                source: if event_type == "INTEGRITY_HEARTBEAT" {
+                    "heartbeat"
+                } else {
+                    "camera"
+                },
+                duration_ms: 0,
+                detail: None,
+            },
+            source_event_ids,
+        );
+        self.prev_hash = event["hash"].as_str().expect("hash").to_string();
+        apply_data_event(state, "integrity", &event, TEST_REACTION_COOLDOWN_S);
+    }
+}
+
+fn stored_types(state: &RuntimeState) -> Vec<&str> {
+    state
+        .integrity_events
+        .iter()
+        .filter_map(|event| event["type"].as_str())
+        .collect()
+}
+
+/// Heartbeats used to evict evidence. One arrives every five seconds and the
+/// buffer holds 25, so a thirty minute interview reported its last two minutes:
+/// a camera that stopped at minute three was gone by minute five, pushed out by
+/// heartbeats reporting that the camera was fine.
+///
+/// The second half matters as much as the first. Eviction and chain
+/// verification used to read the same vector, so dropping an event for space
+/// moved the sequence the next event had to match and every later event was
+/// refused. The cursor is separate now, and this proves it survives a buffer
+/// that turned over twice.
+#[test]
+fn heartbeats_are_evicted_before_evidence_and_do_not_break_the_chain() {
+    let mut state = RuntimeState::default();
+    let mut chain = Chain::new();
+
+    chain.push(&mut state, "SESSION_START", "info");
+    chain.push(&mut state, "CAMERA_STOPPED", "high");
+    // Well past the cap, the way a real interview is.
+    for _ in 0..80 {
+        chain.push(&mut state, "INTEGRITY_HEARTBEAT", "info");
+    }
+
+    assert_eq!(
+        stored_types(&state),
+        vec!["SESSION_START", "CAMERA_STOPPED"],
+        "heartbeats belong in liveness, and nothing should have been evicted"
+    );
+
+    // The heartbeats are not lost, they are filed. The detail is the only
+    // periodic record of analyzer state in the system, so a report that keeps
+    // 25 events and no device-state sample cannot show the analyzer ever ran.
+    let first = state
+        .integrity_first_heartbeat
+        .clone()
+        .expect("heartbeats are kept as liveness, not discarded");
+    let last = state
+        .integrity_last_heartbeat
+        .clone()
+        .expect("and a run of 80 has two ends");
+    assert_eq!(first["seq"], 3, "the opening sample is the first heartbeat");
+    assert_eq!(
+        last["seq"], 82,
+        "the closing sample is the most recent heartbeat"
+    );
+
+    // Evidence past the cap still evicts oldest-first, and that is now the only
+    // eviction there is.
+    for _ in 0..30 {
+        chain.push(&mut state, "CAMERA_STOPPED", "high");
+    }
+    assert_eq!(state.integrity_events.len(), 25);
+    assert!(
+        !stored_types(&state).contains(&"SESSION_START"),
+        "30 real events past the cap should have pushed the opening event out"
+    );
+
+    // The chain must not have noticed any of it.
+    chain.push(&mut state, "MICROPHONE_STOPPED", "high");
+    assert!(
+        stored_types(&state).contains(&"MICROPHONE_STOPPED"),
+        "eviction moved the sequence the next event had to match, so the chain \
+         refused an event the browser numbered correctly: {:?}",
+        stored_types(&state)
+    );
+}
+
+/// A review event may name an event that eviction already removed. Refusing to
+/// store it is right; refusing every event after it is not, and that is what
+/// used to happen because the refusal ran before the chain cursor moved.
+///
+/// Retention is this process's problem. Tampering is the producer's. Only the
+/// second one is allowed to end the chain.
+#[test]
+fn a_review_event_naming_an_evicted_source_does_not_end_the_chain() {
+    let mut state = RuntimeState::default();
+    let mut chain = Chain::new();
+
+    // Evidence, not heartbeats. A heartbeat never reaches the buffer at all, so
+    // citing one would prove the citation invalid for the wrong reason and no
+    // eviction would happen: this test quietly stopped exercising eviction when
+    // liveness moved to its own field.
+    chain.push(&mut state, "SESSION_START", "info");
+    for _ in 0..30 {
+        chain.push(&mut state, "CAMERA_STOPPED", "high");
+    }
+    assert_eq!(state.integrity_events.len(), 25, "the cap must have bitten");
+    assert!(
+        !state
+            .integrity_events
+            .iter()
+            .any(|event| event["seq"].as_u64() == Some(2)),
+        "seq 2 is evidence the cap pushed out, which is what makes the citation stale"
+    );
+
+    chain.push_citing(&mut state, "REVIEW_EVENT", "warning", &["2"]);
+    assert!(
+        !stored_types(&state).contains(&"REVIEW_EVENT"),
+        "a review event with an unretained source should not be stored"
+    );
+
+    // The chain, however, kept going.
+    chain.push(&mut state, "CAMERA_STOPPED", "high");
+    assert!(
+        stored_types(&state).contains(&"CAMERA_STOPPED"),
+        "a retention drop ended the chain: every later event was refused"
+    );
+}
+
+/// The browser slices the event list at the evidence cap plus the two liveness
+/// samples. A cap raised on one side and not the other truncates the report in
+/// silence, dropping the closing device-state sample first.
+#[test]
+fn the_report_row_cap_matches_the_evidence_cap_plus_its_bookends() {
+    let browser = std::fs::read_to_string("web/lib.js").expect("web/lib.js is readable");
+    let declaration = "export const MAX_INTEGRITY_ROWS = ";
+    let start = browser
+        .find(declaration)
+        .expect("web/lib.js declares MAX_INTEGRITY_ROWS")
+        + declaration.len();
+    let rest = &browser[start..];
+    let end = rest.find(';').expect("the declaration ends in a semicolon");
+    let rows: usize = rest[..end]
+        .trim()
+        .parse()
+        .expect("MAX_INTEGRITY_ROWS is a number");
+
+    assert_eq!(
+        rows,
+        codetrial::agent::MAX_INTEGRITY_EVENTS + 2,
+        "the browser keeps {rows} rows and the agent sends up to {} evidence \
+         events plus an opening and a closing heartbeat",
+        codetrial::agent::MAX_INTEGRITY_EVENTS
+    );
+}
+
+/// `durationMs` is candidate-supplied and reaches the report, so its ceiling is
+/// a real bound and not a formality. Nothing pinned it, so a slip in the number
+/// was invisible.
+#[test]
+fn a_duration_is_clamped_to_one_day_of_milliseconds() {
+    let with_duration = |duration: i64| {
+        let event = serde_json::json!({
+            "type": "CAMERA_STOPPED",
+            "at": "2026-08-15T00:00:00.000Z",
+            "severity": "high",
+            "source": "camera",
+            "durationMs": duration,
+            "seq": 1,
+            "prevHash": "",
+            "hash": "a".repeat(64),
+            "detail": null,
+        });
+        sanitize_integrity_event(&event).expect("the event shape is valid")["durationMs"].clone()
+    };
+
+    const ONE_DAY_MS: i64 = 86_400_000;
+    assert_eq!(
+        with_duration(ONE_DAY_MS),
+        json!(ONE_DAY_MS),
+        "the bound itself is allowed"
+    );
+    assert_eq!(
+        with_duration(ONE_DAY_MS + 1),
+        json!(ONE_DAY_MS),
+        "anything past it is cut to it"
+    );
+    assert_eq!(
+        with_duration(-1),
+        json!(0),
+        "and a negative duration is not one"
+    );
+}
+
+/// The fixture proves the browser and the agent strip the same set on a real
+/// payload. This proves the agent enforces it rather than trusting the browser
+/// to have done the stripping, which is the half a fixture cannot cover: the
+/// producer is the adversary, so a hand-built payload must not get further than
+/// one the browser would have cleaned.
+#[test]
+fn a_detail_that_reorders_or_hides_text_is_dropped_but_localized_text_survives() {
+    let detail_with = |detail: &str| {
+        let event = integrity_event(IntegrityEventInput {
+            seq: 1,
+            prev_hash: "",
+            event_type: "MEDIA_PREFLIGHT_PASSED",
+            at: "2026-08-15T00:00:00.000Z",
+            severity: "info",
+            source: "preflight",
+            duration_ms: 0,
+            detail: Some(detail),
+        });
+        sanitize_integrity_event(&event).expect("the event shape itself is valid")["detail"].clone()
+    };
+
+    // Kept: a camera label is evidence a person reads, and most of the world
+    // does not name its devices in ASCII.
+    assert_eq!(
+        detail_with("camera=FaceTime HD \u{30AB}\u{30E1}\u{30E9}"),
+        json!("camera=FaceTime HD \u{30AB}\u{30E1}\u{30E9}")
+    );
+
+    // Kept for the same reason, and the reason the U+200B run has two holes in
+    // it: the zero-width non-joiner is how Persian spells this, not decoration.
+    let persian = "camera=\u{645}\u{6CC}\u{200C}\u{631}\u{648}\u{62F}";
+    assert_eq!(detail_with(persian), json!(persian));
+
+    // Dropped: each of these either reorders or hides the text printed around
+    // it, and the report escapes markup rather than bidirectional overrides.
+    for hostile in [
+        "camera=\u{202E}gnitautis",
+        "camera=OBS\u{200B} Virtual",
+        "camera=soft\u{00AD}hyphen",
+        "camera=\u{2066}isolate",
+        "camera=\u{FEFF}bom",
+    ] {
+        assert_eq!(
+            detail_with(hostile),
+            Value::Null,
+            "detail should have been refused: {hostile:?}"
+        );
     }
 }

--- a/tests/browser/lib.test.js
+++ b/tests/browser/lib.test.js
@@ -18,6 +18,7 @@ import {
   endInterviewPayload,
   escapeHtml,
   formatTime,
+  INTEGRITY_DETAIL_MAX,
   integrityEventPayload,
   normalize,
   orPlaceholder,
@@ -246,6 +247,96 @@ test("integrity events are canonical hashed chain payloads", async () => {
   );
 });
 
+test("a camera label is carried as detail without outgrowing the hashed bound", async () => {
+  // The preflight names the camera because nothing in the media path can tell a
+  // virtual camera from a real one. Device labels are long and full of
+  // punctuation, and `detail` is hashed: a producer that emits more than
+  // INTEGRITY_DETAIL_MAX builds a hash the agent cannot reproduce, which stops
+  // the chain for the rest of the interview. That is not hypothetical, it is
+  // why the bound is commented in web/lib.js.
+  // Long enough to be cut, with an astral character across the cut. `.slice()`
+  // counts UTF-16 units, so it would stop early and leave half a surrogate pair
+  // behind; the agent counts code points and would hash the other string. That
+  // divergence is the entire reason `integrityDetail` uses `Array.from`. A label
+  // that fits under the bound exercises none of it.
+  // Placed so the emoji's two UTF-16 units straddle index 80: "camera=" is 7,
+  // the kana are 70, "ab" is 2, so the pair occupies units 79 and 80. A
+  // `.slice(0, 80)` keeps unit 79 and drops its partner.
+  const label = "仮想カメラ".repeat(14) + "ab\u{1F3A5}tail";
+  const event = await integrityEventPayload({
+    type: "MEDIA_PREFLIGHT_PASSED",
+    source: "preflight",
+    detail: `camera=${label}`,
+  });
+  assert.equal(Array.from(event.detail).length, INTEGRITY_DETAIL_MAX);
+  // A well-formed pair is one element from `Array.from`; a lone surrogate is a
+  // one-unit element in the surrogate range, which is what a UTF-16 cut leaves.
+  assert.ok(
+    !Array.from(event.detail).some((c) => c.length === 1 && c.charCodeAt(0) >= 0xd800 && c.charCodeAt(0) <= 0xdfff),
+    "truncation split a surrogate pair",
+  );
+  assert.ok(event.detail.startsWith("camera=仮想カメラ"), event.detail);
+});
+
+test("a device label cannot reorder or hide the report it is printed in", async () => {
+  // The label is whatever the candidate named their device, and it is rendered
+  // into the interviewer's report where escapeHtml handles markup and nothing
+  // handles a right-to-left override. `hidden_or_reordering` in
+  // src/agent/integrity.rs refuses the identical set: a character kept here and
+  // dropped there is a hash the agent cannot reproduce, which stops the chain.
+  const hostile = "camera=\u202Egnitautis\u200B\u00AD\u2066\uFEFF end";
+  const event = await integrityEventPayload({ type: "MEDIA_PREFLIGHT_PASSED", detail: hostile });
+  assert.equal(event.detail, "camera=gnitautis end");
+
+  // Localized labels survive. Stripping them would leave the evidence
+  // unreadable for the people most likely to need it.
+  const localized = await integrityEventPayload({
+    type: "MEDIA_PREFLIGHT_PASSED",
+    detail: "camera=FaceTime HD \u30AB\u30E1\u30E9",
+  });
+  assert.equal(localized.detail, "camera=FaceTime HD \u30AB\u30E1\u30E9");
+
+  // The zero-width non-joiner is orthographic here, not decoration, which is
+  // why the U+200B run is not a solid range on either side.
+  const persian = "camera=\u0645\u06CC\u200C\u0631\u0648\u062F";
+  const kept = await integrityEventPayload({ type: "MEDIA_PREFLIGHT_PASSED", detail: persian });
+  assert.equal(kept.detail, persian);
+});
+
+test("every Unicode bidi control is stripped, not the ones we thought of", async () => {
+  // Bidi_Control is a closed set of twelve. Listing ranges by hand is how
+  // U+061C ARABIC LETTER MARK was missed, so assert the property rather than
+  // the list: the next code point nobody thinks of fails here.
+  const BIDI_CONTROL = [
+    0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e,
+    0x2066, 0x2067, 0x2068, 0x2069,
+  ];
+  for (const codePoint of BIDI_CONTROL) {
+    const event = await integrityEventPayload({
+      type: "MEDIA_PREFLIGHT_PASSED",
+      detail: `a${String.fromCodePoint(codePoint)}b`,
+    });
+    assert.equal(event.detail, "ab", `U+${codePoint.toString(16).toUpperCase()} reached the report`);
+  }
+});
+
+test("a stored report cannot smuggle a reordering character past the render", () => {
+  // `integrityDetail` runs in the producer and the agent refuses what it missed,
+  // but src/web/interviews.rs stores a POSTed report body verbatim and
+  // web/replay.js renders it back through `sanitizeReport`. That path crosses
+  // neither filter, and `escapeHtml` does not touch bidi.
+  const clean = sanitizeReport({
+    problemId: "two-sum",
+    summary: "looked\u202Efine",
+    integrityEvents: [{
+      type: "CAMERA_STOPPED", at: "00:01", severity: "high",
+      source: "camera", detail: "camera=\u202Egnitautis\u200B",
+    }],
+  });
+  assert.equal(clean.integrityEvents[0].detail, "camera=gnitautis");
+  assert.equal(clean.summary, "lookedfine");
+});
+
 test("only the agent may deliver a report, and only on the report topic", () => {
   const agentByKind = { kind: "AGENT" };
   const agentByPermission = { permissions: { agent: true } };
@@ -309,11 +400,13 @@ test("sanitizeReport clamps scores and strips markup from a hostile report", () 
 // `/api/reports` answers an oversized body with a 413 the UI has nothing to do
 // with, so a report has to fit by construction. The shape below is the largest
 // one sanitizeReport can produce: every list at its cap, every string at its
-// cap, and every character a control one. Those cost six bytes each once JSON
-// escapes them to `\u0001`, which beats even a four-byte character, so this is
-// the case the budget has to survive.
+// cap, and every character the most expensive one that survives sanitizing.
+// Control characters used to be that, at six bytes each once JSON escapes them
+// to `\u0001`, but `boundedText` now strips them before render. The dearest
+// survivor is an astral character at four UTF-8 bytes per code point, and code
+// points are the unit the bounds are counted in, so that is the worst case.
 test("sanitizeReport bounds text so the largest possible report still fits", () => {
-  const long = "\u0001".repeat(50_000);
+  const long = "\u{1F3A5}".repeat(50_000);
   const full = { strengths: [long, long, long, long], improvements: [long, long, long, long] };
   const report = sanitizeReport({
     summary: long,
@@ -335,7 +428,9 @@ test("sanitizeReport bounds text so the largest possible report still fits", () 
 
   assert.equal(report.codingFeedback.strengths.length, 4);
   assert.equal(report.communicationFeedback.improvements.length, 4);
-  assert.equal(report.integrityEvents.length, 25);
+  // 27: `MAX_INTEGRITY_EVENTS` in src/agent.rs caps the evidence at 25, and the
+  // report packet merges the first and last heartbeat in beside it.
+  assert.equal(report.integrityEvents.length, 27);
   assert.ok(new TextEncoder().encode(JSON.stringify(report)).length < 64 * 1024, "MAX_REPORT_BYTES in src/web/mod.rs");
 });
 
@@ -372,6 +467,8 @@ test("sanitizeReport preserves a well-formed agent report", () => {
     codingFeedback: { strengths: ["clear"], improvements: ["edge cases"] },
     communicationFeedback: { strengths: ["narrated"], improvements: ["slow down"] },
     integrityEvents: [{ type: "SESSION_START", at: "now", severity: "info", source: "media", durationMs: 0, seq: 1, prevHash: "", hash: "a".repeat(64), detail: null, sourceEventIds: [] }],
+    integrityChainSeq: 412,
+    integrityDropped: 380,
     hintsUsed: 2,
   });
 
@@ -383,6 +480,10 @@ test("sanitizeReport preserves a well-formed agent report", () => {
     codingFeedback: { strengths: ["clear"], improvements: ["edge cases"] },
     communicationFeedback: { strengths: ["narrated"], improvements: ["slow down"] },
     integrityEvents: [{ type: "SESSION_START", at: "now", severity: "info", source: "media", durationMs: 0, seq: 1, prevHash: "", hash: "a".repeat(64), detail: null, sourceEventIds: [] }],
+    // The event list is one row and the chain reached 412, which is the whole
+    // point of carrying these: the list is a subsequence and says so.
+    integrityChainSeq: 412,
+    integrityDropped: 380,
     hintsUsed: 2,
   });
 });

--- a/tests/browser/render.test.js
+++ b/tests/browser/render.test.js
@@ -12,11 +12,15 @@ import {
   createTranscriptView,
   feedbackMarkup,
   finalRunnerStatus,
+  chainSentence,
   reportMarkdown,
   reportMarkup,
   resultsMarkup,
   runnerStatusMarkup,
 } from "../../web/render.js";
+import { sanitizeReport } from "../../web/lib.js";
+
+const events = [{ type: "CAMERA_STOPPED", at: "00:01", severity: "high", source: "camera", detail: null, sourceEventIds: [] }];
 
 // --- smallest document that satisfies the view -----------------------------
 class StubElement {
@@ -660,4 +664,58 @@ test("markdown export handles an empty session", () => {
   assert.match(markdown, /^\(none\)$/m, "missing summary falls back");
   assert.match(markdown, /^\(editor was empty\)$/m);
   assert.match(markdown, /^\(no speech captured\)$/m);
+});
+
+test("the report says the event list is a subsequence, or says it cannot tell", () => {
+  // Retention makes the list a subsequence with holes, so a reader who is not
+  // told cannot distinguish "the agent dropped 380 for space" from "rows were
+  // deleted from the stored report". That distinction is what the chain is for.
+
+  const dropped = reportMarkup({ report: sanitizeReport({
+    decision: "HIRE", integrityEvents: events, integrityChainSeq: 412, integrityDropped: 380,
+  }), problemTitle: "Two Sum", language: "python", code: "" });
+  assert.match(dropped, /Chain verified through event 412/);
+  assert.match(dropped, /380 more were verified and not kept/);
+
+  const complete = reportMarkup({ report: sanitizeReport({
+    decision: "HIRE", integrityEvents: events, integrityChainSeq: 1, integrityDropped: 0,
+  }), problemTitle: "Two Sum", language: "python", code: "" });
+  assert.match(complete, /every event it verified is listed above/);
+
+  // A report with no checkpoint must not read as "nothing was dropped", which is
+  // the one answer it cannot support. Both shapes reach this: a report stored
+  // before the field existed carries nothing, and the agent sends an explicit
+  // null when the chain never advanced. `Number(null)` is 0, so the second one
+  // used to render as "verified through event 0, every event is listed above".
+  for (const absent of [{}, { integrityChainSeq: null, integrityDropped: null }]) {
+    const legacy = reportMarkup({
+      report: sanitizeReport({ decision: "HIRE", integrityEvents: events, ...absent }),
+      problemTitle: "Two Sum", language: "python", code: "",
+    });
+    assert.match(legacy, /predates chain reporting/, JSON.stringify(absent));
+    assert.doesNotMatch(legacy, /every event it verified is listed above/, JSON.stringify(absent));
+  }
+});
+
+test("the page and the exported markdown tell the same chain story", () => {
+  // They were two copies of the same three branches and already worded
+  // differently. The export is the copy that gets forwarded, so a reader
+  // comparing it against the page must not find a different claim.
+  const shapes = [
+    { integrityChainSeq: 412, integrityDropped: 380 },
+    { integrityChainSeq: 7, integrityDropped: 0 },
+    {},
+  ];
+  // Both list shapes. Nothing retained is not a rare case: it is what a report
+  // looks like when everything the chain verified was dropped for space, and it
+  // is the case where the page used to stay silent while the export spoke.
+  for (const [report, list] of shapes.flatMap((r) => [[r, events], [r, []]])) {
+    const sentence = chainSentence(sanitizeReport({ decision: "HIRE", ...report }));
+    const session = {
+      report: sanitizeReport({ decision: "HIRE", integrityEvents: list, ...report }),
+      problemTitle: "Two Sum", language: "python", code: "",
+    };
+    assert.ok(reportMarkup(session).includes(sentence), sentence);
+    assert.ok(reportMarkdown({ ...session, transcript: [] }).includes(sentence), sentence);
+  }
 });

--- a/tests/fixtures/integrity-chain.json
+++ b/tests/fixtures/integrity-chain.json
@@ -79,13 +79,13 @@
     "severity": "warning",
     "source": "media",
     "durationMs": 0,
-    "detail": "face detection unavailable: Cannot read properties of undefined reading a",
+    "detail": "face detection unavailable: Cannot read properties of undefined (reading 'a')",
     "sourceEventIds": [],
-    "hash": "9421728e0ad0d1e5cb95d4a50f2c448b7f37954110d47a3d09e3f052b5c6e4a9"
+    "hash": "834040f7408ec077f540c5af5e8eedaff7c254ab266388ecd1d2709b4f20036b"
   },
   {
     "seq": 8,
-    "prevHash": "9421728e0ad0d1e5cb95d4a50f2c448b7f37954110d47a3d09e3f052b5c6e4a9",
+    "prevHash": "834040f7408ec077f540c5af5e8eedaff7c254ab266388ecd1d2709b4f20036b",
     "type": "INTEGRITY_HEARTBEAT",
     "at": "2026-08-18T06:39:44.702Z",
     "severity": "info",
@@ -93,11 +93,23 @@
     "durationMs": 0,
     "detail": "az AZ 09 _-=/;:,.",
     "sourceEventIds": [],
-    "hash": "25c8d8c3a25ace7c0963d9fdab1fe688c3999a3c4cc7bc8a7f463da5b1e87d1c"
+    "hash": "82ce6734eeb29a48d8b362c9a3cbe5b6f59178b85b96aad7f86dbb84aab77cd1"
   },
   {
     "seq": 9,
-    "prevHash": "25c8d8c3a25ace7c0963d9fdab1fe688c3999a3c4cc7bc8a7f463da5b1e87d1c",
+    "prevHash": "82ce6734eeb29a48d8b362c9a3cbe5b6f59178b85b96aad7f86dbb84aab77cd1",
+    "type": "MEDIA_PREFLIGHT_PASSED",
+    "at": "2026-08-18T06:39:52.400Z",
+    "severity": "info",
+    "source": "preflight",
+    "durationMs": 0,
+    "detail": "camera=FaceTime HD カメラ می‌ر gnitautis (05AC:8514)",
+    "sourceEventIds": [],
+    "hash": "177213497b39eb1584e86b70c09ff614eb531ddf44622adfecb1d605bd949b18"
+  },
+  {
+    "seq": 10,
+    "prevHash": "177213497b39eb1584e86b70c09ff614eb531ddf44622adfecb1d605bd949b18",
     "type": "MULTIPLE_FACES",
     "at": "2026-08-18T06:40:11.006Z",
     "severity": "critical",
@@ -110,6 +122,6 @@
       "333333333333",
       "444444444444"
     ],
-    "hash": "55d40f02aba778f0753ecf2bcd43f7f5c011c66a0f511cd0305f06d5b395d304"
+    "hash": "e7d0832bf0943d5f5ccf2244480e184237f4362b9397b0bd0b027ad82abe5614"
   }
 ]

--- a/web/interview.html
+++ b/web/interview.html
@@ -144,6 +144,13 @@
 
           <div class="audio-check-step" id="audio-step-camera">
             <p><span class="step-mark" aria-hidden="true"></span><strong>Camera</strong> — <span id="camera-state" aria-live="polite">grant access and keep video on.</span></p>
+            <p id="camera-name-disclosure" class="muted small">
+              The camera's name is recorded in your report so a reviewer can see which device
+              was opened. On Apple devices that name often contains your own, for example
+              "Alex's iPhone". CodeTrial opens whichever camera your browser treats as the
+              default, so change that default in your browser or system settings before
+              starting if you would rather it did not.
+            </p>
           </div>
 
           <!-- Decided here, not in the sidebar: it changes which tracks the

--- a/web/interview.js
+++ b/web/interview.js
@@ -1058,7 +1058,19 @@ async function connectLiveKit(connection, preflight, presenting = false) {
   updateAgentState();
   monitorIntegrityTracks();
   await publishIntegrityEvent({ type: "SESSION_START", source: "media", severity: "info" });
-  await publishIntegrityEvent({ type: "MEDIA_PREFLIGHT_PASSED", source: "preflight", severity: "info" });
+  // The camera is named, not judged. Nothing here can tell a virtual camera
+  // from a real one: `devices.js` asks for `video: true` with no device id, so
+  // Chrome opens whatever is default, and a virtual camera satisfies the face
+  // check with a composited feed this page never captured. Blocking on a list
+  // of vendor names would be a list to maintain and a way to lock out a working
+  // setup, so the label goes in the signed trail and a reader decides. Same
+  // rule as the test counts: safe to narrate, unsafe to score.
+  await publishIntegrityEvent({
+    type: "MEDIA_PREFLIGHT_PASSED",
+    source: "preflight",
+    severity: "info",
+    detail: `camera=${preflight.userStream?.getVideoTracks?.()[0]?.label || "none"}`,
+  });
   startIntegrityHeartbeat();
   // Keyed on what the candidate chose, not on whether a camera happens to be
   // in the stream. A camera that died between the preflight and here leaves an

--- a/web/lib.js
+++ b/web/lib.js
@@ -241,25 +241,43 @@ export function canonicalJson(value) {
 /// this bound is unverifiable by construction, and the rejection is silent.
 export const INTEGRITY_DETAIL_MAX = 80;
 
-/// Must accept exactly what `sanitize_integrity_event` in `src/agent/integrity.rs`
-/// accepts. That filter is all-or-nothing: a `detail` carrying one character
-/// outside it becomes null there, so the agent hashes `"detail":null` while the
-/// browser hashed the text, the hashes differ, the event is refused, and because
-/// sequence continuity is required every later event is refused too.
+/// The characters neither side keeps: control characters, plus the format
+/// characters that reorder or hide the text around them.
 ///
-/// This is the same failure as the 160-versus-80 length bound, with a character
-/// set instead of a length, and it was live: `FACE_DETECTOR_UNAVAILABLE` carries
-/// `error.message` from `web/face-worker.js`, and a JS error routinely reads
-/// `Cannot read properties of undefined (reading 'a')`. Parentheses and quotes
-/// are not in the agent's set, so the one event that fires when face detection
-/// breaks was also the one event that broke the evidence chain.
+/// Must strip exactly what `hidden_or_reordering` in `src/agent/integrity.rs`
+/// refuses. That filter is all-or-nothing: a `detail` carrying one of these
+/// becomes null there, so the agent hashes `"detail":null` while the browser
+/// hashed the text, the hashes differ, the event is refused, and because
+/// sequence continuity is required every later event is refused too. It is the
+/// 160-versus-80 length bound again, with a character set instead of a length.
 ///
-/// Stripped rather than refused, because losing the characters costs a little
-/// legibility and refusing costs every event after it.
-const INTEGRITY_DETAIL_DISALLOWED = /[^0-9A-Za-z _\-=/;:,.]/g;
+/// Written as explicit code points rather than `\p{Cf}`, because Rust's std has
+/// no general-category lookup: a category on this side and a hand-written list
+/// on that one would drift.
+///
+/// U+200C and U+200D are deliberately absent from the U+200B run. The
+/// zero-width non-joiner is orthographic in Persian and Urdu and the zero-width
+/// joiner builds Indic conjuncts, so stripping them corrupts exactly the
+/// localized labels this filter was widened to keep. Neither reorders anything:
+/// they change how the glyphs beside them connect.
+const INTEGRITY_DETAIL_STRIPPED =
+  /[\p{Cc}\u00AD\u061C\u200B\u200E\u200F\u202A-\u202E\u2060-\u2064\u2066-\u2069\uFEFF]/gu;
+
+/// A control character is a separator, so prose keeps a space where one stood.
+/// Only the render path wants that; `integrityDetail` feeds a hash and has to
+/// match the agent, which substitutes nothing.
+const CONTROL_SEPARATOR = /\p{Cc}/gu;
+
+/// Code points, not UTF-16 units, matching Rust's `chars().take()`. Slicing a
+/// string directly stops early on any astral character and can leave half a
+/// surrogate pair behind, which is a different string from the one the agent
+/// hashes.
+function codePoints(text, max) {
+  return Array.from(text).slice(0, max).join("");
+}
 
 function integrityDetail(value) {
-  return String(value).replace(INTEGRITY_DETAIL_DISALLOWED, "").slice(0, INTEGRITY_DETAIL_MAX);
+  return codePoints(String(value).replace(INTEGRITY_DETAIL_STRIPPED, ""), INTEGRITY_DETAIL_MAX);
 }
 
 export async function integrityEventPayload(input, previous = { seq: 0, hash: "" }) {
@@ -310,6 +328,22 @@ export function sanitizeReport(raw) {
     return Number.isFinite(number) ? clamp(number, 0, max) : 0;
   };
   const score = (value) => bounded(value, 100);
+  // The chain checkpoint. The event list is a subsequence, so these are what
+  // say how far the agent verified and how much it dropped on purpose; a report
+  // from before they existed has none of them, and `null` reads as "this report
+  // cannot tell you", which is the truth rather than a zero.
+  //
+  // `typeof value === "number"` rather than `Number.isFinite(Number(value))`,
+  // because `Number(null)` is 0 and the agent sends null for a chain that never
+  // advanced. That read an absent checkpoint as "verified through event 0, and
+  // every event is listed above", which is a completeness claim about a report
+  // that has no idea, and the exact thing the absent branch exists to refuse.
+  const count = (value) =>
+    typeof value === "number" && Number.isFinite(value) ? bounded(value, Number.MAX_SAFE_INTEGER) : null;
+  const checkpoint = (raw) => ({
+    integrityChainSeq: count(raw?.integrityChainSeq),
+    integrityDropped: count(raw?.integrityDropped),
+  });
   const feedback = (section) => ({
     strengths: stringList(section?.strengths),
     improvements: stringList(section?.improvements),
@@ -324,6 +358,7 @@ export function sanitizeReport(raw) {
       incomplete: true,
       summary: typeof raw?.summary === "string" ? boundedText(raw.summary) : "",
       integrityEvents: integrityEvents(raw?.integrityEvents),
+      ...checkpoint(raw),
       hintsUsed: bounded(raw?.hintsUsed, 99),
     };
   }
@@ -335,15 +370,26 @@ export function sanitizeReport(raw) {
     codingFeedback: feedback(raw?.codingFeedback),
     communicationFeedback: feedback(raw?.communicationFeedback),
     integrityEvents: integrityEvents(raw?.integrityEvents),
+    ...checkpoint(raw),
     // Bounded like the scores: `JSON.parse` turns 1e999 into Infinity, which
     // would otherwise render as "Infinity hints used" and land in history.
     hintsUsed: bounded(raw?.hintsUsed, 99),
   };
 }
 
+/// The evidence cap in src/agent.rs plus the two heartbeats that
+/// `report_with_integrity_events` merges in beside it. Slicing at the evidence
+/// cap alone would drop the closing device-state sample, which is the half of
+/// the pair that says how the interview ended.
+///
+/// Exported so `tests/agent.rs` can hold it against `MAX_INTEGRITY_EVENTS`, the
+/// way `INTEGRITY_DETAIL_MAX` is already held against `MAX_INTEGRITY_TEXT`. A
+/// cap raised on one side and not the other truncates the report in silence.
+export const MAX_INTEGRITY_ROWS = 27;
+
 function integrityEvents(events) {
   if (!Array.isArray(events)) return [];
-  return events.slice(0, 25).map((event) => ({
+  return events.slice(0, MAX_INTEGRITY_ROWS).map((event) => ({
     type: typeof event?.type === "string" ? boundedText(event.type, 40) : "",
     at: typeof event?.at === "string" ? boundedText(event.at, 40) : "",
     severity: ["info", "warning", "high", "critical"].includes(event?.severity) ? event.severity : "info",
@@ -362,8 +408,27 @@ function integrityEvents(events) {
 // event flood would silently cost someone their history.
 const MAX_REPORT_TEXT = 300;
 
+// Code points, not UTF-16 units, because `detail` now carries whatever the
+// candidate named their camera. `slice` cut an 80-code-point label down to 44
+// and left a lone surrogate on the end, which renders as a replacement glyph in
+// the evidence a reviewer reads. Matches the bound `integrityDetail` enforces.
+/// The last boundary before render, which is why the strip happens here and not
+/// only in `integrityDetail`.
+///
+/// That one runs in the producer and `hidden_or_reordering` runs in the agent,
+/// and one path crosses neither: `save_report_handler` in
+/// src/web/interviews.rs stores a POSTed report body verbatim, and
+/// web/replay.js reads it back through `sanitizeReport` into `reportMarkup`. A
+/// client posting its own report could otherwise put a right-to-left override
+/// straight into the rendered evidence, because `escapeHtml` handles markup and
+/// nothing handles reordering. On the agent-delivered path this is a no-op.
+///
+/// Every rendered free-text field in `sanitizeReport` comes through here.
 function boundedText(value, max = MAX_REPORT_TEXT) {
-  return String(value).slice(0, max);
+  return codePoints(
+    String(value).replace(CONTROL_SEPARATOR, " ").replace(INTEGRITY_DETAIL_STRIPPED, ""),
+    max,
+  );
 }
 
 function stringList(value) {

--- a/web/render.js
+++ b/web/render.js
@@ -48,12 +48,36 @@ export function feedbackMarkup(title, section) {
   return `<section><h3>${escapeHtml(title)}</h3><h4>Strengths</h4><ul>${list(section.strengths)}</ul><h4>Improve</h4><ul>${list(section.improvements)}</ul></section>`;
 }
 
-function integrityEvidenceMarkup(events = []) {
-  if (!events.length) return "";
-  const rows = events.map((event, index) => `
+function integrityEvidenceMarkup(report = {}) {
+  const rows = (report.integrityEvents || []).map((event, index) => `
     <li data-integrity-index="${index}"><strong>${escapeHtml(event.severity)}</strong> ${escapeHtml(event.type)} <span>${escapeHtml(event.at)}</span>${event.detail ? `<p>${escapeHtml(event.detail)}</p>` : ""}${sourceEventMarkup(event)}</li>
-  `).join("");
-  return `<section><h3>Integrity Evidence</h3><ul>${rows}</ul></section>`;
+  `).join("") || "<li>(none captured)</li>";
+  return `<section><h3>Integrity Evidence</h3><ul>${rows}</ul><p class="muted small">${escapeHtml(chainSentence(report))}</p></section>`;
+}
+
+/// Says out loud that the list above is a subsequence.
+///
+/// The agent keeps 25 events and verifies every one that arrives, so a busy
+/// interview shows a fraction of what was checked. Without this a reader cannot
+/// tell a retention gap from a deleted row, which is the difference the chain
+/// exists to make visible. A report predating the checkpoint has no numbers and
+/// says so rather than implying nothing was dropped.
+/// One sentence, so the page and the exported markdown cannot drift apart.
+///
+/// They were written twice and already disagreed: one said "This report predates
+/// chain reporting" and the other "Chain reporting predates this report". The
+/// export is the copy that gets forwarded, and two wordings of the same fact in
+/// one file is a promise that they will diverge further.
+export function chainSentence(report) {
+  if (report.integrityChainSeq == null) {
+    return "This report predates chain reporting: how much was dropped for space is unknown.";
+  }
+  const dropped = report.integrityDropped ?? 0;
+  return `Chain verified through event ${report.integrityChainSeq}; ${
+    dropped === 0
+      ? "every event it verified is listed above"
+      : `${dropped} more were verified and not kept, for space`
+  }.`;
 }
 
 function sourceEventMarkup(event) {
@@ -94,7 +118,7 @@ export function reportMarkup({ report, problemTitle, language, code }) {
       </div>${scores}
       <section><h3>${report.incomplete ? "What happened" : "Committee summary"}</h3><p>${escapeHtml(report.summary)}</p></section>
       ${feedback}
-      ${integrityEvidenceMarkup(report.integrityEvents)}
+      ${integrityEvidenceMarkup(report)}
       <details><summary>Your final code (${escapeHtml(language)})</summary><pre>${escapeHtml(code.trimEnd() || "(editor was empty)")}</pre></details>
       <div class="report-actions"><button id="download-report" type="button">Download report (.md)</button><button id="done" type="button">Done - back to lobby</button></div>
     </div>
@@ -151,6 +175,7 @@ export function reportMarkdown({ report, problemTitle, language, code, transcrip
     const sources = event.sourceEventIds?.length ? ` - sources: ${event.sourceEventIds.map(mdText).join(", ")}` : "";
     return `- ${mdText(event.at)} [${mdText(event.severity)}] ${mdText(event.type)}${event.detail ? ` - ${mdText(event.detail)}` : ""}${sources}`;
   }).join("\n") || "(none captured)";
+  const chainNote = mdText(chainSentence(report));
   const conversation = transcript
     .filter((segment) => segment.final || segment.text.trim())
     .map((segment) => `**${segment.speaker === "interviewer" ? "Jim" : "You"}:** ${mdText(segment.text.trim())}`)
@@ -210,6 +235,8 @@ export function reportMarkdown({ report, problemTitle, language, code, transcrip
     // evidence, which `sanitizeReport` deliberately keeps.
     "## Integrity Evidence",
     evidence,
+    "",
+    chainNote,
     "",
     `## Final code (${mdText(language)})`,
     fence + info,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes LiveKit Cloud connections blocked by CSP, and reworks the integrity report so evidence survives long interviews and carries camera labels safely.

**Integrity reporting**

- Heartbeats now live apart from evidence as a first/last sample, so they no longer evict real events; eviction also no longer breaks the chain because the chain cursor is separate.
- Reports now carry `integrityChainSeq`, `integrityChainHash`, and `integrityDropped`; the page and exported markdown state whether the event list is a subsequence, and legacy reports say they predate chain reporting.
- Integrity details keep localized text but strip control and bidi-formatting characters, which previously could reorder the report; browser and agent strip the identical set.
- The preflight now records the camera label and tells the candidate the device name may expose their own name.

**LiveKit connection**

- CSP `connect-src` now includes `*.livekit.cloud` for Cloud hosts, so the signaling socket is no longer refused and a policy fault no longer reads as a network error.
- Added a troubleshooting doc that distinguishes the four failure messages and shows how to verify credentials via `ListRooms` without the browser.
- `check-gemini` now says it never authenticates against LiveKit, so a green run no longer implies valid credentials.

<sup>Written for commit 511b3c428ab1ba4934b53500b1c5139814a2eaef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/codetrial/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

