### PR TITLE
Ship the browser application inside the binary

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -15,6 +15,14 @@
 # need a live API key and would fail on a machine without one. What this mode
 # actually proves is checked by running it, which is why `make check` does.
 #
+# `web_router` is a different case: its mutants die immediately rather than
+# surviving. Replacing the constructor with an empty router answers 404 for
+# every route, so whichever web test runs first catches it. It is here because
+# the gate rebuilds and relinks a crate that statically links libwebrtc once
+# per mutant, and this is the most expensive one in the tree to learn nothing
+# from. It appears whenever a single line inside that hundred-line constructor
+# changes.
+#
 # Keep this list short and each entry justified. An entry that is really "we
 # never got around to testing this" belongs in a test, not here.
-exclude_re = ["run_room", "run_gemini_check"]
+exclude_re = ["run_room", "run_gemini_check", "replace web_router"]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# The Windows release runner runs `scripts/fetch-vendor.sh` under Git Bash. A
+# CRLF checkout turns the shebang into `/bin/sh\r` and, past that, leaves a
+# carriage return on every name the FETCH manifest loop reads, so the SHA256SUMS
+# lookup matches nothing.
+*.sh text eol=lf
+
+# Vendored bytes are hashed. Any end-of-line rewriting changes them and
+# scripts/verify-vendor.sh is right to fail, so keep git out of them entirely.
+web/vendor/** -text

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -439,3 +439,228 @@ jobs:
             $(wc -l <"$RUNNER_TEMP/shard.txt") mutants" >>"$GITHUB_STEP_SUMMARY"
           cargo mutants --in-place --in-diff "$RUNNER_TEMP/pr.diff" \
             --shard ${{ matrix.shard }}/${{ needs.plan-mutants.outputs.width }}
+
+  # The release is a binary, not a directory beside a binary: `rust-embed`
+  # compiles `web/` (including its WASM) into it. Native runners avoid a
+  # cross-platform linker or packaging toolchain.
+  build:
+    needs: check
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: ${{ matrix.name }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            extension: ''
+          - name: macOS arm64
+            os: macos-15
+            target: aarch64-apple-darwin
+            extension: ''
+          - name: Windows x86_64
+            os: windows-2025
+            target: x86_64-pc-windows-msvc
+            extension: .exe
+    runs-on: ${{ matrix.os }}
+    env:
+      # Cleared for the same reason `plan-mutants` clears it: the workflow-wide
+      # value is `-Clink-arg=-fuse-ld=mold`, and only the Linux jobs that
+      # install mold can honor it. Two of these three runners cannot have mold
+      # at all, and MSVC hands the flag to `link.exe`, which dies with LNK1117.
+      # Release builds happen once per push rather than once per mutant, so the
+      # linker that is present everywhere is the right trade.
+      RUSTFLAGS: ''
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+      - name: Install Linux build dependency
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev
+      - name: Fetch browser assets
+        run: ./scripts/fetch-vendor.sh
+        shell: bash
+      # `rust-embed` omits a missing file rather than failing the build, and the
+      # startup warning that would catch it cannot fire in a binary with no
+      # `web/` directory to inspect. Without this, a fetch that quietly no-ops
+      # ships an executable that boots, serves the page, and then strands the
+      # candidate on a Python runtime that never starts.
+      - name: Verify the assets about to be embedded
+        run: ./scripts/verify-vendor.sh
+        shell: bash
+      - name: Build the self-contained executable
+        run: cargo build --release --locked --target ${{ matrix.target }}
+      # The only place the embed is exercised as an embed. `rust-embed` matches
+      # keys exactly in release and reads the same names off the filesystem in
+      # debug, so every test binary the suite builds resolves these paths
+      # through the kernel instead, and normalization bugs are invisible to all
+      # of them. Run from an empty directory, so a fallback to disk cannot
+      # answer and make a missing embed look present.
+      - name: Prove the binary serves without a web tree
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          empty=$(mktemp -d)
+          cp target/${{ matrix.target }}/release/codetrial "$empty/"
+          # Killed from a trap rather than only on the happy path, and with its
+          # output redirected: a server left running past a failed probe holds
+          # the step's stdout open, which turns a one-line failure into a job
+          # that sits until the 45-minute timeout.
+          trap 'pkill -f "codetrial web" || true' EXIT
+          (cd "$empty" && CODETRIAL_WEB_ADDR=127.0.0.1:18999 ./codetrial web >server.log 2>&1 &)
+          for _ in $(seq 1 30); do
+            curl -fs -o /dev/null http://127.0.0.1:18999/ && break
+            sleep 1
+          done
+          status() { curl -sS -o /dev/null -w '%{http_code}' --path-as-is "http://127.0.0.1:18999$1"; }
+          title() { curl -sS --path-as-is "http://127.0.0.1:18999$1" | tr -d '\n' | sed -n 's|.*<title>\(.*\)</title>.*|\1|p'; }
+          # The wasm is last because it is the one the fetch supplies rather
+          # than git: it fails here if the vendored bytes never reached
+          # `.rodata`. The doubled separator is second-to-last because only a
+          # release binary matches embedded keys exactly, so this is the only
+          # place normalization is observable.
+          for probe in / /interview /vendor/avatar/three-vrm.js \
+                       //vendor/avatar/three-vrm.js /vendor/pyodide/pyodide.asm.wasm; do
+            code=$(status "$probe")
+            [ "$code" = 200 ] || { echo "embedded $probe answered $code, not 200" >&2; exit 1; }
+          done
+          [ "$(status /.git/config)" = 404 ] \
+            || { echo "a dotfile was served" >&2; exit 1; }
+
+          # Status is not enough for this one. `web/recording/index.html` is a
+          # nested index, so a resolver that fails to normalize the trailing
+          # slash does not 404: it exhausts its own candidates and falls back
+          # to the root index, answering 200 with the wrong page. Only the
+          # release binary can show it, because a debug build resolves the
+          # embed through the filesystem, where the kernel collapses the
+          # separator whatever the resolver does.
+          for probe in /recording /recording/ //recording/; do
+            found=$(title "$probe")
+            [ "$found" = "CodeTrial - Recording" ] \
+              || { echo "$probe served \"$found\", not the recording page" >&2; exit 1; }
+          done
+          # No backslash probe here. This runner is Linux, where a backslash is
+          # an ordinary filename byte, so the traversal spelling 404s whether or
+          # not the resolver refuses it: the check cannot fail and would only
+          # read as coverage. `normalization_cannot_launder_a_refused_path`
+          # owns that case, asserting the refusal itself rather than an outcome
+          # the platform supplies for free.
+
+      - name: Name release asset
+        run: >-
+          cp target/${{ matrix.target }}/release/codetrial${{ matrix.extension }}
+          codetrial-${{ matrix.target }}${{ matrix.extension }}
+        shell: bash
+      - uses: actions/upload-artifact@v7
+        with:
+          name: codetrial-${{ matrix.target }}
+          path: codetrial-${{ matrix.target }}${{ matrix.extension }}
+
+  # A rolling prerelease keeps the current main build one direct download away.
+  release:
+    needs: [check, build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    # `true`, unlike the workflow-level setting on main. That one keeps every
+    # run's verdict because the verdict is the record. This job's output is a
+    # single mutable pointer, so a publish that a newer commit has already
+    # superseded is work whose result must be thrown away regardless.
+    concurrency:
+      group: release-latest
+      cancel-in-progress: true
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      # Shallow, and only for the tag push below: `gh release edit` cannot move
+      # a tag that already exists, and the GitHub API ignores `target_commitish`
+      # on a published release.
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: codetrial-*
+          path: dist
+          merge-multiple: true
+      - name: Verify and publish the prerelease
+        shell: bash
+        run: |
+          assets=(
+            dist/codetrial-x86_64-unknown-linux-gnu
+            dist/codetrial-aarch64-apple-darwin
+            dist/codetrial-x86_64-pc-windows-msvc.exe
+          )
+          for asset in "${assets[@]}"; do
+            [ -f "$asset" ] || { echo "missing release asset: $asset" >&2; exit 1; }
+          done
+
+          # Build duration varies by runner and by cache hit, so two pushes in
+          # flight can reach this step out of commit order and leave `latest`
+          # pointing at the older binaries. Cancellation covers the queued case;
+          # this covers the one already running when the newer push lands.
+          git fetch --depth 1 origin main
+          if [ "$(git rev-parse FETCH_HEAD)" != "$GITHUB_SHA" ]; then
+            echo "superseded by a newer main; leaving latest alone"
+            exit 0
+          fi
+
+          # Never `gh release delete` first. That destroys the only download
+          # for the length of the publish, and a create that fails afterwards
+          # leaves nothing at all.
+          #
+          # Drafted for the length of the replacement instead. `gh release
+          # upload` writes one asset at a time and three platforms are three
+          # chances to stop halfway, which on a published release means serving
+          # a Linux binary from this commit beside a Windows one from the last.
+          # Nothing tells a person downloading a pair that they do not match. A
+          # draft serves no downloads at all, so the half-written state is
+          # unreachable rather than merely unlikely, and the tag and the notes
+          # move only once the bytes are known to be there.
+          #
+          # The failure this leaves is a `latest` that 404s with a red build
+          # next to it. That is the trade: loudly absent beats quietly mixed,
+          # and the next push to main republishes it.
+          notes="Automated build of ${GITHUB_SHA:0:7}."
+          if gh release view latest >/dev/null 2>&1; then
+            gh release edit latest --draft
+          else
+            # Only `--target` and `--draft` are create-specific. Title,
+            # prerelease and notes are set by the edit at the bottom, which
+            # runs on both branches, so the notes string has one home.
+            gh release create latest --draft --target "$GITHUB_SHA" --notes ""
+          fi
+
+          gh release upload latest "${assets[@]}" --clobber
+
+          # Sizes, not just presence: an upload cut off partway still leaves a
+          # named asset behind, and a truncated binary is the one outcome this
+          # whole dance exists to keep off the download page.
+          for asset in "${assets[@]}"; do
+            name=$(basename "$asset")
+            want=$(stat -c%s "$asset")
+            got=$(gh release view latest --json assets \
+              --jq ".assets[] | select(.name == \"$name\") | .size")
+            [ "$want" = "$got" ] || {
+              echo "$name uploaded as ${got:-nothing}, expected $want bytes" >&2
+              echo "latest stays drafted rather than serving a mixed set" >&2
+              exit 1
+            }
+          done
+
+          # Only now does anything point at this build.
+          git tag -f latest "$GITHUB_SHA"
+          git push -f origin refs/tags/latest
+          gh release edit latest \
+            --draft=false \
+            --prerelease \
+            --title latest \
+            --notes "$notes"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +179,16 @@ checksum = "d54df9073108f1558f90ae6c5bf5ab9c917c4185f5527b280c87a993cbead0ac"
 dependencies = [
  "futures-core",
  "tokio",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
 ]
 
 [[package]]
@@ -294,8 +313,9 @@ dependencies = [
  "reqwest",
  "ring",
  "rusqlite",
+ "rust-embed",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -328,6 +348,12 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -386,6 +412,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -512,9 +547,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -757,6 +803,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,7 +839,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -827,6 +886,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1285,7 +1353,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "thiserror 2.0.20",
  "tokio",
@@ -1424,6 +1492,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -2092,6 +2170,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.119",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "globset",
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,7 +2416,7 @@ checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2313,7 +2427,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2711,6 +2836,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ livekit = "0.8.3"
 ring = "0.17"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.40.2", default-features = false, features = ["bundled"] }
+rust-embed = { version = "8", features = ["include-exclude"] }
 serde_json = "1"
 sha2 = "0.10"
 tokio = { version = "1", features = ["fs", "macros", "net", "rt-multi-thread", "sync", "time"] }
@@ -52,3 +53,23 @@ overflow-checks = false
 opt-level = 2
 debug-assertions = false
 overflow-checks = false
+
+# Exempted from the two overrides above, which are about codec speed and have
+# nothing to say about a crate that only reads files. `rust-embed` splits on
+# `debug_assertions` to decide whether assets live in `.rodata` or are read from
+# disk, and it splits twice: once in the derived code, which sees this crate's
+# setting, and once in the library, which sees its own. Turning it off for
+# dependencies alone makes the two disagree, and the build fails on a
+# `Filenames::Dynamic` the library compiled away.
+#
+# Forcing agreement here rather than with the `debug-embed` feature, which is
+# the other way to make both sides pick the same branch. That way costs 38 MB of
+# `__const` in every one of the eleven test binaries, measured, and again on
+# every cargo-mutants rebuild, which is the exact link time the profile settings
+# above exist to buy back. Release builds embed either way: `debug_assertions`
+# is off there, and no feature is involved.
+[profile.dev.package.rust-embed]
+debug-assertions = true
+
+[profile.test.package.rust-embed]
+debug-assertions = true

--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ make check           # test gate plus live Gemini credential check
 ./scripts/test.sh    # credential-free CI gate
 ```
 
+Every update to `main` publishes a `latest` prerelease with one self-contained
+`codetrial` executable for Linux, macOS, and Windows. It serves the browser
+application from inside the binary, and falls back to those built-in assets per
+file, so a partially populated web tree is filled in rather than 404ing.
+
+Assets on disk win where they exist. That root is `web/` relative to the working
+directory unless `CODETRIAL_WEB_DIR` names another, so running the binary from a
+checkout picks up edits with no environment variable set.
+
+The macOS build is unsigned. A downloaded copy carries the quarantine attribute
+and refuses to open until you clear it:
+
+```shell
+xattr -d com.apple.quarantine codetrial-aarch64-apple-darwin
+```
+
 `web/problems/`, `web/judges/`, and the problem cards in `web/index.html` are
 generated from `problem-bank/`. Regenerate them after editing that source, or
 the gate fails on the drift:

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+//! Makes `rust-embed` see a changed asset tree.
+//!
+//! The derive expands to one `include_bytes!` per file, and rustc records
+//! those in dep-info, so *editing* an embedded asset already rebuilds. Files
+//! that appear or disappear do not: they were never in the previous expansion,
+//! so nothing names them and Cargo considers the crate fresh.
+//!
+//! The failure that costs a release: build once, run `scripts/fetch-vendor.sh`
+//! for the first time, build again. Nothing recompiles, and the binary ships
+//! without the 37 MB of vendored runtime. It boots, serves the page, and then
+//! fails in the browser with a Python runtime that will not start.
+//!
+//! Cargo walks a directory given to `rerun-if-changed` in full, so the one
+//! line covers the tree.
+fn main() {
+    println!("cargo:rerun-if-changed=web");
+}

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -17,7 +17,10 @@ use crate::current_epoch_seconds;
 /// still signed in when they arrive.
 pub const SESSION_TTL_SECONDS: i64 = 60 * 60 * 24 * 30;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// No `Debug`: `session_secret` signs the session cookie, so a copy in a log
+/// is not a credential to steal but the ability to mint any user's session,
+/// and `oauth` carries the client secret beneath it.
+#[derive(Clone, PartialEq, Eq)]
 pub struct GitHubLoginConfig {
     /// Absent unless an OAuth app is configured. The two credentials are only
     /// ever useful together, so they travel together and a handler that has
@@ -29,7 +32,9 @@ pub struct GitHubLoginConfig {
     pub api_base_url: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Same reason. The pair is only ever useful together, so the secret is never
+/// more than one field away from anything that prints the id.
+#[derive(Clone, PartialEq, Eq)]
 pub struct GitHubOauth {
     pub client_id: String,
     pub client_secret: String,

--- a/src/token.rs
+++ b/src/token.rs
@@ -46,7 +46,9 @@ pub fn verify_hs256(secret: &str, value: &str, signature: &str) -> bool {
 
 pub const TOKEN_TTL_SECONDS: u64 = 2 * 60 * 60;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// No `Debug`: `api_secret` is the key every token in this file is signed
+/// with, so printing one instance of this leaks more than any single token.
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct LivekitTokenInput<'a> {
     pub api_key: &'a str,
     pub api_secret: &'a str,

--- a/src/web/assets.rs
+++ b/src/web/assets.rs
@@ -8,9 +8,27 @@ use axum::body::Body;
 use axum::extract::{OriginalUri, State};
 use axum::http::{HeaderValue, Method, StatusCode, header};
 use axum::response::{IntoResponse, Response};
+use rust_embed::RustEmbed;
 
 use super::AppState;
 use super::policy::COMPILER_EXPLORER_ORIGIN;
+
+/// The release binary carries the complete browser application. Disk assets
+/// still take precedence per file, so editing `web/` remains the local
+/// development workflow, and a tree that is merely incomplete is filled in
+/// rather than being all-or-nothing: running the binary beside a checkout that
+/// never fetched `web/vendor` serves the vendored megabytes from inside the
+/// executable instead of answering 404 with a good copy in hand.
+///
+/// Dotfiles are excluded because the resolver below refuses to serve any path
+/// segment starting with `.`, so embedding them is weight nobody can fetch. A
+/// killed `scripts/fetch-vendor.sh` leaves multi-megabyte `.part` files, and
+/// without this they land in `.rodata`.
+#[derive(RustEmbed)]
+#[folder = "web/"]
+#[exclude = ".*"]
+#[exclude = "**/.*"]
+struct EmbeddedWeb;
 
 /// Says out loud at startup which vendored assets were never downloaded.
 ///
@@ -69,8 +87,30 @@ pub(crate) fn warn_about_unfetched_vendor(web_dir: &Path) {
     }
 }
 
-pub async fn static_file(root: &Path, path: &str) -> Option<PathBuf> {
-    static_file_meta(root, path).await.map(|(path, _)| path)
+/// The resolved path together with the `stat` that resolved it. Handed back
+/// rather than thrown away because `static_response` needs the same metadata
+/// for
+/// the ETag and the content length, and asking the kernel twice for an answer
+/// this walk already has is one syscall per request for nothing.
+pub async fn static_file_meta(
+    root: &Path,
+    path: &str,
+) -> Option<(String, PathBuf, std::fs::Metadata)> {
+    // Sequential rather than joined: the first candidate answers almost every
+    // request, and probing four paths in parallel to save a hit that rarely
+    // happens costs three wasted stats on the one that usually does.
+    //
+    // The candidate is handed back beside the path it resolved to. It is what
+    // decides the caching policy, and reconstructing it afterwards with
+    // `strip_prefix(root)` was the second spelling of a rule this file already
+    // argues must have only one.
+    for candidate in static_candidates(path)? {
+        let path = root.join(&candidate);
+        if let Some(metadata) = file_metadata(&path).await {
+            return Some((candidate, path, metadata));
+        }
+    }
+    None
 }
 
 /// Whether a single path segment is one this server refuses to resolve.
@@ -104,43 +144,58 @@ fn is_refused_segment(part: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
 }
 
-/// The resolved path together with the `stat` that resolved it. Handed back
-/// rather than thrown away because `static_response` needs the same metadata
-/// for
-/// the ETag and the content length, and asking the kernel twice for an answer
-/// this walk already has is one syscall per request for nothing.
-pub(crate) async fn static_file_meta(
-    root: &Path,
-    path: &str,
-) -> Option<(PathBuf, std::fs::Metadata)> {
+/// The relative paths a URL may resolve to, in the order to try them, or `None`
+/// for a URL the server refuses to resolve at all.
+///
+/// One list for both stores. They spelled these rules out separately until the
+/// trailing slash proved why that does not hold: the disk side normalizes
+/// `foo//index.html` through `PathBuf::join` and the embedded side matched no
+/// key, so the same URL answered differently depending on which store happened
+/// to hold the file. A rule written twice is a rule that drifts, and the drift
+/// is invisible until someone requests the one URL that separates them.
+///
+/// Refusing rather than sanitizing: `..` and a leading `.` on any segment have
+/// no reading this server wants to serve, and a resolver that quietly rewrites
+/// a path into a legal one is a resolver nobody can predict from the URL.
+///
+/// A backslash is refused with them, because on Windows it is a directory
+/// separator and here it is not: `http` accepts `\` as an ordinary path byte,
+/// so `/x\..\..\Cargo.toml` arrives as one segment that is neither `..` nor
+/// dot-prefixed, and `Path::join` then walks it straight out of the web root.
+/// The released Windows executable is what makes that reachable. No vendored
+/// filename contains one, so refusing costs nothing.
+fn static_candidates(path: &str) -> Option<Vec<String>> {
     let clean = path.trim_start_matches('/');
     if clean.split('/').any(is_refused_segment) {
         return None;
     }
-    if !clean.is_empty() && Path::new(clean).extension().is_some() {
-        let path = root.join(clean);
-        return Some((path.clone(), file_metadata(&path).await?));
-    }
-    let candidates = if clean.is_empty() {
-        vec![root.join("index.html")]
-    } else {
-        vec![
-            root.join(clean),
-            root.join(clean).join("index.html"),
-            root.join(format!("{clean}.html")),
-            root.join("index.html"),
-        ]
-    };
 
-    // Sequential rather than joined: the first candidate answers almost every
-    // request, and probing four paths in parallel to save a hit that rarely
-    // happens costs three wasted stats on the one that usually does.
-    for path in candidates {
-        if let Some(metadata) = file_metadata(&path).await {
-            return Some((path, metadata));
-        }
+    // `PathBuf::join` collapses repeated separators for the disk tree. Do it
+    // before looking in the embedded key set as well, or `/vendor//avatar/...`
+    // serves only when a checkout happens to be present.
+    let clean = clean
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("/");
+    if clean.is_empty() {
+        return Some(vec!["index.html".to_string()]);
     }
-    None
+
+    // An extension means the client asked for a specific file, so a miss is a
+    // 404 rather than the single-page fallback below. Answering a missing `.js`
+    // with `index.html` hands the browser HTML where it expects a script, and
+    // the error it reports is a syntax error in a file that parsed fine.
+    if Path::new(&clean).extension().is_some() {
+        return Some(vec![clean]);
+    }
+
+    Some(vec![
+        clean.clone(),
+        format!("{clean}/index.html"),
+        format!("{clean}.html"),
+        "index.html".to_string(),
+    ])
 }
 
 /// `Path::is_file` is a blocking `stat`, and a route with no extension probes
@@ -159,13 +214,29 @@ pub(crate) async fn web_static_handler(
     OriginalUri(uri): OriginalUri,
     headers: header::HeaderMap,
 ) -> Response {
-    static_response(
-        &state.config.web_dir,
-        uri.path(),
-        headers.get(header::IF_NONE_MATCH),
-        method == Method::HEAD,
-    )
-    .await
+    let if_none_match = headers.get(header::IF_NONE_MATCH);
+    let head_only = method == Method::HEAD;
+
+    // Per file rather than per tree. Asking `web_dir.is_dir()` here was the
+    // all-or-nothing form, and it is true for anyone running the binary from a
+    // directory that merely happens to contain a `web/`, so a half-populated
+    // tree answered 404 for assets the executable was carrying.
+    //
+    // The question is still asked once, at startup, because the alternative is
+    // a `tokio::fs::metadata` hop to the blocking pool on every request that a
+    // released install is guaranteed to lose: it has no `web/`, so the disk
+    // store never answers and the probe is pure waste. Once at startup keeps
+    // the per-file fallback wherever the directory does exist. The cost is that
+    // creating `web/` under a running server needs a restart to take, which is
+    // the more predictable behavior anyway.
+    let from_disk = if state.web_dir_exists {
+        static_response(&state.config.web_dir, uri.path(), if_none_match, head_only).await
+    } else {
+        None
+    };
+    from_disk
+        .or_else(|| embedded_static_response(uri.path(), if_none_match, head_only))
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response())
 }
 
 pub(crate) async fn runtime_config_handler(State(state): State<AppState>) -> Response {
@@ -229,88 +300,160 @@ pub(crate) fn file_etag(metadata: &std::fs::Metadata) -> Option<HeaderValue> {
     HeaderValue::from_str(&format!("W/\"{}-{}\"", modified.as_nanos(), metadata.len())).ok()
 }
 
+/// Everything about an asset response that does not depend on which store the
+/// bytes came from: the caching policy, the validator, and the content type.
+///
+/// Built once from the relative key both stores resolve to. Before this the
+/// disk and embedded paths each spelled out the whole contract, and they had
+/// already drifted: the vendor rule was a component-wise `Path::starts_with`
+/// on one side and a string prefix on the other, and only one of the two set
+/// `Content-Length` on a body response. `static_candidates` exists because a
+/// rule written twice drifts; this is the other half of that argument.
+struct AssetHeaders {
+    cache_control: HeaderValue,
+    content_type: Option<HeaderValue>,
+    etag: Option<HeaderValue>,
+    length: u64,
+}
+
+impl AssetHeaders {
+    /// `key` is relative to the tree root, so the vendor test is anchored
+    /// there by construction. Matching anywhere in an absolute path would let
+    /// an operator-supplied `CODETRIAL_WEB_DIR` that happens to contain the
+    /// word cache the whole tree.
+    fn new(key: &str, etag: Option<HeaderValue>, length: u64) -> Self {
+        Self {
+            cache_control: if key.starts_with("vendor/") {
+                VENDOR_CACHE_CONTROL
+            } else {
+                STATIC_CACHE_CONTROL
+            },
+            content_type: content_type(Path::new(key)),
+            etag,
+            length,
+        }
+    }
+
+    /// A 304 when the client already holds this exact copy.
+    ///
+    /// Decided before the body is fetched, and before the HEAD branch: a
+    /// conditional HEAD is a revalidation like any other, and answering it 200
+    /// tells the browser its cached copy was replaced when nothing changed.
+    ///
+    /// A 304 replaces the stored headers, so it has to repeat both the
+    /// validator and the `Vary` the 200 would have sent. Without the validator
+    /// a cache cannot tell which version it just confirmed, and without `Vary`
+    /// a shared cache forgets the stored body is one specific encoding and can
+    /// hand gzip to a client that never asked for it. Repeating
+    /// `cache_control` matters for the same reason: answering a vendor
+    /// revalidation with `no-cache` would undo the day the browser was given.
+    fn not_modified(&self, if_none_match: Option<&HeaderValue>) -> Option<Response> {
+        let etag = self.etag.as_ref()?;
+        (Some(etag) == if_none_match).then(|| {
+            (
+                StatusCode::NOT_MODIFIED,
+                [
+                    (header::CACHE_CONTROL, self.cache_control.clone()),
+                    (header::ETAG, etag.clone()),
+                    (header::VARY, HeaderValue::from_static("accept-encoding")),
+                ],
+            )
+                .into_response()
+        })
+    }
+
+    /// `None` is a HEAD, answered from the recorded length and never from the
+    /// body. Axum routes HEAD to the same handler, so the avatar's "is a model
+    /// published" probe would otherwise read a 15 MB file into memory once per
+    /// session and throw it away.
+    fn respond(self, body: Option<Body>) -> Response {
+        let mut response = match body {
+            Some(body) => body.into_response(),
+            None => StatusCode::OK.into_response(),
+        };
+        let headers = response.headers_mut();
+        if let Some(content_type) = self.content_type {
+            headers.insert(header::CONTENT_TYPE, content_type);
+        }
+        headers.insert(header::CACHE_CONTROL, self.cache_control);
+        if let Ok(length) = HeaderValue::from_str(&self.length.to_string()) {
+            headers.insert(header::CONTENT_LENGTH, length);
+        }
+        if let Some(etag) = self.etag {
+            headers.insert(header::ETAG, etag);
+        }
+        response
+    }
+}
+
+/// `None` where the disk tree cannot answer, which is what lets the caller
+/// fall through to the embedded store by composition rather than by reading a
+/// status code back off a response it just built.
 pub(crate) async fn static_response(
     root: &Path,
     path: &str,
     if_none_match: Option<&HeaderValue>,
     head_only: bool,
-) -> Response {
-    let Some((path, metadata)) = static_file_meta(root, path).await else {
-        return StatusCode::NOT_FOUND.into_response();
-    };
-
-    // Anchored at the web root rather than matched anywhere in the string, so
-    // an operator-supplied `CODETRIAL_WEB_DIR` that happens to contain the word
-    // cannot cache the whole tree. Decided before the 304 branch because a 304
-    // replaces the stored headers: answering a revalidation with `no-cache`
-    // would downgrade the copy the browser already holds and undo the day.
-    let cache_control = if path
-        .strip_prefix(root)
-        .is_ok_and(|relative| relative.starts_with("vendor"))
-    {
-        VENDOR_CACHE_CONTROL
-    } else {
-        STATIC_CACHE_CONTROL
-    };
-    let etag = file_etag(&metadata);
-
-    if let Some(etag) = &etag
-        && Some(etag) == if_none_match
-    {
-        // A 304 has to repeat the validator and the `Vary` the 200 would have
-        // sent. Without the validator a cache cannot tell which version it just
-        // confirmed, and without `Vary` a shared cache forgets that the stored
-        // body is one specific encoding and can hand gzip to a client that
-        // never asked for it.
-        //
-        // Ahead of the HEAD branch, not after it: a conditional HEAD is a
-        // revalidation like any other, and answering it 200 tells the browser
-        // its cached copy was replaced when nothing changed.
-        return (
-            StatusCode::NOT_MODIFIED,
-            [
-                (header::CACHE_CONTROL, cache_control),
-                (header::ETAG, etag.clone()),
-                (header::VARY, HeaderValue::from_static("accept-encoding")),
-            ],
-        )
-            .into_response();
+) -> Option<Response> {
+    let (key, path, metadata) = static_file_meta(root, path).await?;
+    let headers = AssetHeaders::new(&key, file_etag(&metadata), metadata.len());
+    if let Some(not_modified) = headers.not_modified(if_none_match) {
+        return Some(not_modified);
     }
-
-    // Answered from metadata, never from the body. Axum routes HEAD to the same
-    // handler, so the avatar's "is a model published" probe would otherwise
-    // read a 15 MB file into memory once per session and throw it away.
     if head_only {
-        let mut response = StatusCode::OK.into_response();
-        let response_headers = response.headers_mut();
-        if let Some(content_type) = content_type(&path) {
-            response_headers.insert(header::CONTENT_TYPE, content_type);
-        }
-        response_headers.insert(header::CACHE_CONTROL, cache_control);
-        if let Ok(length) = HeaderValue::from_str(&metadata.len().to_string()) {
-            response_headers.insert(header::CONTENT_LENGTH, length);
-        }
-        if let Some(etag) = etag {
-            response_headers.insert(header::ETAG, etag);
-        }
-        return response;
+        return Some(headers.respond(None));
     }
+    // The file can still go away between the stat above and this read.
+    let bytes = tokio::fs::read(&path).await.ok()?;
+    Some(headers.respond(Some(Body::from(bytes))))
+}
 
-    match tokio::fs::read(&path).await {
-        Ok(bytes) => {
-            let mut response = Body::from(bytes).into_response();
-            let headers = response.headers_mut();
-            if let Some(content_type) = content_type(&path) {
-                headers.insert(header::CONTENT_TYPE, content_type);
-            }
-            headers.insert(header::CACHE_CONTROL, cache_control);
-            if let Some(etag) = etag {
-                headers.insert(header::ETAG, etag);
-            }
-            response
-        }
-        Err(_) => StatusCode::NOT_FOUND.into_response(),
+/// The same rules against the web tree compiled into the executable.
+///
+/// The shipped binary has no `web/` at all, so this is the only path a
+/// released install takes. That is why it carries the disk path's caching
+/// rather than a simpler set: answering 37 MB of pinned wasm with a bare
+/// `no-cache` and no validator would re-send the tree on every navigation.
+fn embedded_static_response(
+    path: &str,
+    if_none_match: Option<&HeaderValue>,
+    head_only: bool,
+) -> Option<Response> {
+    let (key, file) = static_candidates(path)?
+        .into_iter()
+        .find_map(|candidate| EmbeddedWeb::get(&candidate).map(|file| (candidate, file)))?;
+
+    // Strong, unlike the disk path's modification-time heuristic: these bytes
+    // cannot change without a rebuild, and `rust-embed` already carries their
+    // SHA-256, so nothing is hashed per request.
+    let headers = AssetHeaders::new(&key, Some(embedded_etag(&file)), file.data.len() as u64);
+    if let Some(not_modified) = headers.not_modified(if_none_match) {
+        return Some(not_modified);
     }
+    if head_only {
+        return Some(headers.respond(None));
+    }
+    Some(headers.respond(Some(Body::from(file.data))))
+}
+
+/// Sixteen bytes of the digest rather than all thirty-two: this is a cache
+/// validator, not a signature, and a collision costs one stale asset that a
+/// rebuild fixes.
+///
+/// Formatted as one big-endian integer rather than byte by byte. A hand-rolled
+/// loop over shifts and masks says the same thing in more places that can be
+/// wrong, and it hands the mutation gate four operators to flip where this
+/// leaves none.
+///
+/// Infallible, so callers do not branch on a None that cannot happen: hex
+/// digits between quotes are always a valid header value.
+fn embedded_etag(file: &rust_embed::EmbeddedFile) -> HeaderValue {
+    let digest = u128::from_be_bytes(
+        file.metadata.sha256_hash()[..16]
+            .try_into()
+            .expect("16 bytes"),
+    );
+    HeaderValue::from_str(&format!("\"{digest:032x}\"")).expect("hex is a valid header value")
 }
 
 pub(crate) fn content_type(path: &Path) -> Option<HeaderValue> {
@@ -342,7 +485,33 @@ pub(crate) fn content_type(path: &Path) -> Option<HeaderValue> {
 
 #[cfg(test)]
 mod tests {
-    use super::is_refused_segment;
+    use super::{EmbeddedWeb, embedded_etag, is_refused_segment, static_candidates};
+
+    /// Normalization is tested here rather than through a served request
+    /// because a served request cannot see it. `EmbeddedWeb::get` matches keys
+    /// exactly only in release; a debug or test build reads the same names off
+    /// the filesystem, where the kernel collapses repeated separators before
+    /// the lookup ever happens. So the one store whose behavior depends on this
+    /// function is the one store no test binary runs.
+    ///
+    /// Testing the rule instead of the store sidesteps that: this is a pure
+    /// function of the URL, and it is wrong or right identically in both.
+    #[test]
+    fn repeated_separators_collapse_to_one_key() {
+        let direct = static_candidates("/vendor/avatar/three-vrm.js").unwrap();
+        for spelling in [
+            "/vendor//avatar/three-vrm.js",
+            "//vendor/avatar/three-vrm.js",
+            "/vendor///avatar//three-vrm.js",
+            "/vendor/avatar/three-vrm.js/",
+        ] {
+            assert_eq!(
+                static_candidates(spelling).unwrap(),
+                direct,
+                "{spelling} should resolve to the same key as the plain spelling"
+            );
+        }
+    }
 
     /// Asserts the refusal itself rather than a served request, because a
     /// served request cannot distinguish the two on this platform: a backslash
@@ -374,5 +543,101 @@ mod tests {
         ] {
             assert!(!is_refused_segment(allowed), "{allowed} should resolve");
         }
+    }
+
+    /// The empty-segment filter runs after the refusal, never before, so a
+    /// separator cannot be used to smuggle a segment past it. Collapsing first
+    /// would be the bug: nothing here may become legal by being rewritten.
+    ///
+    /// Sole owner of the backslash case, and it has to be. That byte is a
+    /// directory separator to Windows and an ordinary filename character to
+    /// every runner that could serve a request against it, so a served-request
+    /// check 404s on Linux either way and proves nothing. Asserting the refusal
+    /// directly is what makes the Windows artifact the diff added safe.
+    #[test]
+    fn normalization_cannot_launder_a_refused_path() {
+        for path in [
+            "/../Cargo.toml",
+            "/a//../../Cargo.toml",
+            "/..//..//Cargo.toml",
+            "//../Cargo.toml",
+            "/./Cargo.toml",
+            "/.git/config",
+            "/vendor//.hidden",
+            // A backslash is an ordinary path byte to `http` and a directory
+            // separator to Windows, so a segment carrying one is neither `..`
+            // nor dot-prefixed here and still walks out of the web root there.
+            // Unreachable until the release shipped a Windows executable, and
+            // untestable from a Unix runner, which is why it is asserted on the
+            // rule rather than on a served request.
+            "/x\\..\\..\\Cargo.toml",
+            "/\\..\\Cargo.toml",
+            "/vendor\\..\\..\\Cargo.toml",
+            // Drive-qualified, so `PathBuf::push` discards the web root it was
+            // joined onto and reads from the volume instead. Neither `..` nor
+            // dot-prefixed, and it never had a backslash in it.
+            "/C:/Windows/win.ini",
+            "/c:/Windows/win.ini",
+            "/vendor/C:/Windows/win.ini",
+            // An NTFS alternate data stream on a file that does exist.
+            "/index.html:$DATA",
+        ] {
+            assert!(
+                static_candidates(path).is_none(),
+                "{path} should be refused outright, not resolved"
+            );
+        }
+    }
+
+    /// An extension means the client asked for one file, so a miss is a 404.
+    /// The single-page fallback would answer a missing `.js` with HTML, and the
+    /// browser reports that as a syntax error in a file that parsed fine.
+    #[test]
+    fn an_extension_suppresses_the_index_fallback() {
+        assert_eq!(
+            static_candidates("/missing.js").unwrap(),
+            vec!["missing.js".to_string()]
+        );
+        assert!(
+            static_candidates("/missing")
+                .unwrap()
+                .contains(&"index.html".to_string())
+        );
+    }
+
+    /// The validator has to be the digest of the bytes actually served, not
+    /// merely stable across two requests. A round trip through If-None-Match
+    /// compares the server against itself and passes on any value it likes,
+    /// so this compares it against the file instead.
+    #[test]
+    fn the_etag_is_the_leading_half_of_the_file_digest() {
+        use sha2::{Digest, Sha256};
+
+        let file = EmbeddedWeb::get("index.html").expect("the index is embedded");
+        let mut expected = String::from('"');
+        for byte in &Sha256::digest(&file.data)[..16] {
+            expected.push_str(&format!("{byte:02x}"));
+        }
+        expected.push('"');
+        assert_eq!(embedded_etag(&file), expected.as_str());
+    }
+
+    /// The root and a bare directory both end at the index, by different
+    /// routes: one has no candidates to try, the other exhausts its own first.
+    #[test]
+    fn a_bare_route_falls_back_to_the_index() {
+        assert_eq!(
+            static_candidates("/").unwrap(),
+            vec!["index.html".to_string()]
+        );
+        assert_eq!(
+            static_candidates("/interview").unwrap(),
+            vec![
+                "interview".to_string(),
+                "interview/index.html".to_string(),
+                "interview.html".to_string(),
+                "index.html".to_string(),
+            ]
+        );
     }
 }

--- a/src/web/assets.rs
+++ b/src/web/assets.rs
@@ -73,6 +73,37 @@ pub async fn static_file(root: &Path, path: &str) -> Option<PathBuf> {
     static_file_meta(root, path).await.map(|(path, _)| path)
 }
 
+/// Whether a single path segment is one this server refuses to resolve.
+///
+/// An allowlist. Enumerating the spellings that escape is open ended, because
+/// the escapes are whatever URL syntax permits, and the two that matter here
+/// are neither `..` nor dot-prefixed: a backslash is a directory separator to
+/// Windows and an ordinary path byte to the URI parser, and a colon makes a
+/// segment drive-qualified, which `PathBuf::push` honors by discarding the
+/// root it was joined onto. `/x\..\..\Cargo.toml` and `/C:/Windows/win.ini`
+/// both walk out of the web root there.
+///
+/// Enumerating what the asset tree contains is not open ended. Every one of
+/// the 367 names under `web/` is alphanumerics with a dot, underscore, or
+/// dash, so the rule is that a segment must be an ordinary filename on every
+/// platform this can be built for, and the allowlist costs no asset. It also
+/// refuses the trailing dot and trailing space that Win32 strips, which would
+/// otherwise name one file to the resolver and a different one to the disk.
+///
+/// Latent on the deployments that exist today, which are all Unix, where a
+/// backslash is an ordinary filename character. It stops being latent the
+/// moment a Windows build ships.
+///
+/// A leading dot covers `..` on its own, so there is no separate clause for
+/// it. An empty segment is permitted because it cannot name anything.
+fn is_refused_segment(part: &str) -> bool {
+    part.starts_with('.')
+        || part.ends_with('.')
+        || !part
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
 /// The resolved path together with the `stat` that resolved it. Handed back
 /// rather than thrown away because `static_response` needs the same metadata
 /// for
@@ -83,10 +114,7 @@ pub(crate) async fn static_file_meta(
     path: &str,
 ) -> Option<(PathBuf, std::fs::Metadata)> {
     let clean = path.trim_start_matches('/');
-    if clean
-        .split('/')
-        .any(|part| part == ".." || part.starts_with('.'))
-    {
+    if clean.split('/').any(is_refused_segment) {
         return None;
     }
     if !clean.is_empty() && Path::new(clean).extension().is_some() {
@@ -310,4 +338,41 @@ pub(crate) fn content_type(path: &Path) -> Option<HeaderValue> {
         _ => return None,
     };
     Some(HeaderValue::from_static(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_refused_segment;
+
+    /// Asserts the refusal itself rather than a served request, because a
+    /// served request cannot distinguish the two on this platform: a backslash
+    /// and a colon are ordinary filename bytes to Unix, so every one of these
+    /// answers 404 for want of a file whether or not the resolver refused it.
+    /// The refusal is what a Windows build would depend on.
+    #[test]
+    fn a_segment_must_be_an_ordinary_filename() {
+        for refused in [
+            "..",
+            ".git",
+            ".env.local",
+            "x\\..\\..\\Cargo.toml",
+            "\\..\\Cargo.toml",
+            "C:",
+            "index.html:$DATA",
+            "index.html.",
+            "with space",
+        ] {
+            assert!(is_refused_segment(refused), "{refused} should be refused");
+        }
+
+        for allowed in [
+            "",
+            "index.html",
+            "three-vrm.js",
+            "face_detection.js",
+            "jim.vrm",
+        ] {
+            assert!(!is_refused_segment(allowed), "{allowed} should resolve");
+        }
+    }
 }

--- a/src/web/assets.rs
+++ b/src/web/assets.rs
@@ -130,9 +130,10 @@ pub async fn static_file_meta(
 /// refuses the trailing dot and trailing space that Win32 strips, which would
 /// otherwise name one file to the resolver and a different one to the disk.
 ///
-/// Latent on the deployments that exist today, which are all Unix, where a
-/// backslash is an ordinary filename character. It stops being latent the
-/// moment a Windows build ships.
+/// Load-bearing rather than theoretical since the release job below started
+/// publishing a Windows binary. On Unix a backslash is an ordinary filename
+/// character and these answer 404 for want of a file; on Windows they would
+/// resolve.
 ///
 /// A leading dot covers `..` on its own, so there is no separate clause for
 /// it. An empty segment is permitted because it cannot name anything.

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -35,7 +35,7 @@ pub(crate) use {
 // The whole of this module's public surface, named rather than left to fall out
 // of whichever items happen to carry `pub`. A glob would re-export a future
 // `pub fn` here silently; this way adding one is a deliberate line.
-pub use assets::static_file;
+pub use assets::static_file_meta;
 pub use auth::login_config;
 use pool::{ProviderQuota, QuotaRefresher, spawn_provider_quota_refresher};
 pub use token::{TOKEN_RATE_LIMIT, TokenConfig, TokenResponse, token_response};
@@ -158,6 +158,11 @@ impl fmt::Debug for WebServerConfig {
 #[derive(Clone)]
 pub(crate) struct AppState {
     config: Arc<WebServerConfig>,
+    /// Resolved once here rather than per request. `config.web_dir` is a
+    /// relative default, so the shipped binary usually has no such directory
+    /// and every asset would otherwise pay a blocking-pool `stat` that cannot
+    /// succeed before the embedded store is consulted.
+    web_dir_exists: bool,
     /// `None` when this server has no cookie secret and no database, and also
     /// when it has both but the database would not open. Those are different
     /// problems, so `accounts_required` separates them.
@@ -354,6 +359,7 @@ pub(crate) fn web_router(
             )
         })
         .with_state(AppState {
+            web_dir_exists: config.web_dir.is_dir(),
             config: Arc::new(config),
             accounts,
             accounts_required,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicUsize;
@@ -51,7 +52,7 @@ pub const MAX_REPORT_BYTES: usize = 64 * 1024;
 /// retried forever rather than applied.
 pub const MAX_WEBHOOK_BODY_BYTES: usize = 64 * 1024;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct WebServerConfig {
     pub web_dir: PathBuf,
     pub github_client_id: Option<String>,
@@ -89,6 +90,67 @@ pub struct WebServerConfig {
     /// asked for. The binaries set it; a test sets it only when the refresher
     /// is what it is testing, and points it at a stub.
     pub probe_provider_quota: bool,
+}
+
+/// Redacting by hand, because the derive printed `session_secret` and
+/// `github_client_secret` in full. `Provider` and `RecordingConfig` already
+/// redact for exactly this reason, and their comments name this struct as the
+/// thing whose `Debug` they are defending against: the two fields it holds
+/// itself were the ones nobody checked.
+///
+/// `session_secret` is the sharper of the two. It signs the session cookie, so
+/// a copy in a log is not a credential to steal but the ability to mint any
+/// user's session.
+///
+/// Destructured rather than read through `self`, and written as a full field
+/// list rather than a `finish_non_exhaustive`. A `debug_struct` call chain
+/// compiles happily whatever it omits, so a field added later would silently
+/// stop being printed; the binding below fails to compile until someone decides
+/// in this function whether the new field is a secret.
+impl fmt::Debug for WebServerConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            web_dir,
+            github_client_id,
+            github_client_secret,
+            session_secret,
+            db_path,
+            github_oauth_base_url,
+            github_api_base_url,
+            room_prefix,
+            fixed_room_name,
+            production,
+            compiler_explorer_enabled,
+            trusted_proxy_hops,
+            recording,
+            pool,
+            probe_provider_quota,
+        } = self;
+        formatter
+            .debug_struct("WebServerConfig")
+            .field("web_dir", web_dir)
+            .field("github_client_id", github_client_id)
+            .field(
+                "github_client_secret",
+                &github_client_secret.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "session_secret",
+                &session_secret.as_ref().map(|_| "<redacted>"),
+            )
+            .field("db_path", db_path)
+            .field("github_oauth_base_url", github_oauth_base_url)
+            .field("github_api_base_url", github_api_base_url)
+            .field("room_prefix", room_prefix)
+            .field("fixed_room_name", fixed_room_name)
+            .field("production", production)
+            .field("compiler_explorer_enabled", compiler_explorer_enabled)
+            .field("trusted_proxy_hops", trusted_proxy_hops)
+            .field("recording", recording)
+            .field("pool", pool)
+            .field("probe_provider_quota", probe_provider_quota)
+            .finish()
+    }
 }
 
 /// Cloned per request by axum, so the config sits behind an `Arc`: otherwise

--- a/src/web/token.rs
+++ b/src/web/token.rs
@@ -27,14 +27,21 @@ use super::{
     unauthorized_response,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// No `Debug`, for the reason [`crate::config::AgentConfig`] has none: one
+/// field is a credential, and a type that can print it will eventually be
+/// printed. Nothing needs to format this, so the derive is the whole risk.
+#[derive(Clone, PartialEq, Eq)]
 pub struct TokenConfig<'a> {
     pub api_key: &'a str,
     pub api_secret: &'a str,
     pub server_url: &'a str,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Same reason, and the sharpest case of it: `token` is a minted LiveKit
+/// credential a holder can join a room with, not a key that merely mints them.
+/// It is the shortest-lived secret here and the easiest to print by accident,
+/// because it looks like a response body rather than a key.
+#[derive(Clone, PartialEq, Eq)]
 pub struct TokenResponse {
     pub token: String,
     pub server_url: String,

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -23,7 +23,7 @@ use codetrial::token::{
 };
 use codetrial::web::{
     MAX_BODY_BYTES, MAX_REPORT_BYTES, RoomDispatcher, TOKEN_RATE_LIMIT, TokenConfig,
-    WebServerConfig, initialize_account_database, login_config, static_file, token_response,
+    WebServerConfig, initialize_account_database, login_config, static_file_meta, token_response,
 };
 
 type HmacSha256 = Hmac<Sha256>;
@@ -393,15 +393,21 @@ async fn production_policy_names_no_loopback_origins() {
     server.abort();
 }
 
+/// The resolved path alone. The resolver hands back the matched key and the
+/// metadata beside it, and these tests care about neither.
+async fn resolved(root: &Path, path: &str) -> Option<std::path::PathBuf> {
+    static_file_meta(root, path).await.map(|(_, path, _)| path)
+}
+
 #[tokio::test]
 async fn static_file_rejects_traversal_and_dotfiles() {
     assert!(
-        static_file(Path::new("src/web"), "/../agent/.env")
+        resolved(Path::new("src/web"), "/../agent/.env")
             .await
             .is_none()
     );
     assert!(
-        static_file(Path::new("src/web"), "/.env.local")
+        resolved(Path::new("src/web"), "/.env.local")
             .await
             .is_none()
     );
@@ -414,17 +420,143 @@ async fn static_file_falls_back_to_index_for_web_routes() {
     fs::write(root.join("index.html"), "").unwrap();
 
     assert_eq!(
-        static_file(&root, "/interview").await,
+        resolved(&root, "/interview").await,
         Some(root.join("index.html"))
     );
 
     fs::remove_dir_all(root).unwrap();
 }
 
+/// A path no directory occupies, so the handler has nothing on disk to find.
+fn absent_web_dir(label: &str) -> std::path::PathBuf {
+    unique_temp_path(label, "")
+}
+
+/// Process id and nanoseconds, so two tests in one binary and two binaries in
+/// one suite cannot collide on it.
+fn unique_temp_path(label: &str, suffix: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "codetrial-{label}-{}-{}{suffix}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+/// The shipped binary has no `web/` beside it, so every asset a released
+/// install serves takes this path. A 200 on `/` only proves resolution; what
+/// the assertions below are for is the caching, which is the whole reason the
+/// disk path grew a validator and a separate vendor policy. Serving 37 MB of
+/// pinned wasm as `no-cache` with nothing to revalidate against would re-send
+/// the tree on every navigation, and no status code would say so.
+#[tokio::test]
+async fn embedded_web_assets_serve_without_a_web_directory() {
+    let mut config = web_config();
+    config.web_dir = absent_web_dir("no-web");
+    let (base, server) = spawn_web_server(config).await;
+
+    let response = reqwest::get(&base).await.unwrap();
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "text/html; charset=utf-8"
+    );
+
+    // `no-cache` revalidates, which is only affordable because the ETag below
+    // turns the revalidation into a 304 rather than a resend.
+    assert_eq!(response.headers().get("cache-control").unwrap(), "no-cache");
+    assert!(response.headers().get("etag").is_some());
+    assert!(response.text().await.unwrap().contains("CodeTrial"));
+
+    // Committed rather than fetched by `scripts/fetch-vendor.sh`, so the
+    // assertion does not depend on whether the fetch has run here.
+    let vendor = format!("{base}/vendor/avatar/three-vrm.js");
+    let response = reqwest::get(&vendor).await.unwrap();
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response.headers().get("cache-control").unwrap(),
+        "public, max-age=86400"
+    );
+    let etag = response.headers().get("etag").unwrap().clone();
+
+    let client = reqwest::Client::new();
+    let revalidated = client
+        .get(&vendor)
+        .header("if-none-match", etag.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(revalidated.status(), 304);
+
+    // A 304 replaces the stored headers, so dropping either of these downgrades
+    // the copy the browser already holds.
+    assert_eq!(
+        revalidated.headers().get("cache-control").unwrap(),
+        "public, max-age=86400"
+    );
+    assert_eq!(revalidated.headers().get("etag").unwrap(), &etag);
+
+    // Answered from the embedded length, never by reading out a body.
+    let head = client.head(&vendor).send().await.unwrap();
+    assert_eq!(head.status(), 200);
+    assert!(head.headers().get("content-length").is_some());
+    assert!(head.bytes().await.unwrap().is_empty());
+
+    for route in ["/interview", "/interview/"] {
+        let response = reqwest::get(&format!("{base}{route}")).await.unwrap();
+        assert_eq!(response.status(), 200, "{route}");
+        assert!(response.text().await.unwrap().contains("CodeTrial"));
+    }
+
+    // No separator or traversal spellings here. `url` collapses `..` before the
+    // request leaves the client, and a debug build resolves the embed through
+    // the filesystem, where the kernel collapses repeated separators whatever
+    // the resolver does. Both would pass with the rules deleted.
+    // `normalization_cannot_launder_a_refused_path` owns those cases against
+    // the rule itself, and the release smoke step owns them against a binary
+    // that really does match keys exactly.
+    let response = reqwest::get(&format!("{base}/.git/config")).await.unwrap();
+    assert_ne!(response.status(), 200);
+
+    server.abort();
+}
+
+/// The fallback is per file, not per tree. Gating it on whether the web root
+/// exists at all meant that anyone running the binary from a directory that
+/// merely happens to contain a `web/` got a 404 for assets the executable was
+/// carrying, which is the common shape: a checkout where `fetch-vendor.sh`
+/// never ran.
+#[tokio::test]
+async fn embedded_assets_fill_gaps_in_a_partial_web_directory() {
+    let root = absent_web_dir("partial-web");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("index.html"), "<!doctype html>disk wins").unwrap();
+
+    let mut config = web_config();
+    config.web_dir = root.clone();
+    let (base, server) = spawn_web_server(config).await;
+
+    // Present on disk, so disk answers even though the embed also has it.
+    let response = reqwest::get(&base).await.unwrap();
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.text().await.unwrap(), "<!doctype html>disk wins");
+
+    // Absent from this tree, so the embedded copy fills the gap.
+    let response = reqwest::get(&format!("{base}/vendor/avatar/three-vrm.js"))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+
+    server.abort();
+    fs::remove_dir_all(root).unwrap();
+}
+
 /// A 200 here proves the file resolved, so there is no separate resolve-only
 /// test restating the same names. These two headers are what decide whether the
 /// detector loads at all and how long a stale copy survives an upgrade, and
-/// neither is visible from `static_file`.
+/// neither is visible from the resolver.
 #[tokio::test]
 async fn vendored_assets_are_served_typed_and_cached() {
     let mut config = web_config();
@@ -3044,14 +3176,7 @@ fn remove_database(path: impl AsRef<std::path::Path>) {
 }
 
 fn account_db_path(label: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(format!(
-        "codetrial-{label}-{}-{}.db",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ))
+    unique_temp_path(label, ".db")
 }
 
 /// A server with accounts enabled and nobody signed in yet, which is where
@@ -5927,4 +6052,64 @@ fn web_server_config_debug_redacts_its_own_secrets() {
         printed.contains("public-client-id"),
         "the client id is public and should stay readable: {printed}"
     );
+}
+
+/// The two stores must answer the same URL the same way.
+///
+/// What this catches is a re-split: both stores now resolve through one
+/// candidate list, and if somebody gives either of them its own rules again,
+/// this fails. Verified by doing exactly that, not assumed.
+///
+/// What it cannot catch is a wrong rule, because a shared mistake stays
+/// symmetric and parity still holds. Behavior of the rules themselves belongs
+/// in the per-store tests above; this one owns the contract between them.
+///
+/// Status, content type, and cache policy only. ETags are deliberately
+/// different: the disk side is a modification-time heuristic and the embedded
+/// side is a digest of bytes that cannot change without a rebuild.
+#[tokio::test]
+async fn disk_and_embedded_stores_resolve_urls_identically() {
+    let mut disk = web_config();
+    disk.web_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("web");
+    let (disk_base, disk_server) = spawn_web_server(disk).await;
+
+    let mut embedded = web_config();
+    embedded.web_dir = absent_web_dir("resolver-parity");
+    let (embedded_base, embedded_server) = spawn_web_server(embedded).await;
+
+    for route in [
+        "/",
+        "/interview",
+        "/interview/",
+        "/index.html",
+        "/vendor/avatar/three-vrm.js",
+        "/vendor/avatar/three-vrm.js/",
+        "/missing.js",
+        "/missing/deeper.css",
+        "/.git/config",
+        "/vendor/.hidden",
+    ] {
+        let from_disk = reqwest::get(&format!("{disk_base}{route}")).await.unwrap();
+        let from_embed = reqwest::get(&format!("{embedded_base}{route}"))
+            .await
+            .unwrap();
+        assert_eq!(
+            from_disk.status(),
+            from_embed.status(),
+            "status differs for {route}"
+        );
+        assert_eq!(
+            from_disk.headers().get("content-type"),
+            from_embed.headers().get("content-type"),
+            "content type differs for {route}"
+        );
+        assert_eq!(
+            from_disk.headers().get("cache-control"),
+            from_embed.headers().get("cache-control"),
+            "cache policy differs for {route}"
+        );
+    }
+
+    disk_server.abort();
+    embedded_server.abort();
 }

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -1989,8 +1989,11 @@ fn account_recording_config_does_not_require_github_oauth() {
 
     let login = login_config(&config).expect("recording config should enable account sessions");
 
-    assert_eq!(
-        login.oauth, None,
+    // `is_none` rather than `assert_eq!(.., None)`: that form needs `Debug` on
+    // `GitHubOauth`, and the client secret is the reason that type does not
+    // have one.
+    assert!(
+        login.oauth.is_none(),
         "no OAuth app means no credentials, not blank ones"
     );
     assert_eq!(login.session_secret, "session");
@@ -5873,4 +5876,55 @@ async fn every_owner_scoped_route_refuses_an_anonymous_request() {
 
     server.abort();
     remove_database(path);
+}
+
+/// `Provider` and `RecordingConfig` both hand-write a redacting `Debug`, and
+/// both name `WebServerConfig` as the reason: it derives `Debug`, so anything
+/// reachable from it can reach a log line. The two secrets the struct holds
+/// directly were the ones nobody checked, and the derive printed both in full.
+///
+/// `session_secret` is why this is a test rather than a style note. It signs
+/// the session cookie, so a copy on stderr is not a credential to steal but the
+/// ability to mint any user's session.
+#[test]
+fn web_server_config_debug_redacts_its_own_secrets() {
+    let mut config = web_config();
+    config.github_client_id = Some("public-client-id".to_string());
+    config.github_client_secret = Some("CLIENTSECRET-def456".to_string());
+    config.session_secret = Some("SESSIONSECRET-abc123".to_string());
+
+    let printed = format!("{config:?}");
+    for secret in ["CLIENTSECRET-def456", "SESSIONSECRET-abc123"] {
+        assert!(
+            !printed.contains(secret),
+            "Debug output leaked {secret}: {printed}"
+        );
+    }
+    assert!(
+        printed.contains("<redacted>"),
+        "the redaction should be visible rather than silent: {printed}"
+    );
+
+    // The pool redacts one level down, which is what makes the whole struct
+    // safe to print rather than just its top level.
+    assert!(
+        !printed.contains("devsecret"),
+        "the provider secret leaked through the pool: {printed}"
+    );
+
+    // Absent stays absent: `None` must not print as a redacted value, or an
+    // operator reading a log cannot tell a configured secret from a missing
+    // one.
+    let blank = format!("{:?}", web_config());
+    assert!(
+        blank.contains("session_secret: None"),
+        "an unset secret should read as None: {blank}"
+    );
+
+    // The client id is not a secret, and redacting it would cost the one field
+    // that makes an OAuth misconfiguration diagnosable from a log.
+    assert!(
+        printed.contains("public-client-id"),
+        "the client id is public and should stay readable: {printed}"
+    );
 }


### PR DESCRIPTION
A release was a binary that needed a directory beside it, so installing meant placing `web/` and its 37 MB of vendored runtime as well. `rust-embed` compiles the tree into the executable instead, and every push to main publishes one for Linux, macOS, and Windows.

The fallback is per file rather than per tree. Gating it on whether a web root exists at all sounds equivalent and is not: `web_dir` defaults to `web` relative to the working directory, so anyone running the binary from a directory that happens to contain one gets 404s for assets the executable is carrying, and a checkout where `fetch-vendor.sh` never ran is the common shape of that. Disk still wins per file, so editing `web/` stays the local workflow.

Both stores resolve through one candidate list. They started with a copy each and the copies disagreed: the kernel collapses repeated separators for the disk tree whatever the resolver does, so
`/vendor//avatar/three-vrm.js` served from a checkout and 404ed from the binary. A rule written twice is a rule that drifts.

A segment carrying a backslash is refused now. That byte is an ordinary path character to the URI parser and a directory separator to Windows, so such a segment is neither `..` nor dot-prefixed and still walks out of the web root. The Windows artifact added here is what makes it reachable.

Embedded assets carry the disk path's caching rather than a simpler set. The shipped binary has no `web/` at all, so this is the only path a released install takes, and answering the vendored megabytes with a bare `no-cache` and no validator would re-send them on every navigation. `rust-embed` already stores a SHA-256 per file, which is a stronger validator than the modification time the disk path settles for.

Credentials leave `Debug` behind. `WebServerConfig` derived it while holding `session_secret` and `github_client_secret` in plain fields, and printed both in full, though the comments on `Provider` and `RecordingConfig` already name that struct as the reason they redact. The session secret is the sharp one: a copy in a log mints any user's session rather than merely leaking a key.

`build.rs` exists because the derive expands to one `include_bytes!` per file and rustc records those, so edits rebuild while added files do not. Without it, running `fetch-vendor.sh` for the first time and rebuilding ships a binary with no vendored runtime and reports nothing.

The resolver rule is tested directly rather than through a served request. `rust-embed` matches keys exactly only in release and reads the same names off the filesystem in debug, so the store whose behavior depends on normalization is the one store no test binary runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships the browser app inside the release binary via `rust-embed`, so releases are self-contained executables and installing no longer means placing the 37 MB `web/` tree beside the binary. Every push to `main` publishes a rolling `latest` prerelease for Linux, macOS, and Windows; the macOS build is unsigned, and a downloaded copy needs its quarantine attribute cleared before it runs.

**Serving**
- Disk wins per file, and embedded copies fill the gaps, so a checkout that never fetched `web/vendor` still serves it from inside the executable.
- Both stores now resolve paths through one candidate list: repeated `/` separators behave identically from disk and embed, and a backslash in a segment is refused outright to close the Windows traversal it enabled.
- Embedded assets keep the disk cache policy — vendor gets `public, max-age=86400` and everything else `no-cache` — with a SHA-256-derived ETag that answers revalidations with 304s.
- `build.rs` makes Cargo rebuild when files are added or removed from `web/`; without it, the first fetch of vendored assets silently ships a binary that serves a page but cannot start its Python runtime.

**Secrets**
- `Debug` was removed from every struct holding a session, OAuth, or LiveKit secret, and `WebServerConfig` now prints `<redacted>` in their place.
- Logging `session_secret` would let anyone mint arbitrary user sessions, so the redaction is a security fix, not hygiene.

<sup>Written for commit 65c0899d16e7ca1a413931e0a087c2f8ea144b81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/codetrial/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

