### PR TITLE
Fix the vendored-asset checksum check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -94,8 +94,11 @@ jobs:
             "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}"
           df -h /
 
+      # shellcheck rides along on an apt call this job already makes. The runner
+      # image ships it today, but the shell gate skips itself when it is absent,
+      # and a gate that stops running quietly is the thing it guards against.
       - name: Install native build dependency
-        run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev mold
+        run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev mold shellcheck
 
       # The runner image ships a stable toolchain, but not necessarily one new
       # enough for edition 2024, and clippy and rustfmt are gates rather than

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,14 @@
+# Two false positives that every script here would otherwise carry a directive
+# for. Both are about idioms this tree uses deliberately, so they are answered
+# once rather than eleven times.
+
+# `ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)` is how a script finds
+# the repo root without CDPATH making `cd` echo its destination. shellcheck
+# reads the space in `CDPATH= cd` as a typo for `CDPATH=cd`. It is not one:
+# dropping the space would run a command named `cd` with CDPATH set to "cd".
+disable=SC1007
+
+# Scripts source the operator's config file, whose path is a variable by
+# design. There is no literal for shellcheck to follow, and inventing one would
+# make the gate check a file no deployment uses.
+disable=SC1090

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ license are recorded in that notice.
 
 | Phase | Required | Notes |
 |---|---|---|
-| Build time | Rust stable, `curl` or `wget`, and `shasum` | Cargo resolves application crates from `Cargo.lock`. `make build` fetches the checksum-pinned browser assets on the first build. |
+| Build time | Rust stable, `curl` or `wget`, and `sha256sum` or `shasum` | Cargo resolves application crates from `Cargo.lock`. `make build` fetches the checksum-pinned browser assets on the first build. |
 | Test time | Build-time tools, Node.js 18+, and Python 3 | Node runs browser and fixture checks; Python verifies generated problem-bank files. `npm ci` adds ESLint and Playwright for the full local browser gate. |
 | Runtime | The compiled `codetrial` binary and its `web/` assets | No Node.js, Python, or `node_modules` is required. Rust dependencies are compiled into the binary; browser dependencies are vendored and checksum-pinned. |
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ license are recorded in that notice.
 | Phase | Required | Notes |
 |---|---|---|
 | Build time | Rust stable, `curl` or `wget`, and `sha256sum` or `shasum` | Cargo resolves application crates from `Cargo.lock`. `make build` fetches the checksum-pinned browser assets on the first build. |
-| Test time | Build-time tools, Node.js 18+, and Python 3 | Node runs browser and fixture checks; Python verifies generated problem-bank files. `npm ci` adds ESLint and Playwright for the full local browser gate. |
+| Test time | Build-time tools, Node.js 18+, and Python 3 | Node runs browser and fixture checks; Python verifies generated problem-bank files. `npm ci` adds ESLint and Playwright for the full local browser gate. `shellcheck`, `actionlint`, and `cargo-audit` are optional: each gate reports that it skipped rather than failing without them. |
 | Runtime | The compiled `codetrial` binary and its `web/` assets | No Node.js, Python, or `node_modules` is required. Rust dependencies are compiled into the binary; browser dependencies are vendored and checksum-pinned. |
 
 Running an interview also requires a LiveKit Cloud project and a Google AI Studio

--- a/scripts/browser-check.sh
+++ b/scripts/browser-check.sh
@@ -166,6 +166,11 @@ if [ -z "$SESSION_COOKIE" ]; then
   SESSION_COOKIE=$(login_session_cookie "$BASE_URL" browser-check) || exit 2
 fi
 
+# `ROOT="$ROOT"` reads to shellcheck as a self-assignment whose value the
+# argument below will not see. Right about the mechanism, wrong about the
+# intent: the argument wants this shell's ROOT, and the prefix exists to hand
+# node the same value. Nothing here wants the forked one.
+# shellcheck disable=SC2097,SC2098
 BASE_URL="$BASE_URL" \
   BROWSER_CHECK_AGENT="$BROWSER_CHECK_AGENT" \
   BROWSER_CHECK_FLOW="$BROWSER_CHECK_FLOW" \

--- a/scripts/fetch-vendor.sh
+++ b/scripts/fetch-vendor.sh
@@ -44,13 +44,15 @@ fi
 # gate until someone deleted it by hand. Only this run's own temp is removed:
 # sweeping the directory would delete the in-flight temp of a concurrent run,
 # which is the race the per-process name below exists to avoid.
+#
+# Inline rather than a `cleanup` function the way the other scripts here write
+# it. A function only the trap calls looks unreachable to shellcheck, and the
+# two versions in play disagree about what to call that: 0.9.0, which is what
+# the CI runner has, reports SC2317 on the body, while 0.11.0 reports SC2329 on
+# the declaration. Suppressing both spellings is a note that goes stale on the
+# next release. Having no function to misread does not.
 tmp=
-# Invoked by the `trap` below, which shellcheck does not read as a call site.
-# shellcheck disable=SC2329
-cleanup() {
-  [ -z "$tmp" ] || rm -f "$tmp"
-}
-trap cleanup EXIT INT TERM HUP
+trap '[ -z "$tmp" ] || rm -f "$tmp"' EXIT INT TERM HUP
 
 fetch_manifest() {
   manifest=$1

--- a/scripts/fetch-vendor.sh
+++ b/scripts/fetch-vendor.sh
@@ -25,9 +25,19 @@ download() {
   fi
 }
 
-sha256() {
-  shasum -a 256 "$1" | cut -d' ' -f1
-}
+# macOS ships shasum but not sha256sum; most Linux distros ship the reverse.
+# Bind one at startup rather than probing per file: a machine with neither
+# should say so before the first download, not hash an empty string afterwards
+# and blame the mirror. sha256sum is tried first because shasum is a Perl
+# script, so it is the slower of the two when both are present.
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256() { sha256sum "$1" | cut -d' ' -f1; }
+elif command -v shasum >/dev/null 2>&1; then
+  sha256() { shasum -a 256 "$1" | cut -d' ' -f1; }
+else
+  echo "fetch-vendor: need sha256sum or shasum" >&2
+  exit 1
+fi
 
 # An interrupted download leaves a `.part` file behind, and verify-vendor
 # rejects any file in the tree SHA256SUMS does not pin, so it would fail the
@@ -35,6 +45,8 @@ sha256() {
 # sweeping the directory would delete the in-flight temp of a concurrent run,
 # which is the race the per-process name below exists to avoid.
 tmp=
+# Invoked by the `trap` below, which shellcheck does not read as a call site.
+# shellcheck disable=SC2329
 cleanup() {
   [ -z "$tmp" ] || rm -f "$tmp"
 }

--- a/scripts/recording-integration.sh
+++ b/scripts/recording-integration.sh
@@ -122,7 +122,7 @@ case "${CODETRIAL_RECORDING_ROOM_SECONDS:-60}" in
     exit 2
     ;;
 esac
-export CODETRIAL_RECORDING_TIMEOUT_SECONDS=$timeout_seconds
+export CODETRIAL_RECORDING_TIMEOUT_SECONDS="$timeout_seconds"
 room_seconds=${CODETRIAL_RECORDING_ROOM_SECONDS:-60}
 acceptance=${CODETRIAL_RECORDING_ACCEPTANCE_JSON:-$ROOT/target/recording-acceptance.json}
 template_origin=${CODETRIAL_RECORDING_TEMPLATE_BASE_URL%/}

--- a/scripts/report-parity-check.sh
+++ b/scripts/report-parity-check.sh
@@ -32,6 +32,10 @@ run_capture() {
   output=$1
   attempt=1
   while [ "$attempt" -le 2 ]; do
+
+    # The `${...}` inside the single quotes is a JavaScript template literal
+    # that node expands, not a shell expansion this script wants back.
+    # shellcheck disable=SC2016
     if BROWSER_CHECK_AGENT=rust BROWSER_CHECK_FLOW=report BROWSER_CHECK_CAPTURE="$output" "$ROOT/scripts/browser-check.sh" &&
       CAPTURE="$output" node -e 'const c=JSON.parse(require("fs").readFileSync(process.env.CAPTURE,"utf8")); if (c.report?.error === true) { console.error(`rust report fallback: ${String(c.report.summary || "").slice(0, 240)}`); process.exit(1); }'; then
       return 0

--- a/scripts/session-cookie.sh
+++ b/scripts/session-cookie.sh
@@ -1,3 +1,6 @@
+# Sourced, so no shebang: the dialect is stated for shellcheck instead.
+# shellcheck shell=sh
+
 # Sourced by the check scripts. Signs a candidate in through the same door the
 # browser uses, so no check needs sqlite3, the cookie secret, or its own copy of
 # the signing scheme, and every one of them works against a server it did not

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -77,11 +77,25 @@ cargo_audit_gate() {
   cargo audit --file "$ROOT/Cargo.lock"
 }
 
+# `sh -n` says whether a script parses. shellcheck says whether it means what it
+# reads like, which matters here because these scripts include the supply-chain
+# gate. Repo-wide false positives are answered once in `.shellcheckrc`; the few
+# local ones carry a directive naming why, beside the code it is about.
+#
+# Optional the way cargo-audit is: CI installs it, and a contributor without it
+# gets a note rather than a failure they cannot act on.
 shell_syntax() {
   status=0
   for script in "$ROOT"/scripts/*.sh; do
     sh -n "$script" || status=1
   done
+
+  if command -v shellcheck >/dev/null 2>&1; then
+    (cd "$ROOT" && shellcheck scripts/*.sh) || status=1
+  else
+    echo "skipping shellcheck: install it to enable the rest of this gate locally" >&2
+  fi
+
   return "$status"
 }
 

--- a/scripts/verify-vendor.sh
+++ b/scripts/verify-vendor.sh
@@ -18,23 +18,62 @@ VENDOR="$ROOT/web/vendor"
 
 [ -d "$VENDOR" ] || exit 0
 
+# macOS ships shasum but not sha256sum; most Linux distros ship the reverse.
+# Both read the same `hash name` lines, so SHA256SUMS needs no variant. Bind one
+# at startup so a machine with neither fails here rather than mid-walk.
+# sha256sum is tried first because shasum is a Perl script and slower.
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256_check() { sha256sum -c SHA256SUMS; }
+elif command -v shasum >/dev/null 2>&1; then
+  sha256_check() { shasum -a 256 -c SHA256SUMS; }
+else
+  echo "verify-vendor: need sha256sum or shasum" >&2
+  exit 1
+fi
+
 status=0
 
 # Every vendored file needs a line in the SHA256SUMS beside it. `basename` is
-# what the sums files record, matching the `cd && shasum -c` convention. README
-# and LICENSE are provenance, not bytes the browser runs, so they are the only
-# things allowed to be unpinned.
-find "$VENDOR" -type f ! -name SHA256SUMS ! -name FETCH ! -name 'README*' ! -name 'LICENSE*' | while read -r file; do
+# what the sums files record, matching the `cd && sha256sum -c` convention.
+# README and LICENSE are provenance, not bytes the browser runs, so they are the
+# only things allowed to be unpinned.
+#
+# Collected rather than piped into the loop, for two reasons. A pipeline reports
+# the status of its last command, so `find | while` skips a subtree it cannot
+# read and still exits 0, which is the one outcome a supply-chain check must
+# never produce on an unexamined tree. Its loop body is also a subshell, so a
+# failure there has to be signalled by exiting rather than by `status`.
+#
+# The `||` has to stay out here rather than move into a helper the two walks
+# share: `exit` inside `$(...)` leaves the substitution, not the script, and the
+# silent pass is back.
+files=$(find "$VENDOR" -type f ! -name SHA256SUMS ! -name FETCH ! -name 'README*' ! -name 'LICENSE*') ||
+  { echo "verify-vendor: cannot scan ${VENDOR#"$ROOT"/}" >&2; exit 1; }
+
+while read -r file; do
+  [ -n "$file" ] || continue
   sums=$(dirname "$file")/SHA256SUMS
   if [ ! -f "$sums" ] || ! grep -qF "  $(basename "$file")" "$sums"; then
     echo "unpinned vendored file: ${file#"$ROOT"/}" >&2
-    exit 1
+    status=1
   fi
-done || status=1
+done <<EOF
+$files
+EOF
 
 [ "$status" -eq 0 ] || exit 1
 
-# Then verify the recorded hashes still match the bytes on disk.
-find "$VENDOR" -name SHA256SUMS | while read -r sums; do
-  (cd "$(dirname "$sums")" && shasum -a 256 -c SHA256SUMS)
-done
+# Then verify the recorded hashes still match the bytes on disk. Every directory
+# is checked even after one fails, so a bad checkout reports all of its damage
+# in one run instead of one bad file per rerun.
+sums_files=$(find "$VENDOR" -name SHA256SUMS) ||
+  { echo "verify-vendor: cannot scan ${VENDOR#"$ROOT"/}" >&2; exit 1; }
+
+while read -r sums; do
+  [ -n "$sums" ] || continue
+  (cd "$(dirname "$sums")" && sha256_check) || status=1
+done <<EOF
+$sums_files
+EOF
+
+exit "$status"

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,9 @@ fn run_web(options: CliOptions) -> Result<(), String> {
                 .to_string(),
         );
     }
+    for warning in relaxed_for_local_use(&values) {
+        eprintln!("{warning}");
+    }
     let listener = bind_web_listener(&values)?;
 
     // Built straight from the values rather than through `load_from_pairs`:
@@ -738,6 +741,42 @@ fn trusted_proxy_hops(values: &BTreeMap<String, String>) -> u32 {
         .unwrap_or(0)
 }
 
+/// What a `codetrial web` start without `NODE_ENV=production` is allowing, in
+/// the operator's words rather than the code's.
+///
+/// Every guard this reports on is keyed on `NODE_ENV`, so the one mistake none
+/// of them can catch is the deployment that sets every credential correctly and
+/// never sets `NODE_ENV` at all. The refusal in `run_web` fires only once the
+/// operator has already said this is production; a server that was meant to be
+/// production and does not say so gets the local defaults and no complaint.
+/// This is the only signal it ever gets.
+///
+/// `config::is_production` matches the exact string, so a `NODE_ENV=Production`
+/// typo lands here too, which is the other way a deployment ends up local
+/// without meaning to.
+///
+/// `run_serve` does not call this. That mode refuses `NODE_ENV=production`
+/// outright, so it is local by definition and has nothing to warn about.
+fn relaxed_for_local_use(values: &BTreeMap<String, String>) -> Vec<String> {
+    if is_production(values) {
+        return Vec::new();
+    }
+
+    let mut warnings = vec![
+        "NODE_ENV is not production: the page's CSP allows loopback origins and a \
+         plaintext ws:// LiveKit URL is accepted. Set NODE_ENV=production to deploy."
+            .to_string(),
+    ];
+    if nonempty(values, "SESSION_SECRET").is_none() {
+        warnings.push(format!(
+            "SESSION_SECRET is unset: signing session cookies with the built-in \
+                 {DEFAULT_SESSION_SECRET:?}, which is published in this repository and lets \
+                 anyone forge a session."
+        ));
+    }
+    warnings
+}
+
 fn compiler_explorer_enabled(values: &BTreeMap<String, String>) -> bool {
     codetrial::config::compiler_explorer_enabled(
         values
@@ -771,6 +810,86 @@ fn account_db_path(values: &BTreeMap<String, String>) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+
+    fn values(pairs: &[(&str, &str)]) -> super::BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect()
+    }
+
+    /// The deployment this whole warning exists for: every credential set, and
+    /// `NODE_ENV` forgotten. Nothing else in the startup path says a word about
+    /// it, so if this stops firing the misconfiguration goes back to silent.
+    #[test]
+    fn a_start_without_node_env_says_what_it_relaxed() {
+        let warnings = super::relaxed_for_local_use(&values(&[
+            ("LIVEKIT_URL", "wss://example.livekit.cloud"),
+            ("GITHUB_CLIENT_ID", "id"),
+        ]));
+
+        assert_eq!(warnings.len(), 2, "{warnings:?}");
+        assert!(
+            warnings[0].contains("NODE_ENV is not production"),
+            "{warnings:?}"
+        );
+        assert!(
+            warnings[1].contains("SESSION_SECRET is unset"),
+            "{warnings:?}"
+        );
+        assert!(
+            warnings[1].contains(super::DEFAULT_SESSION_SECRET),
+            "the warning has to name the published value, or an operator cannot \
+             tell which key is in use: {warnings:?}"
+        );
+    }
+
+    /// A set secret drops that half and keeps the other. The relaxed CSP and
+    /// the plaintext LiveKit URL do not depend on the secret, so a local run
+    /// that sets one is still a local run.
+    #[test]
+    fn a_set_secret_leaves_only_the_mode_warning() {
+        let warnings =
+            super::relaxed_for_local_use(&values(&[("SESSION_SECRET", "a-real-secret")]));
+
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(
+            warnings[0].contains("NODE_ENV is not production"),
+            "{warnings:?}"
+        );
+    }
+
+    /// `is_production` matches the exact string, so a capitalized value is not
+    /// production and the server really is running local defaults. Warning is
+    /// the correct answer, and it is the only thing that catches the typo.
+    #[test]
+    fn a_misspelled_node_env_is_not_production_and_says_so() {
+        let warnings = super::relaxed_for_local_use(&values(&[
+            ("NODE_ENV", "Production"),
+            ("SESSION_SECRET", "a-real-secret"),
+        ]));
+
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(
+            warnings[0].contains("NODE_ENV is not production"),
+            "{warnings:?}"
+        );
+    }
+
+    /// Production is the configured case and says nothing. A warning on every
+    /// deployed start is a warning operators learn to scroll past, which is how
+    /// the one above stops working.
+    #[test]
+    fn production_warns_about_nothing() {
+        assert!(super::relaxed_for_local_use(&values(&[("NODE_ENV", "production")])).is_empty());
+        assert!(
+            super::relaxed_for_local_use(&values(&[
+                ("NODE_ENV", "production"),
+                ("SESSION_SECRET", "a-real-secret"),
+            ]))
+            .is_empty()
+        );
+    }
 
     /// The capacity slot is released by dropping, so an interview that panics
     /// gives its slot back like one that ends. Sixteen leaked slots would


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `shellcheck` gate, warns when `codetrial web` starts on local defaults, and fixes the vendored-asset checksum check so it can't silently pass on an unexamined tree.

**Bug Fixes**
- The vendor gate failed on Linux systems lacking `shasum`; it now binds `sha256sum` or `shasum` at startup and errors if neither exists.
- The checksum walk reported success when it couldn't read a subtree; it now collects the file list first, so an unreadable tree exits nonzero and every bad file is reported in one run.

**New Features**
- `codetrial web` now warns at startup when `NODE_ENV` is not exactly `production`, including an unset `SESSION_SECRET` that falls back to the published default; nothing is printed in production.
- The shell gate now runs `shellcheck` alongside `sh -n`; it's optional locally, and CI installs it.

<sup>Written for commit 138c94c52b5467d84475ba4a24eec68a6c260431. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/codetrial/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

