### PR TITLE
Releases now ship compressed, and the concurrent interview cap is configurable

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -9,6 +9,13 @@
 # ignored. What covers this path is the browser interview check and
 # scripts/browser-check.sh, not unit tests.
 #
+# `open_session` is the first half of `run_room`, split out of it: it joins the
+# room, waits for a candidate, brings up the audio track and the Gemini session,
+# and greets. Every line of it needs a LiveKit server for the same reason the
+# loop below it does, so `Ok(None)`, which reads as "nobody joined", survives
+# exactly as `run_room`'s own mutants did. Excluded for the same reason and
+# covered by the same thing: scripts/browser-check.sh in its credentialed modes.
+#
 # `run_gemini_check` is the same shape one layer down: it opens a Gemini Live
 # session against Google and closes it. Replacing the body with `Ok(())` cannot
 # be caught by `cargo test`, because a test that reached the real thing would
@@ -25,4 +32,4 @@
 #
 # Keep this list short and each entry justified. An entry that is really "we
 # never got around to testing this" belongs in a test, not here.
-exclude_re = ["run_room", "run_gemini_check", "replace web_router"]
+exclude_re = ["run_room", "open_session", "run_gemini_check", "replace web_router"]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -459,14 +459,17 @@ jobs:
             os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             extension: ''
+            archive: tar.gz
           - name: macOS arm64
             os: macos-15
             target: aarch64-apple-darwin
             extension: ''
+            archive: zip
           - name: Windows x86_64
             os: windows-2025
             target: x86_64-pc-windows-msvc
             extension: .exe
+            archive: zip
     runs-on: ${{ matrix.os }}
     env:
       # Cleared for the same reason `plan-mutants` clears it: the workflow-wide
@@ -568,10 +571,32 @@ jobs:
           cp target/${{ matrix.target }}/release/codetrial${{ matrix.extension }}
           codetrial-${{ matrix.target }}${{ matrix.extension }}
         shell: bash
+      - name: Compress Linux release asset
+        if: runner.os == 'Linux'
+        shell: bash
+        run: tar -czf codetrial-${{ matrix.target }}.tar.gz codetrial-${{ matrix.target }}
+      # `zip`, not `ditto`. `--keepParent` keeps the parent *directory* of what
+      # it is given, and what it is given here is a file, so the archive carried
+      # `codetrial/codetrial-aarch64-apple-darwin`: the runner's checkout
+      # directory name, leaked into a download, with the binary a level deeper
+      # than the other two platforms put it. ditto also writes an AppleDouble
+      # `._` sidecar that is noise everywhere it is unpacked.
+      #
+      # Nothing is lost by dropping it: the ad-hoc signature the linker applies
+      # lives inside the Mach-O, not in the extended attributes ditto exists to
+      # preserve, and it survives a zip round trip along with the mode bits.
+      - name: Compress macOS release asset
+        if: runner.os == 'macOS'
+        shell: bash
+        run: zip -q codetrial-${{ matrix.target }}.zip codetrial-${{ matrix.target }}
+      - name: Compress Windows release asset
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -LiteralPath codetrial-${{ matrix.target }}.exe -DestinationPath codetrial-${{ matrix.target }}.zip
       - uses: actions/upload-artifact@v7
         with:
           name: codetrial-${{ matrix.target }}
-          path: codetrial-${{ matrix.target }}${{ matrix.extension }}
+          path: codetrial-${{ matrix.target }}.${{ matrix.archive }}
 
   # A rolling prerelease keeps the current main build one direct download away.
   release:
@@ -605,9 +630,9 @@ jobs:
         shell: bash
         run: |
           assets=(
-            dist/codetrial-x86_64-unknown-linux-gnu
-            dist/codetrial-aarch64-apple-darwin
-            dist/codetrial-x86_64-pc-windows-msvc.exe
+            dist/codetrial-x86_64-unknown-linux-gnu.tar.gz
+            dist/codetrial-aarch64-apple-darwin.zip
+            dist/codetrial-x86_64-pc-windows-msvc.zip
           )
           for asset in "${assets[@]}"; do
             [ -f "$asset" ] || { echo "missing release asset: $asset" >&2; exit 1; }
@@ -665,6 +690,21 @@ jobs:
               exit 1
             }
           done
+
+          # Anything on `latest` that this build did not just upload came from
+          # an older naming scheme, and `--clobber` cannot touch it: it only
+          # overwrites names that match. The raw `codetrial-<target>` binaries
+          # these archives replaced are exactly that, and left alone they sit on
+          # the download page beside the current set with nothing saying which
+          # commit they are from. Removed inside the draft, where the page
+          # serves nobody, and before the tag moves.
+          wanted=$(for asset in "${assets[@]}"; do basename "$asset"; done)
+          gh release view latest --json assets --jq '.assets[].name' \
+            | while read -r name; do
+                printf '%s\n' "$wanted" | grep -qxF "$name" && continue
+                echo "removing stale release asset: $name"
+                gh release delete-asset latest "$name" --yes
+              done
 
           # Only now does anything point at this build.
           git tag -f latest "$GITHUB_SHA"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -490,6 +490,14 @@ jobs:
       - name: Install Linux build dependency
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev
+      # The same entry the check job saves, on the same key. Without it all
+      # three platform legs re-download 24 MB that one job already fetched and
+      # stored on this commit, and the fetch script no-ops on a hit.
+      - name: Restore vendored bytes
+        uses: actions/cache/restore@v6
+        with:
+          path: web/vendor
+          key: vendor-${{ hashFiles('web/vendor/**') }}
       - name: Fetch browser assets
         run: ./scripts/fetch-vendor.sh
         shell: bash

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -512,6 +512,13 @@ jobs:
         run: |
           empty=$(mktemp -d)
           cp target/${{ matrix.target }}/release/codetrial "$empty/"
+          # `web` refuses to start without a primary config file, so the empty
+          # directory gets one. It is still empty of a web tree, which is the
+          # only emptiness this step is about.
+          printf '%s\n' \
+            'LIVEKIT_URL=wss://example.livekit.cloud' \
+            'LIVEKIT_API_KEY=embed-check-key' \
+            'LIVEKIT_API_SECRET=embed-check-secret' >"$empty/codetrial.env.local"
           # Killed from a trap rather than only on the happy path, and with its
           # output redirected: a server left running past a failed probe holds
           # the step's stdout open, which turns a one-line failure into a job

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,9 +241,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,6 @@ verify-vendor:
 	@./scripts/verify-vendor.sh
 
 serve: fetch-vendor
-	@if [ "$${CODETRIAL_SKIP_CONFIG:-}" != 1 ] && \
-		[ -z "$${LIVEKIT_URL:-}" -o -z "$${LIVEKIT_API_KEY:-}" -o -z "$${LIVEKIT_API_SECRET:-}" ] && \
-		[ ! -f config/codetrial.env.local ]; then \
-		echo "Error: config/codetrial.env.local does not exist. Copy config/codetrial.env.example to config/codetrial.env.local before running 'make serve'."; \
-		exit 1; \
-	fi
 	cargo run -- serve
 
 web: fetch-vendor

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ license are recorded in that notice.
 |---|---|---|
 | Build time | Rust stable, `curl` or `wget`, and `sha256sum` or `shasum` | Cargo resolves application crates from `Cargo.lock`. `make build` fetches the checksum-pinned browser assets on the first build. |
 | Test time | Build-time tools, Node.js 18+, and Python 3 | Node runs browser and fixture checks; Python verifies generated problem-bank files. `npm ci` adds ESLint and Playwright for the full local browser gate. `shellcheck`, `actionlint`, and `cargo-audit` are optional: each gate reports that it skipped rather than failing without them. |
-| Runtime | The compiled `codetrial` binary and its `web/` assets | No Node.js, Python, or `node_modules` is required. Rust dependencies are compiled into the binary; browser dependencies are vendored and checksum-pinned. |
+| Runtime | The compiled `codetrial` binary and a config file | No Node.js, Python, or `node_modules` is required. Rust dependencies are compiled into the binary; browser dependencies are vendored, checksum-pinned, and embedded, so a `web/` directory is optional and only overrides what is already inside. |
 
 Running an interview also requires a LiveKit Cloud project and a Google AI Studio
 API key. C, C++, and Java test runs additionally use the remote Compiler
@@ -74,7 +74,63 @@ current directory. Use `--config PATH` for an alternate primary config file.
 Extra `codetrial.env.*` files in the same directory are optional providers used
 for pooling.
 
+## Prebuilt binaries
+
+Every push to `main` republishes the `latest` prerelease at
+<https://github.com/sysprog21/codetrial/releases/latest>. Nothing is required at
+runtime beyond the binary itself: the browser application, its vendored assets,
+and the WASM are compiled in, so there is no Node.js, no `node_modules`, and no
+`web/` directory to unpack alongside it.
+
+```bash
+# Linux
+tar -xzf codetrial-x86_64-unknown-linux-gnu.tar.gz
+mv codetrial-x86_64-unknown-linux-gnu codetrial
+
+# macOS
+unzip codetrial-aarch64-apple-darwin.zip
+xattr -d com.apple.quarantine codetrial-aarch64-apple-darwin
+mv codetrial-aarch64-apple-darwin codetrial
+```
+
+A config file has to sit beside it. The binary will not run on environment
+variables alone, and it refuses to start without LiveKit credentials rather than
+booting a server that cannot mint a token. There is no `config/codetrial.env.example`
+to copy outside a checkout, so write the three required keys yourself:
+
+```bash
+cat >codetrial.env.local <<'EOF'
+LIVEKIT_URL=wss://YOUR-PROJECT.livekit.cloud
+LIVEKIT_API_KEY=...
+LIVEKIT_API_SECRET=...
+GOOGLE_API_KEY=...
+EOF
+./codetrial web   # http://127.0.0.1:3000
+```
+
+`GOOGLE_API_KEY` is the optional one, and it decides which of two things this
+process is. With it, the server hosts interviewers itself. Without it, it serves
+the web side only and every room waits for an agent to join from elsewhere, and
+it says so on startup. There is no matching line for the hosting case, so a
+silent start is the one that hosts interviewers. `--config PATH` names the file
+if you would rather keep it somewhere else; see
+[Configuration](#configuration) for the rest.
+
+Platform notes:
+
+- macOS binaries carry only the ad-hoc signature the linker applies, which is
+  what lets an arm64 binary run at all. They are not Developer ID signed and not
+  notarized, because that needs a paid Apple Developer Program membership this
+  project does not have. A downloaded `.zip` carries the quarantine attribute
+  and Gatekeeper refuses it, so clear the attribute as above or build from
+  source.
+- Windows binaries are unsigned. SmartScreen warns on first run.
+- Only `x86_64` Linux, `arm64` macOS, and `x86_64` Windows are published. Build
+  from source for anything else.
+
 ## Run
+
+Building from a checkout instead:
 
 ```bash
 INTERVIEW_ROOM_NAME=interview-local make serve
@@ -128,21 +184,18 @@ make check           # test gate plus live Gemini credential check
 ./scripts/test.sh    # credential-free CI gate
 ```
 
-Every update to `main` publishes a `latest` prerelease with one self-contained
-`codetrial` executable for Linux, macOS, and Windows. It serves the browser
-application from inside the binary, and falls back to those built-in assets per
-file, so a partially populated web tree is filled in rather than 404ing.
+The [prerelease](#prebuilt-binaries) is published by the `build` and `release`
+jobs in `.github/workflows/check.yml`, which run only on a push to `main`. No
+repository secrets are involved: the macOS binary ships with the linker's ad-hoc
+signature and nothing else, so a fork builds the same artifacts this repository
+does. Developer ID signing and notarization would need a paid Apple Developer
+Program membership, and the download instructions clear quarantine instead.
 
-Assets on disk win where they exist. That root is `web/` relative to the working
-directory unless `CODETRIAL_WEB_DIR` names another, so running the binary from a
-checkout picks up edits with no environment variable set.
-
-The macOS build is unsigned. A downloaded copy carries the quarantine attribute
-and refuses to open until you clear it:
-
-```shell
-xattr -d com.apple.quarantine codetrial-aarch64-apple-darwin
-```
+The embed falls back per file rather than wholesale, so a partially populated
+web tree is filled in from the built-in copy rather than 404ing. Assets on disk
+win where they exist. That root is `web/` relative to the working directory
+unless `CODETRIAL_WEB_DIR` names another, so running the binary from a checkout
+picks up edits with no environment variable set.
 
 `web/problems/`, `web/judges/`, and the problem cards in `web/index.html` are
 generated from `problem-bank/`. Regenerate them after editing that source, or

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ URL rather than the interview. See [docs/providers.md](docs/providers.md).
 | `cargo run -- check-gemini` | Verify Gemini credentials |
 
 `serve` is for local work and refuses `NODE_ENV=production`; use `web` in
-production. A `web` process handles at most 16 concurrent interviews.
+production. A `web` process hosts agents for at most
+`CODETRIAL_MAX_CONCURRENT_INTERVIEWS` interviews at once, 16 by default; past
+that, dispatch is refused and the candidate waits.
 
 Set `CODETRIAL_COMPILER_EXPLORER_ENABLED=false` to leave C, C++, and Java
 editors available while disabling their remote test runs.
@@ -201,6 +203,7 @@ the environment instead. The common ones are:
 | `GEMINI_REPORT_MODEL` | `gemini-3.1-flash-lite` | Report model |
 | `CODETRIAL_GEMINI_CANDIDATE_VIDEO_ENABLED` | `false` | Forward candidate video to Gemini |
 | `CODETRIAL_COMPILER_EXPLORER_ENABLED` | `true` | Enable remote C, C++, and Java runs |
+| `CODETRIAL_MAX_CONCURRENT_INTERVIEWS` | `16` | Interviews one `web` process hosts agents for |
 
 Two more matter in production. `SESSION_SECRET` signs the session cookie and its
 built-in default is a published string, so with `NODE_ENV=production` the server

--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ Explorer service.
 3. Set `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`, and
    `GOOGLE_API_KEY` in that file.
 
-The binary loads `config/codetrial.env.local` automatically. Use `--config PATH`
-for another file, or `CODETRIAL_SKIP_CONFIG=1` to disable that behavior.
+The binary requires `codetrial.env.local`, searching `./config/` before the
+current directory. Use `--config PATH` for an alternate primary config file.
+Extra `codetrial.env.*` files in the same directory are optional providers used
+for pooling.
 
 ## Run
 
@@ -192,7 +194,7 @@ run on their own: `scripts/server-check.sh`, `gemini-check.sh`,
 ## Configuration
 
 `config/codetrial.env.example` documents the variables that belong in a config
-file. `NODE_ENV`, `CODETRIAL_SKIP_CONFIG`, and `INTERVIEW_ROOM_NAME` are set in
+file. `NODE_ENV` and `INTERVIEW_ROOM_NAME` are set in
 the environment instead. The common ones are:
 
 | Variable | Default | Purpose |

--- a/scripts/browser-check.cjs
+++ b/scripts/browser-check.cjs
@@ -256,12 +256,17 @@ async function isolateRustAgent(roomName, rustAgentIdentity, timeoutMs = 120000)
     let rustAgentIdentity;
     let rustAgentParticipants = [];
     function startRustAgent(room) {
+      // The same `--config` the server was started with. `provider_dir` is
+      // the config file's directory, so an agent left to find its own would
+      // route against a different pool than the server it is answering for.
       rustAgent = spawn("cargo", [
         "run",
         "--quiet",
         "--",
         "run-livekit",
         room,
+        "--config",
+        process.env.BROWSER_CHECK_CONFIG_PATH,
       ], {
         cwd: process.env.ROOT,
         detached: true,

--- a/scripts/browser-check.sh
+++ b/scripts/browser-check.sh
@@ -27,6 +27,7 @@ USE_AGENT_SERVE=0
 DISPATCH_MODE=0
 LOGIN_DB_PATH="$TMP/accounts.db"
 LOGIN_SESSION_SECRET=browser-check-session
+CONFIG_PATH="$TMP/codetrial.env.local"
 
 cleanup() {
   if [ "${SERVER_PID:-}" ]; then
@@ -38,8 +39,13 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 if [ "$BROWSER_CHECK_AGENT" = "rust" ] || [ "$BROWSER_CHECK_AGENT" = "dispatch" ]; then
-  CONFIG_ENV=${CODETRIAL_CONFIG_ENV:-$ROOT/config/codetrial.env.local}
-  if [ -f "$CONFIG_ENV" ]; then
+  CONFIG_ENV=${CODETRIAL_CONFIG_ENV:-}
+  if [ -z "$CONFIG_ENV" ]; then
+    for candidate in "$ROOT/config/codetrial.env.local" "$ROOT/codetrial.env.local"; do
+      [ -f "$candidate" ] && { CONFIG_ENV=$candidate; break; }
+    done
+  fi
+  if [ -f "${CONFIG_ENV:-}" ]; then
     set -a
     . "$CONFIG_ENV"
     set +a
@@ -49,6 +55,33 @@ if [ "$BROWSER_CHECK_AGENT" = "rust" ] || [ "$BROWSER_CHECK_AGENT" = "dispatch" 
   : "${LIVEKIT_API_SECRET:?set LIVEKIT_API_SECRET for credentialed browser check}"
   : "${GOOGLE_API_KEY:?set GOOGLE_API_KEY for credentialed browser check}"
 fi
+
+case $BROWSER_CHECK_AGENT in
+  home | offline)
+    printf '%s\n' \
+      'LIVEKIT_URL=wss://example.livekit.cloud' \
+      'LIVEKIT_API_KEY=browser-check-key' \
+      'LIVEKIT_API_SECRET=browser-check-secret' >"$CONFIG_PATH"
+    ;;
+  rust | dispatch)
+
+    # The operator's own file, named rather than copied. `provider_dir` is the
+    # config file's directory, so a copy in $TMP has no `codetrial.env.<id>`
+    # siblings beside it and the pool collapses to the primary project. The
+    # credentialed check is the only one that can exercise pooling at all, and a
+    # copy is exactly what stops it: an external server minting a pooled room
+    # would hand it to an agent that has never heard of that provider.
+    #
+    # A config assembled from the environment is the fallback, for the runner
+    # that has the four variables and no file to point at.
+    if [ -f "${CONFIG_ENV:-}" ]; then
+      CONFIG_PATH=$CONFIG_ENV
+    else
+      printf 'LIVEKIT_URL=%s\nLIVEKIT_API_KEY=%s\nLIVEKIT_API_SECRET=%s\nGOOGLE_API_KEY=%s\n' \
+        "$LIVEKIT_URL" "$LIVEKIT_API_KEY" "$LIVEKIT_API_SECRET" "$GOOGLE_API_KEY" >"$CONFIG_PATH"
+    fi
+    ;;
+esac
 
 if [ "${BROWSER_CHECK_VALIDATE_ENV_ONLY:-}" ]; then
   exit 0
@@ -98,10 +131,9 @@ else
   case $BROWSER_CHECK_AGENT in
     home | offline)
       env -u LIVEKIT_URL -u LIVEKIT_API_KEY -u LIVEKIT_API_SECRET -u GOOGLE_API_KEY \
-        CODETRIAL_SKIP_CONFIG=1 \
         SESSION_SECRET="$LOGIN_SESSION_SECRET" \
         CODETRIAL_DB_PATH="$LOGIN_DB_PATH" \
-        cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- web --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
+        cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- web --config "$CONFIG_PATH" --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
         >"$SERVER_LOG" 2>&1 &
       ;;
     dispatch)
@@ -111,20 +143,18 @@ else
       # that a missing dispatch breaks, and nothing else covers it.
       unset INTERVIEW_ROOM_NAME
       DISPATCH_MODE=1
-      CODETRIAL_SKIP_CONFIG=1 \
-        SESSION_SECRET="$LOGIN_SESSION_SECRET" \
-        CODETRIAL_DB_PATH="$LOGIN_DB_PATH" \
-        cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- web --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
+      SESSION_SECRET="$LOGIN_SESSION_SECRET" \
+      CODETRIAL_DB_PATH="$LOGIN_DB_PATH" \
+      cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- web --config "$CONFIG_PATH" --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
         >"$SERVER_LOG" 2>&1 &
       ;;
     rust)
       INTERVIEW_ROOM_NAME=${INTERVIEW_ROOM_NAME:-interview-browser-$(date +%s)-$$}
       export INTERVIEW_ROOM_NAME
       USE_AGENT_SERVE=1
-      CODETRIAL_SKIP_CONFIG=1 \
-        SESSION_SECRET="$LOGIN_SESSION_SECRET" \
-        CODETRIAL_DB_PATH="$LOGIN_DB_PATH" \
-        cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- serve --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
+      SESSION_SECRET="$LOGIN_SESSION_SECRET" \
+      CODETRIAL_DB_PATH="$LOGIN_DB_PATH" \
+      cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- serve --config "$CONFIG_PATH" --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
         >"$SERVER_LOG" 2>&1 &
       ;;
     *)
@@ -179,6 +209,7 @@ BASE_URL="$BASE_URL" \
   BROWSER_CHECK_COMPILER_EXPLORER_BASE_URL="$COMPILER_EXPLORER_BASE_URL_ARG" \
   BROWSER_CHECK_SESSION_COOKIE="$SESSION_COOKIE" \
   BROWSER_CHECK_USE_AGENT_SERVE="$USE_AGENT_SERVE" \
+  BROWSER_CHECK_CONFIG_PATH="$CONFIG_PATH" \
   INTERVIEW_ROOM_NAME="${INTERVIEW_ROOM_NAME:-}" \
   PLAYWRIGHT_PATH="$PLAYWRIGHT_PATH" \
   ROOT="$ROOT" \

--- a/scripts/gemini-check.sh
+++ b/scripts/gemini-check.sh
@@ -4,10 +4,12 @@ set -eu
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 ENV_FILE="${CODETRIAL_ENV:-$ROOT/config/codetrial.env.local}"
 
+# Named rather than sourced. The binary requires a config file of its own and no
+# longer reads credentials out of the environment alone, so sourcing this one
+# would leave `CODETRIAL_ENV` pointing somewhere the binary never looks. When it
+# is absent the binary runs its own search and reports the miss.
 if [ -f "$ENV_FILE" ]; then
-  set -a
-  . "$ENV_FILE"
-  set +a
+  set -- --config "$ENV_FILE" "$@"
 fi
 
 cargo run --manifest-path "$ROOT/Cargo.toml" -- check-gemini "$@"

--- a/scripts/server-check.sh
+++ b/scripts/server-check.sh
@@ -5,6 +5,11 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 . "$ROOT/scripts/session-cookie.sh"
 TMP=$(mktemp -d)
 SERVER_LOG="$TMP/web.log"
+CONFIG_PATH="$TMP/codetrial.env.local"
+printf '%s\n' \
+  'LIVEKIT_URL=wss://example.livekit.cloud' \
+  'LIVEKIT_API_KEY=server-check-key' \
+  'LIVEKIT_API_SECRET=server-check-secret' >"$CONFIG_PATH"
 
 cleanup() {
   if [ "${SERVER_PID:-}" ]; then
@@ -38,10 +43,9 @@ else
   fi
 
   env -u LIVEKIT_URL -u LIVEKIT_API_KEY -u LIVEKIT_API_SECRET -u GOOGLE_API_KEY \
-    CODETRIAL_SKIP_CONFIG=1 \
     SESSION_SECRET=browser-check-session \
     CODETRIAL_DB_PATH="$TMP/accounts.db" \
-    cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- web --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
+    cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- web --config "$CONFIG_PATH" --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
     >"$SERVER_LOG" 2>&1 &
   SERVER_PID=$!
 fi
@@ -87,5 +91,5 @@ status=$(curl -sS \
   -w "%{http_code}" \
   "$BASE_URL/api/token")
 
-test "$status" = "500"
-grep -F "missing LiveKit credentials" "$TMP/signed-token.json" >/dev/null
+test "$status" = "200"
+grep -F '"token"' "$TMP/signed-token.json" >/dev/null

--- a/scripts/visual-parity-check.sh
+++ b/scripts/visual-parity-check.sh
@@ -10,6 +10,11 @@ TMP=$(mktemp -d)
 SERVER_LOG="$TMP/server.log"
 LOGIN_DB_PATH="$TMP/accounts.db"
 LOGIN_SESSION_SECRET=visual-parity-session
+CONFIG_PATH="$TMP/codetrial.env.local"
+printf '%s\n' \
+  'LIVEKIT_URL=wss://example.livekit.cloud' \
+  'LIVEKIT_API_KEY=visual-parity-key' \
+  'LIVEKIT_API_SECRET=visual-parity-secret' >"$CONFIG_PATH"
 
 cleanup() {
   if [ "${SERVER_PID:-}" ]; then
@@ -47,10 +52,9 @@ fi
 mkdir -p "$GOLDEN_DIR" "$ARTIFACT_DIR"
 
 env -u LIVEKIT_URL -u LIVEKIT_API_KEY -u LIVEKIT_API_SECRET -u GOOGLE_API_KEY \
-  CODETRIAL_SKIP_CONFIG=1 \
   SESSION_SECRET="$LOGIN_SESSION_SECRET" \
   CODETRIAL_DB_PATH="$LOGIN_DB_PATH" \
-  cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- web --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
+  cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- web --config "$CONFIG_PATH" --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
   >"$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,15 @@ pub const DEFAULT_WEB_ADDR: &str = "127.0.0.1:3000";
 pub const DEFAULT_COMPILER_EXPLORER_ENABLED: bool = true;
 pub const DEFAULT_GEMINI_CANDIDATE_VIDEO_ENABLED: bool = false;
 
+/// How many interviews one `codetrial web` process will host agents for at
+/// once. Each is a LiveKit room plus a metered Gemini Live session, so an
+/// unbounded count is an unbounded bill; a refused dispatch leaves the
+/// candidate on the "Waiting" pill, which is bad, but recoverable and visible.
+///
+/// Configurable because it is the one number that tracks the operator's budget
+/// and hardware rather than anything this code knows.
+pub const DEFAULT_MAX_CONCURRENT_INTERVIEWS: usize = 16;
+
 const REQUIRED_KEYS: &[&str] = &[
     "LIVEKIT_URL",
     "LIVEKIT_API_KEY",
@@ -677,6 +686,54 @@ fn report_model_or_default(values: &BTreeMap<String, String>) -> String {
             DEFAULT_GEMINI_REPORT_MODEL.to_string()
         }
         model => model.to_string(),
+    }
+}
+
+/// `CODETRIAL_MAX_CONCURRENT_INTERVIEWS`, or the default, and a word about it
+/// when the operator asked for something this cannot do.
+///
+/// The fallback does not fail the load: the cap is a throttle, and refusing to
+/// start over a typo in it would trade a slow server for no server. It does not
+/// happen quietly either. Zero and `sixteeen` both land on the default, and an
+/// operator who set one of them deliberately, to drain a node before a deploy,
+/// would otherwise get sixteen interviews and no hint that the number they
+/// wrote was never read.
+pub fn max_concurrent_interviews(
+    values: &BTreeMap<String, String>,
+    warnings: &mut Vec<String>,
+) -> usize {
+    const KEY: &str = "CODETRIAL_MAX_CONCURRENT_INTERVIEWS";
+    let Some(configured) = values
+        .get(KEY)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    else {
+        return DEFAULT_MAX_CONCURRENT_INTERVIEWS;
+    };
+
+    // Matched on the literal rather than guarded on `parsed > 0`. The guard
+    // says the same thing through a comparison, and a comparison is four more
+    // ways for the mutation gate to ask whether anything checks it.
+    match configured.parse::<usize>() {
+        // Zero is spelled out separately. "must be a positive whole number" is
+        // true of it too, but an operator who typed 0 meant "stop taking
+        // interviews", and being told their number was unreadable would send
+        // them looking for a typo that is not there.
+        Ok(0) => {
+            warnings.push(format!(
+                "{KEY}=0 would refuse every interview; using {DEFAULT_MAX_CONCURRENT_INTERVIEWS}. \
+                 Stop the process to drain it."
+            ));
+            DEFAULT_MAX_CONCURRENT_INTERVIEWS
+        }
+        Ok(parsed) => parsed,
+        Err(_) => {
+            warnings.push(format!(
+                "{KEY}={configured} is not a positive whole number; using \
+                 {DEFAULT_MAX_CONCURRENT_INTERVIEWS}."
+            ));
+            DEFAULT_MAX_CONCURRENT_INTERVIEWS
+        }
     }
 }
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,6 +1,6 @@
 //! Running interviewers for the rooms this process named.
 //!
-//! Separate from main because none of it is startup: the cap, the slot
+//! Separate from `main` because none of it is startup: the cap, the slot
 //! accounting and the spawn all happen on the request path, for the length of
 //! an interview, long after the binary finished deciding what it is. Here it
 //! also gets tests that do not need a process.
@@ -10,12 +10,6 @@ use std::sync::{Arc, Mutex};
 
 use crate::config::{AgentConfig, Provider};
 use crate::web::RoomDispatcher;
-
-/// How many interviews one `codetrial web` process will host agents for at
-/// once. Each is a LiveKit room plus a metered Gemini Live session, so an
-/// unbounded count is an unbounded bill; a refused dispatch leaves the
-/// candidate on the "Waiting" pill, which is bad, but recoverable and visible.
-const MAX_CONCURRENT_INTERVIEWS: usize = 16;
 
 /// Runs the interviewer for rooms this process just named, in this process.
 ///
@@ -30,6 +24,9 @@ pub struct LocalDispatcher {
     pub config: AgentConfig,
     pub runtime: tokio::runtime::Handle,
     pub live: Arc<Mutex<HashSet<String>>>,
+    /// From `config::max_concurrent_interviews`, so the ceiling an operator set
+    /// is the ceiling this enforces.
+    pub max_concurrent: usize,
 }
 
 impl RoomDispatcher for LocalDispatcher {
@@ -42,9 +39,10 @@ impl RoomDispatcher for LocalDispatcher {
             if live.contains(room_name) {
                 return true;
             }
-            if live.len() >= MAX_CONCURRENT_INTERVIEWS {
+            if live.len() >= self.max_concurrent {
                 eprintln!(
-                    "codetrial dispatch_refused room={room_name} reason=at_capacity limit={MAX_CONCURRENT_INTERVIEWS}"
+                    "codetrial dispatch_refused room={room_name} reason=at_capacity limit={}",
+                    self.max_concurrent
                 );
                 return false;
             }
@@ -54,8 +52,8 @@ impl RoomDispatcher for LocalDispatcher {
 
         // Released by dropping, not by a line at the end of the task: a panic
         // in the interview would otherwise skip that line and burn the slot for
-        // the life of the process, and sixteen of those refuse every interview
-        // after them.
+        // the life of the process, and a cap's worth of those refuse every
+        // interview after them.
         let slot = Slot {
             live: Arc::clone(&self.live),
             room_name: room_name.to_string(),
@@ -95,7 +93,7 @@ impl Drop for Slot {
     }
 }
 
-/// The credential half of [`select_provider`], without the pool lookup, for the
+/// The credential half of provider selection, without the pool lookup, for the
 /// caller that was already handed the provider.
 pub fn agent_config_for(base: &AgentConfig, provider: &Provider) -> AgentConfig {
     let mut config = base.clone();
@@ -134,6 +132,42 @@ mod tests {
             live.lock().unwrap().is_empty(),
             "a panicking interview must not keep its slot"
         );
+    }
+
+    /// The cap is the configured one, not a constant. An operator who set it to
+    /// one gets one, and the refusal names the number they chose.
+    #[tokio::test]
+    async fn the_configured_cap_is_the_one_enforced() {
+        let live = Arc::new(Mutex::new(HashSet::new()));
+        live.lock().unwrap().insert("interview-first".to_string());
+        let dispatcher = LocalDispatcher {
+            config: crate::config::load_from_pairs([
+                ("LIVEKIT_URL", "wss://primary.example"),
+                ("LIVEKIT_API_KEY", "primary-key"),
+                ("LIVEKIT_API_SECRET", "primary-secret"),
+                ("GOOGLE_API_KEY", "primary-google"),
+            ])
+            .unwrap(),
+            runtime: tokio::runtime::Handle::current(),
+            live: Arc::clone(&live),
+            max_concurrent: 1,
+        };
+        let provider = Provider {
+            id: crate::config::PRIMARY_PROVIDER_ID.to_string(),
+            url: "wss://primary.example".to_string(),
+            api_key: "primary-key".to_string(),
+            api_secret: "primary-secret".to_string(),
+            google_api_key: String::new(),
+        };
+
+        assert!(
+            !dispatcher.ensure_agent("interview-second", &provider),
+            "a second room must be refused at a cap of one"
+        );
+
+        // The room already running is still admitted, because a reload asks for
+        // the same room and refusing it would break the page that is open.
+        assert!(dispatcher.ensure_agent("interview-first", &provider));
     }
 
     /// A provider's own Google key wins, and an empty one leaves the base key

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,0 +1,168 @@
+//! Running interviewers for the rooms this process named.
+//!
+//! Separate from main because none of it is startup: the cap, the slot
+//! accounting and the spawn all happen on the request path, for the length of
+//! an interview, long after the binary finished deciding what it is. Here it
+//! also gets tests that do not need a process.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+use crate::config::{AgentConfig, Provider};
+use crate::web::RoomDispatcher;
+
+/// How many interviews one `codetrial web` process will host agents for at
+/// once. Each is a LiveKit room plus a metered Gemini Live session, so an
+/// unbounded count is an unbounded bill; a refused dispatch leaves the
+/// candidate on the "Waiting" pill, which is bad, but recoverable and visible.
+const MAX_CONCURRENT_INTERVIEWS: usize = 16;
+
+/// Runs the interviewer for rooms this process just named, in this process.
+///
+/// The alternative is a LiveKit agent worker registered against the project,
+/// which is the shape LiveKit intends and which survives this process
+/// restarting. This is the smaller thing that makes production work: the room
+/// name is invented in `/api/token` and never leaves this process, so the
+/// process that invented it is the one that can act on it.
+pub struct LocalDispatcher {
+    /// Everything an interview needs except which LiveKit project it is in:
+    /// that arrives with the room, from the same lookup that minted the token.
+    pub config: AgentConfig,
+    pub runtime: tokio::runtime::Handle,
+    pub live: Arc<Mutex<HashSet<String>>>,
+}
+
+impl RoomDispatcher for LocalDispatcher {
+    fn ensure_agent(&self, room_name: &str, provider: &Provider) -> bool {
+        {
+            let mut live = self.live.lock().unwrap_or_else(|error| error.into_inner());
+
+            // A reload mints a token for the same fixed room in local mode, and
+            // two agents in one room evict each other.
+            if live.contains(room_name) {
+                return true;
+            }
+            if live.len() >= MAX_CONCURRENT_INTERVIEWS {
+                eprintln!(
+                    "codetrial dispatch_refused room={room_name} reason=at_capacity limit={MAX_CONCURRENT_INTERVIEWS}"
+                );
+                return false;
+            }
+            live.insert(room_name.to_string());
+        }
+        let config = agent_config_for(&self.config, provider);
+
+        // Released by dropping, not by a line at the end of the task: a panic
+        // in the interview would otherwise skip that line and burn the slot for
+        // the life of the process, and sixteen of those refuse every interview
+        // after them.
+        let slot = Slot {
+            live: Arc::clone(&self.live),
+            room_name: room_name.to_string(),
+        };
+
+        // Spawned, not awaited: this runs on the request path, and the task
+        // outlives the response by the length of the interview.
+        self.runtime.spawn(async move {
+            eprintln!("codetrial dispatch room={}", slot.room_name);
+            if let Err(error) = crate::livekit::run_room(
+                &config,
+                &slot.room_name,
+                crate::web::current_epoch_seconds(),
+            )
+            .await
+            {
+                eprintln!("codetrial agent_failed room={}: {error}", slot.room_name);
+            }
+        });
+        true
+    }
+}
+
+/// One interview's claim on this process's capacity, held for as long as the
+/// task that owns it.
+pub struct Slot {
+    pub live: Arc<Mutex<HashSet<String>>>,
+    pub room_name: String,
+}
+
+impl Drop for Slot {
+    fn drop(&mut self) {
+        self.live
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(&self.room_name);
+    }
+}
+
+/// The credential half of [`select_provider`], without the pool lookup, for the
+/// caller that was already handed the provider.
+pub fn agent_config_for(base: &AgentConfig, provider: &Provider) -> AgentConfig {
+    let mut config = base.clone();
+    config.livekit_url = provider.url.clone();
+    config.livekit_api_key = provider.api_key.clone();
+    config.livekit_api_secret = provider.api_secret.clone();
+    if !provider.google_api_key.is_empty() {
+        config.google_api_key = provider.google_api_key.clone();
+    }
+    config
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The capacity slot is released by dropping, so an interview that panics
+    /// gives its slot back like one that ends. A cap's worth of leaked slots
+    /// would refuse every interview after them for the life of the process.
+    #[tokio::test]
+    async fn a_panicking_interview_gives_its_capacity_back() {
+        let live = Arc::new(Mutex::new(HashSet::new()));
+        live.lock().unwrap().insert("interview-boom".to_string());
+        let slot = Slot {
+            live: Arc::clone(&live),
+            room_name: "interview-boom".to_string(),
+        };
+
+        let task = tokio::spawn(async move {
+            let _held = slot;
+            panic!("the interview blew up");
+        });
+        assert!(task.await.is_err(), "the task must have panicked");
+
+        assert!(
+            live.lock().unwrap().is_empty(),
+            "a panicking interview must not keep its slot"
+        );
+    }
+
+    /// A provider's own Google key wins, and an empty one leaves the base key
+    /// alone rather than blanking it.
+    #[test]
+    fn provider_credentials_replace_the_base_without_blanking_the_key() {
+        let base = crate::config::load_from_pairs([
+            ("LIVEKIT_URL", "wss://primary.example"),
+            ("LIVEKIT_API_KEY", "primary-key"),
+            ("LIVEKIT_API_SECRET", "primary-secret"),
+            ("GOOGLE_API_KEY", "primary-google"),
+        ])
+        .unwrap();
+        let mut provider = Provider {
+            id: "second".to_string(),
+            url: "wss://second.example".to_string(),
+            api_key: "second-key".to_string(),
+            api_secret: "second-secret".to_string(),
+            google_api_key: String::new(),
+        };
+
+        let inherited = agent_config_for(&base, &provider);
+        assert_eq!(inherited.livekit_url, "wss://second.example");
+        assert_eq!(inherited.google_api_key, "primary-google");
+
+        provider.google_api_key = "second-google".to_string();
+        assert_eq!(
+            agent_config_for(&base, &provider).google_api_key,
+            "second-google"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod accounts;
 pub mod agent;
 pub mod config;
 pub mod delivery;
+pub mod dispatch;
 pub mod gemini;
 pub mod livekit;
 pub mod recording;

--- a/src/livekit.rs
+++ b/src/livekit.rs
@@ -243,11 +243,40 @@ async fn resume_after_close(
     Ok(ControlFlow::Continue(()))
 }
 
-pub async fn run_room(
-    config: &AgentConfig,
-    room_name: &str,
+/// Everything the interview loop needs, owned, once the candidate has joined
+/// and both sides are talking.
+///
+/// Owned and not a set of borrows: the loop builds `InterviewContext` and
+/// `RoomIdentities` out of these fields, and a struct that held those views
+/// alongside the values they point at would be borrowing itself. `'a` is the
+/// caller's, carried only by `boot`.
+struct OpenSession<'a> {
+    room: Room,
+    events: tokio::sync::mpsc::UnboundedReceiver<RoomEvent>,
+    agent_identity: String,
+    candidate_identity: String,
+    boot: RuntimeBootstrap<'a>,
+    output_audio: OutputAudio,
+    gemini: crate::gemini::GeminiLiveSession,
+    media: CandidateMedia,
+    turn: TurnState,
+    started_at: Instant,
+}
+
+/// Joins, waits for a candidate, brings up audio and Gemini, and greets.
+///
+/// Split from [`run_room`] because none of it repeats: it runs once, in order,
+/// and every line of it is a step that either succeeds or ends the interview
+/// before it starts. What is left in `run_room` is the part that runs many
+/// times, which is the part worth reading as a loop.
+///
+/// `Ok(None)` is nobody joined. That is not an error: the room was named, the
+/// candidate never arrived, and there is nothing to run or report.
+async fn open_session<'a>(
+    config: &'a AgentConfig,
+    room_name: &'a str,
     now_seconds: u64,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<Option<OpenSession<'a>>, Box<dyn std::error::Error + Send + Sync>> {
     let agent_identity = agent_identity(room_name);
     let (room, mut events) = join_room(config, room_name, &agent_identity, now_seconds).await?;
     let mut agent_state = String::new();
@@ -260,7 +289,7 @@ pub async fn run_room(
         candidate_metadata(&room, &mut events, &mut deferred_events).await?
     else {
         eprintln!("no candidate joined room={room_name}; leaving it");
-        return Ok(());
+        return Ok(None);
     };
     let boot = candidate_bootstrap(config, room_name, Some(&candidate_metadata));
     eprintln!(
@@ -278,7 +307,7 @@ pub async fn run_room(
     // "Neither needs the other's return value" was the wrong test. The
     // dependency is on room state, not on data.
     let setup_began = Instant::now();
-    let (mut output_audio, mut gemini) = tokio::try_join!(
+    let (output_audio, mut gemini) = tokio::try_join!(
         async {
             isolate_local_agent(config, room_name, &agent_identity, now_seconds).await?;
             publish_output_audio(&room, GEMINI_OUTPUT_AUDIO_SAMPLE_RATE).await
@@ -290,17 +319,6 @@ pub async fn run_room(
         setup_began.elapsed().as_secs_f64()
     );
     let started_at = Instant::now();
-    let interview = InterviewContext {
-        config,
-        boot: &boot,
-        started_at,
-    };
-    let ids = RoomIdentities {
-        room_name,
-        agent: &agent_identity,
-        candidate: &candidate_identity,
-        now_seconds,
-    };
 
     let mut turn = TurnState {
         state: RuntimeState::default(),
@@ -327,6 +345,53 @@ pub async fn run_room(
 
     gemini.send_text(&boot.greeting).await?;
     turn.activity.mark_speaking();
+
+    Ok(Some(OpenSession {
+        room,
+        events,
+        agent_identity,
+        candidate_identity,
+        boot,
+        output_audio,
+        gemini,
+        media,
+        turn,
+        started_at,
+    }))
+}
+
+pub async fn run_room(
+    config: &AgentConfig,
+    room_name: &str,
+    now_seconds: u64,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let Some(OpenSession {
+        room,
+        mut events,
+        agent_identity,
+        candidate_identity,
+        boot,
+        mut output_audio,
+        mut gemini,
+        mut media,
+        mut turn,
+        started_at,
+    }) = open_session(config, room_name, now_seconds).await?
+    else {
+        return Ok(());
+    };
+
+    let interview = InterviewContext {
+        config,
+        boot: &boot,
+        started_at,
+    };
+    let ids = RoomIdentities {
+        room_name,
+        agent: &agent_identity,
+        candidate: &candidate_identity,
+        now_seconds,
+    };
 
     let mut resumed = 0usize;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use codetrial::config::{
     AgentConfig, DEFAULT_DURATION_MIN, DEFAULT_ROOM_PREFIX, DEFAULT_WEB_ADDR, DEFAULT_WEB_DIR,
@@ -249,7 +249,7 @@ fn run_web(options: CliOptions) -> Result<(), String> {
         .block_on(async {
             let listener = tokio::net::TcpListener::from_std(listener)?;
             let dispatcher = agent_config.map(|config| {
-                Arc::new(LocalDispatcher {
+                Arc::new(codetrial::dispatch::LocalDispatcher {
                     config,
                     runtime: tokio::runtime::Handle::current(),
                     live: Arc::default(),
@@ -262,103 +262,6 @@ fn run_web(options: CliOptions) -> Result<(), String> {
             .await
         })
         .map_err(|error| format!("web server failed: {error}"))
-}
-
-/// How many interviews one `codetrial web` process will host agents for at
-/// once. Each is a LiveKit room plus a metered Gemini Live session, so an
-/// unbounded count is an unbounded bill; a refused dispatch leaves the
-/// candidate on the "Waiting" pill, which is bad, but recoverable and visible.
-const MAX_CONCURRENT_INTERVIEWS: usize = 16;
-
-/// Runs the interviewer for rooms this process just named, in this process.
-///
-/// The alternative is a LiveKit agent worker registered against the project,
-/// which is the shape LiveKit intends and which survives this process
-/// restarting. This is the smaller thing that makes production work: the room
-/// name is invented in `/api/token` and never leaves this process, so the
-/// process that invented it is the one that can act on it.
-struct LocalDispatcher {
-    /// Everything an interview needs except which LiveKit project it is in:
-    /// that arrives with the room, from the same lookup that minted the token.
-    config: AgentConfig,
-    runtime: tokio::runtime::Handle,
-    live: Arc<Mutex<HashSet<String>>>,
-}
-
-impl RoomDispatcher for LocalDispatcher {
-    fn ensure_agent(&self, room_name: &str, provider: &codetrial::config::Provider) -> bool {
-        {
-            let mut live = self.live.lock().unwrap_or_else(|error| error.into_inner());
-
-            // A reload mints a token for the same fixed room in local mode, and
-            // two agents in one room evict each other.
-            if live.contains(room_name) {
-                return true;
-            }
-            if live.len() >= MAX_CONCURRENT_INTERVIEWS {
-                eprintln!(
-                    "codetrial dispatch_refused room={room_name} reason=at_capacity limit={MAX_CONCURRENT_INTERVIEWS}"
-                );
-                return false;
-            }
-            live.insert(room_name.to_string());
-        }
-        let config = agent_config_for(&self.config, provider);
-
-        // Released by dropping, not by a line at the end of the task: a panic
-        // in the interview would otherwise skip that line and burn the slot for
-        // the life of the process, and sixteen of those refuse every interview
-        // after them.
-        let slot = Slot {
-            live: Arc::clone(&self.live),
-            room_name: room_name.to_string(),
-        };
-
-        // Spawned, not awaited: this runs on the request path, and the task
-        // outlives the response by the length of the interview.
-        self.runtime.spawn(async move {
-            eprintln!("codetrial dispatch room={}", slot.room_name);
-            if let Err(error) = codetrial::livekit::run_room(
-                &config,
-                &slot.room_name,
-                codetrial::web::current_epoch_seconds(),
-            )
-            .await
-            {
-                eprintln!("codetrial agent_failed room={}: {error}", slot.room_name);
-            }
-        });
-        true
-    }
-}
-
-/// One interview's claim on this process's capacity, held for as long as the
-/// task that owns it.
-struct Slot {
-    live: Arc<Mutex<HashSet<String>>>,
-    room_name: String,
-}
-
-impl Drop for Slot {
-    fn drop(&mut self) {
-        self.live
-            .lock()
-            .unwrap_or_else(|error| error.into_inner())
-            .remove(&self.room_name);
-    }
-}
-
-/// The credential half of [`select_provider`], without the pool lookup, for the
-/// caller that was already handed the provider.
-fn agent_config_for(base: &AgentConfig, provider: &codetrial::config::Provider) -> AgentConfig {
-    let mut config = base.clone();
-    config.livekit_url = provider.url.clone();
-    config.livekit_api_key = provider.api_key.clone();
-    config.livekit_api_secret = provider.api_secret.clone();
-    if !provider.google_api_key.is_empty() {
-        config.google_api_key = provider.google_api_key.clone();
-    }
-    config
 }
 
 fn run_serve(options: CliOptions) -> Result<(), String> {
@@ -450,7 +353,7 @@ fn run_serve(options: CliOptions) -> Result<(), String> {
             // constructing the service opens the database, migrates it and
             // sweeps it, all blocking, and doing that inside the serving task
             // parks a worker while the bound listener backs up.
-            let dispatcher = Arc::new(LocalDispatcher {
+            let dispatcher = Arc::new(codetrial::dispatch::LocalDispatcher {
                 config,
                 runtime: tokio::runtime::Handle::current(),
                 live: Arc::default(),
@@ -809,7 +712,6 @@ fn account_db_path(values: &BTreeMap<String, String>) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     fn values(pairs: &[(&str, &str)]) -> super::BTreeMap<String, String> {
         pairs
@@ -888,30 +790,6 @@ mod tests {
                 ("SESSION_SECRET", "a-real-secret"),
             ]))
             .is_empty()
-        );
-    }
-
-    /// The capacity slot is released by dropping, so an interview that panics
-    /// gives its slot back like one that ends. Sixteen leaked slots would
-    /// refuse every interview after them for the life of the process.
-    #[tokio::test]
-    async fn a_panicking_interview_gives_its_capacity_back() {
-        let live = Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
-        live.lock().unwrap().insert("interview-boom".to_string());
-        let slot = super::Slot {
-            live: Arc::clone(&live),
-            room_name: "interview-boom".to_string(),
-        };
-
-        let task = tokio::spawn(async move {
-            let _held = slot;
-            panic!("the interview blew up");
-        });
-        assert!(task.await.is_err(), "the task must have panicked");
-
-        assert!(
-            live.lock().unwrap().is_empty(),
-            "a panicking interview must not keep its slot"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -591,7 +591,16 @@ fn primary_config_path(options: &CliOptions) -> Result<PathBuf, String> {
             return Ok(path);
         }
     }
-    Err("required configuration file is missing: ./config/codetrial.env.local or ./codetrial.env.local; copy config/codetrial.env.example to one of these paths".to_string())
+    // The keys, not a file to copy. `config/codetrial.env.example` exists in a
+    // checkout and nowhere else: the release archives hold the executable and
+    // nothing beside it, so telling someone who just unpacked one to copy it
+    // sends them looking for a file they were never given. Naming what the file
+    // must contain is an instruction both audiences can act on.
+    Err(format!(
+        "required configuration file is missing: ./{DEFAULT_CONFIG_PATH} or ./codetrial.env.local; \
+         write one with LIVEKIT_URL, LIVEKIT_API_KEY and LIVEKIT_API_SECRET \
+         (config/codetrial.env.example lists the optional keys in a checkout)"
+    ))
 }
 
 /// Providers live beside the config file the operator named, so

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,6 +236,7 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     // purpose. The dispatcher never looks a provider up: it is handed the one
     // the token was minted from, so a second scan could only introduce a pool
     // that disagrees with the web side's.
+    let max_concurrent = read_max_concurrent(&values);
     let agent_config = codetrial::config::load_from_pairs(values).ok();
     if agent_config.is_none() {
         eprintln!(
@@ -253,6 +254,7 @@ fn run_web(options: CliOptions) -> Result<(), String> {
                     config,
                     runtime: tokio::runtime::Handle::current(),
                     live: Arc::default(),
+                    max_concurrent,
                 }) as Arc<dyn RoomDispatcher>
             });
             axum::serve(
@@ -290,6 +292,11 @@ fn run_serve(options: CliOptions) -> Result<(), String> {
     let db_path = Some(account_db_path(&values));
     let trusted_proxy_hops = trusted_proxy_hops(&values);
     let recording_values = values.clone();
+
+    // serve hosts one room, so this can only ever refuse a second. It is read
+    // anyway so the two modes cannot disagree about what the operator asked
+    // for.
+    let max_concurrent = read_max_concurrent(&values);
     let provider_order = value_or(&values, codetrial::config::PROVIDER_ORDER_KEY, "");
     let mut config =
         codetrial::config::load_from_pairs(values).map_err(|error| error.to_string())?;
@@ -357,6 +364,7 @@ fn run_serve(options: CliOptions) -> Result<(), String> {
                 config,
                 runtime: tokio::runtime::Handle::current(),
                 live: Arc::default(),
+                max_concurrent,
             }) as Arc<dyn RoomDispatcher>;
             axum::serve(
                 listener,
@@ -575,6 +583,19 @@ fn initialize_accounts(config: &WebServerConfig) -> Result<(), String> {
     codetrial::web::initialize_account_database(&login.db_path)
         .map_err(|error| format!("account database {}: {error}", login.db_path.display()))?;
     Ok(())
+}
+
+/// The dispatcher cap, with anything unusable about it said out loud.
+///
+/// One helper for both modes: a warning printed by web and swallowed by serve
+/// would be the same misconfiguration reported twice differently.
+fn read_max_concurrent(values: &BTreeMap<String, String>) -> usize {
+    let mut warnings = Vec::new();
+    let max_concurrent = codetrial::config::max_concurrent_interviews(values, &mut warnings);
+    for warning in &warnings {
+        eprintln!("{warning}");
+    }
+    max_concurrent
 }
 
 fn is_production(values: &BTreeMap<String, String>) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use codetrial::config::{
 };
 use codetrial::web::{RoomDispatcher, WebServerConfig};
 
-const DEFAULT_CONFIG_DIR: &str = "config";
 const DEFAULT_CONFIG_PATH: &str = "config/codetrial.env.local";
 const DEFAULT_ACCOUNT_DB_PATH: &str = "codetrial.db";
 const DEFAULT_SESSION_SECRET: &str = "codetrial-local-session";
@@ -197,9 +196,8 @@ fn print_help(usage: Option<&str>) {
     );
 }
 
-fn bind_web_listener(values: &BTreeMap<String, String>) -> Result<std::net::TcpListener, String> {
-    let addr = value_or(values, "CODETRIAL_WEB_ADDR", DEFAULT_WEB_ADDR);
-    let listener = std::net::TcpListener::bind(&addr)
+fn bind_web_listener(addr: &str) -> Result<std::net::TcpListener, String> {
+    let listener = std::net::TcpListener::bind(addr)
         .map_err(|error| format!("failed to bind {addr}: {error}"))?;
     listener
         .set_nonblocking(true)
@@ -223,7 +221,13 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     for warning in relaxed_for_local_use(&values) {
         eprintln!("{warning}");
     }
-    let listener = bind_web_listener(&values)?;
+
+    // Beside the other startup warnings and not next to the dispatcher that
+    // consumes it. A cap the operator wrote and this cannot honor is worth
+    // saying before the first thing that can fail: read late, a bad bind or a
+    // half-configured pool ends the process first and the operator never learns
+    // the number in their config file was ignored.
+    let max_concurrent = read_max_concurrent(&values);
 
     // Built straight from the values rather than through `load_from_pairs`:
     // this mode serves HTTP and mints LiveKit tokens, and has no use for the
@@ -231,25 +235,35 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     // a web-only deployment into an empty pool, silently.
     let production = is_production(&values);
     let mut pool = codetrial::config::ProviderPool::default();
-    if let (Some(url), Some(api_key), Some(api_secret)) = (
+    let (url, api_key, api_secret) = match (
         nonempty(&values, "LIVEKIT_URL"),
         nonempty(&values, "LIVEKIT_API_KEY"),
         nonempty(&values, "LIVEKIT_API_SECRET"),
     ) {
-        codetrial::config::validate_livekit_url(&url, production)?;
-        pool.providers.push(codetrial::config::Provider {
-            id: codetrial::config::PRIMARY_PROVIDER_ID.to_string(),
-            url,
-            api_key,
-            api_secret,
-            google_api_key: value_or(&values, "GOOGLE_API_KEY", ""),
-        });
-    }
+        (Some(url), Some(api_key), Some(api_secret)) => (url, api_key, api_secret),
+
+        // Names the file that was actually read. A fixed `config/` in this
+        // message sends anyone running with `--config` or a bare
+        // `./codetrial.env.local` to edit a file the server never opened.
+        _ => {
+            return Err(format!(
+                "missing required LiveKit credentials: set LIVEKIT_URL, LIVEKIT_API_KEY and LIVEKIT_API_SECRET in {}",
+                primary_config_path(&options)?.display()
+            ));
+        }
+    };
+    codetrial::config::validate_livekit_url(&url, production)?;
+    pool.providers.push(codetrial::config::Provider {
+        id: codetrial::config::PRIMARY_PROVIDER_ID.to_string(),
+        url,
+        api_key,
+        api_secret,
+        google_api_key: value_or(&values, "GOOGLE_API_KEY", ""),
+    });
     extend_pool(
         &mut pool,
         production,
         &provider_dir(&options),
-        should_discover_providers(&options),
         &value_or(&values, codetrial::config::PROVIDER_ORDER_KEY, ""),
     );
 
@@ -290,6 +304,7 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     };
 
     initialize_accounts(&config)?;
+    let listener = bind_web_listener(&value_or(&values, "CODETRIAL_WEB_ADDR", DEFAULT_WEB_ADDR))?;
 
     // Whether this process also hosts interviewers. A full agent config, which
     // is a Gemini key on top of what the web side needs, means yes; without it
@@ -300,7 +315,6 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     // purpose. The dispatcher never looks a provider up: it is handed the one
     // the token was minted from, so a second scan could only introduce a pool
     // that disagrees with the web side's.
-    let max_concurrent = read_max_concurrent(&values);
     let agent_config = codetrial::config::load_from_pairs(values).ok();
     if agent_config.is_none() {
         eprintln!(
@@ -332,7 +346,6 @@ fn run_web(options: CliOptions) -> Result<(), String> {
 
 fn run_serve(options: CliOptions) -> Result<(), String> {
     let values = load_values(&options)?;
-    let listener = bind_web_listener(&values).map_err(|error| format!("web side {error}"))?;
 
     // `serve` runs one agent in one room, and `/api/token` only hands out that
     // room while `production` is false. Refusing here beats booting a server
@@ -357,7 +370,7 @@ fn run_serve(options: CliOptions) -> Result<(), String> {
     let trusted_proxy_hops = trusted_proxy_hops(&values);
     let recording_values = values.clone();
 
-    // serve hosts one room, so this can only ever refuse a second. It is read
+    // `serve` hosts one room, so this can only ever refuse a second. It is read
     // anyway so the two modes cannot disagree about what the operator asked
     // for.
     let max_concurrent = read_max_concurrent(&values);
@@ -369,7 +382,6 @@ fn run_serve(options: CliOptions) -> Result<(), String> {
         &mut config.pool,
         false,
         &provider_dir(&options),
-        should_discover_providers(&options),
         &provider_order,
     );
 
@@ -415,6 +427,8 @@ fn run_serve(options: CliOptions) -> Result<(), String> {
     };
 
     initialize_accounts(&web_config)?;
+    let listener =
+        bind_web_listener(&config.web_addr).map_err(|error| format!("web side {error}"))?;
     let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
     runtime
         .block_on(async {
@@ -532,7 +546,6 @@ fn load_agent_config(options: &CliOptions) -> Result<AgentConfig, String> {
         &mut config.pool,
         production,
         &provider_dir(options),
-        should_discover_providers(options),
         &provider_order,
     );
     Ok(config)
@@ -540,17 +553,9 @@ fn load_agent_config(options: &CliOptions) -> Result<AgentConfig, String> {
 
 fn load_values(options: &CliOptions) -> Result<BTreeMap<String, String>, String> {
     let mut values = std::env::vars().collect::<BTreeMap<_, _>>();
-    if std::env::var("CODETRIAL_SKIP_CONFIG").is_err()
-        && std::path::Path::new(DEFAULT_CONFIG_PATH).is_file()
-    {
-        for (key, value) in read_config_file(DEFAULT_CONFIG_PATH)? {
-            values.insert(key, value);
-        }
-    }
-    if let Some(path) = &options.config_path {
-        for (key, value) in read_config_file(path)? {
-            values.insert(key, value);
-        }
+    let path = primary_config_path(options)?;
+    for (key, value) in codetrial::config::read_config_file(&path)? {
+        values.insert(key, value);
     }
     if let Some(value) = &options.web_addr {
         values.insert("CODETRIAL_WEB_ADDR".to_string(), value.clone());
@@ -567,8 +572,26 @@ fn load_values(options: &CliOptions) -> Result<BTreeMap<String, String>, String>
     Ok(values)
 }
 
-fn read_config_file(path: &str) -> Result<Vec<(String, String)>, String> {
-    codetrial::config::read_config_file(std::path::Path::new(path))
+fn primary_config_path(options: &CliOptions) -> Result<PathBuf, String> {
+    if let Some(path) = &options.config_path {
+        let path = PathBuf::from(path);
+        if !path.is_file() {
+            return Err(format!(
+                "required configuration file is missing: {}",
+                path.display()
+            ));
+        }
+        return Ok(path);
+    }
+    for path in [
+        PathBuf::from(DEFAULT_CONFIG_PATH),
+        PathBuf::from("codetrial.env.local"),
+    ] {
+        if path.is_file() {
+            return Ok(path);
+        }
+    }
+    Err("required configuration file is missing: ./config/codetrial.env.local or ./codetrial.env.local; copy config/codetrial.env.example to one of these paths".to_string())
 }
 
 /// Providers live beside the config file the operator named, so
@@ -578,19 +601,27 @@ fn read_config_file(path: &str) -> Result<Vec<(String, String)>, String> {
 /// halves of a deployment are launched with the same `--config`, and that is
 /// what makes them agree on the pool.
 fn provider_dir(options: &CliOptions) -> PathBuf {
-    let Some(path) = options.config_path.as_deref() else {
-        return PathBuf::from(DEFAULT_CONFIG_DIR);
-    };
-    match std::path::Path::new(path).parent() {
+    // The search order comes from primary_config_path rather than being written
+    // out again here. Spelled twice, it was free to drift, and the drift is
+    // silent: the server keeps reading its own config while the pool quietly
+    // collapses to the primary project.
+    //
+    // A named file still decides, even when it is missing. The operator said
+    // where the config lives, and load_values is what refuses a path that is
+    // not there; answering with a different directory would be this function
+    // second-guessing that.
+    let path = options
+        .config_path
+        .as_deref()
+        .map(PathBuf::from)
+        .or_else(|| primary_config_path(options).ok())
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH));
+    match path.parent() {
         // A bare filename has an empty parent, and its siblings are in the
         // working directory, not in `config/`.
         Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
         _ => PathBuf::from("."),
     }
-}
-
-fn should_discover_providers(options: &CliOptions) -> bool {
-    options.config_path.is_some() || std::env::var("CODETRIAL_SKIP_CONFIG").is_err()
 }
 
 /// The pool this process routes with. Discovery happens here, once, and never
@@ -601,16 +632,13 @@ fn extend_pool(
     pool: &mut codetrial::config::ProviderPool,
     production: bool,
     config_dir: &std::path::Path,
-    discover: bool,
     order: &str,
 ) {
-    if discover {
-        let (providers, warnings) = codetrial::config::discover_providers(config_dir, production);
-        for warning in warnings {
-            eprintln!("{warning}");
-        }
-        pool.providers.extend(providers);
+    let (providers, warnings) = codetrial::config::discover_providers(config_dir, production);
+    for warning in warnings {
+        eprintln!("{warning}");
     }
+    pool.providers.extend(providers);
 
     // Outside the `discover` guard: an order naming the environment provider is
     // still an order, and a deployment with discovery off should not silently
@@ -797,7 +825,6 @@ fn account_db_path(values: &BTreeMap<String, String>) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-
     fn values(pairs: &[(&str, &str)]) -> super::BTreeMap<String, String> {
         pairs
             .iter()
@@ -963,15 +990,6 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(super::provider_dir(&options), std::path::PathBuf::from("."));
-    }
-
-    #[test]
-    fn explicit_config_keeps_provider_discovery_when_auto_config_is_skipped() {
-        let options = super::CliOptions {
-            config_path: Some("/etc/codetrial/prod.env".to_string()),
-            ..Default::default()
-        };
-        assert!(super::should_discover_providers(&options));
     }
 
     /// The pair, not the id. `login_config` enables OAuth only when it has

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,23 @@ fn main() {
 }
 
 fn run_agent_command(args: &[String]) -> i32 {
+    // Answered before parsing, and from the raw arguments. `--help` beside a
+    // flag that is missing its value is still a request for help, and a parse
+    // error is not an answer to it. Resolving it here is also why `CliOptions`
+    // carries no help field: nothing downstream ever sees one.
+    if args
+        .iter()
+        .take_while(|arg| *arg != "--")
+        .any(|arg| arg == "--help" || arg == "-h")
+    {
+        print_help(args.iter().find_map(|arg| {
+            MODES
+                .iter()
+                .find(|(name, ..)| name == arg)
+                .map(|(_, _, usage, _)| *usage)
+        }));
+        return 0;
+    }
     let (positionals, options) = match parse_agent_args(args) {
         Ok(parsed) => parsed,
         Err(error) => {
@@ -98,25 +115,51 @@ fn run_agent_command(args: &[String]) -> i32 {
     }
 }
 
+/// Positionals and options, in one pass over the arguments.
+///
+/// Driven by an iterator rather than an index. The index form needed a manual
+/// `index += 1` or `+= 2` on every path, which is one edit away from a loop
+/// that never advances: mutation testing hangs it by turning that `+=` into
+/// `-=`. Nothing here can fail to make progress, because `next` is the only way
+/// forward and it is unconditional.
 fn parse_agent_args(args: &[String]) -> Result<(Vec<String>, CliOptions), String> {
     let mut positionals = Vec::new();
     let mut options = CliOptions::default();
-    let mut index = 0;
-    while index < args.len() {
-        let arg = &args[index];
+    let mut rest = args.iter().peekable();
+    while let Some(arg) = rest.next() {
+        // Everything after a bare `--` is a positional, whatever it looks like.
+        // The escape hatch the separated form below needs: without it there is
+        // no way to name a file whose own name starts with a dash.
+        if arg == "--" {
+            positionals.extend(rest.cloned());
+            break;
+        }
         if !arg.starts_with("--") {
             positionals.push(arg.clone());
-            index += 1;
             continue;
         }
-        let Some(value) = args.get(index + 1) else {
-            return Err(format!("{arg} requires a value"));
+
+        // `--flag=value` or `--flag value`. The attached form is what makes a
+        // dash-prefixed value expressible at all, because in the separated form
+        // a flag in the value slot is a missing value and not the value:
+        // without that rule `--config --help` reports a configuration file
+        // named `--help` instead of printing help. `next_if` is what leaves it
+        // where it is, to be read as the flag it is on the next turn.
+        let (flag, value) = match arg.split_once('=') {
+            Some((flag, value)) => (flag, Some(value.to_string())),
+            None => (
+                arg.as_str(),
+                rest.next_if(|next| !next.starts_with('-')).cloned(),
+            ),
         };
-        match arg.as_str() {
-            "--config" => options.config_path = Some(value.clone()),
-            "--web-addr" => options.web_addr = Some(value.clone()),
-            "--web-dir" => options.web_dir = Some(value.clone()),
-            "--room-prefix" => options.room_prefix = Some(value.clone()),
+        let Some(value) = value else {
+            return Err(format!("{flag} requires a value"));
+        };
+        match flag {
+            "--config" => options.config_path = Some(value),
+            "--web-addr" => options.web_addr = Some(value),
+            "--web-dir" => options.web_dir = Some(value),
+            "--room-prefix" => options.room_prefix = Some(value),
             "--duration-min" => {
                 let duration = value
                     .parse::<u32>()
@@ -126,11 +169,32 @@ fn parse_agent_args(args: &[String]) -> Result<(Vec<String>, CliOptions), String
                 }
                 options.duration_min = Some(duration);
             }
-            _ => return Err(format!("unknown flag: {arg}")),
+            _ => return Err(format!("unknown flag: {flag}")),
         }
-        index += 2;
     }
     Ok((positionals, options))
+}
+
+/// Help, for one mode or for the binary.
+///
+/// One printer rather than two. The mode-specific half was a `println!` beside
+/// a call to the general half, which is a shape that drifts: the options are
+/// the same options either way, and the only difference is whether the modes
+/// are listed above them.
+fn print_help(usage: Option<&str>) {
+    match usage {
+        Some(usage) => println!("usage: {usage}"),
+        None => {
+            println!("usage: codetrial MODE [OPTIONS]\n\nModes:");
+            for (_, _, usage, _) in MODES {
+                println!("  {usage}");
+            }
+            println!("\nRun `codetrial MODE --help` for mode-specific usage.");
+        }
+    }
+    println!(
+        "\nOptions:\n  --config PATH        Use PATH instead of config/codetrial.env.local\n  --web-addr ADDR      Listen on ADDR\n  --web-dir PATH       Serve files from PATH\n  --room-prefix PREFIX Prefix generated room names\n  --duration-min MIN   Set the interview duration\n  -h, --help           Show this help\n\nEvery option also takes `--flag=value`, which is the only way to pass a value\nthat starts with a dash. `--` ends the options."
+    );
 }
 
 fn bind_web_listener(values: &BTreeMap<String, String>) -> Result<std::net::TcpListener, String> {

--- a/src/web/assets.rs
+++ b/src/web/assets.rs
@@ -229,15 +229,33 @@ pub(crate) async fn web_static_handler(
     // store never answers and the probe is pure waste. Once at startup keeps
     // the per-file fallback wherever the directory does exist. The cost is that
     // creating `web/` under a running server needs a restart to take, which is
-    // the more predictable behavior anyway.
-    let from_disk = if state.web_dir_exists {
-        static_response(&state.config.web_dir, uri.path(), if_none_match, head_only).await
-    } else {
-        None
+    // the more predictable behavior anyway. Candidate order beats store order.
+    // Exhausting the disk tree first let its single-page fallback,
+    // `index.html`, answer for a candidate the embed could have matched
+    // exactly: a directory holding one stale `index.html` served it for
+    // `/interview` with a 200, because the disk's fourth candidate was tried
+    // before the embed's third. That is the wrong page rather than a missing
+    // one, which is the failure this resolver argues everywhere else that it
+    // exists to avoid.
+    //
+    // Nothing changes for the two shapes that are not half-populated. A
+    // checkout answers from disk on the same candidate it always did, and a
+    // released binary has no `web/` at all, so the disk store is never asked.
+    let Some(candidates) = static_candidates(uri.path()) else {
+        return StatusCode::NOT_FOUND.into_response();
     };
-    from_disk
-        .or_else(|| embedded_static_response(uri.path(), if_none_match, head_only))
-        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response())
+    for candidate in candidates {
+        if state.web_dir_exists
+            && let Some(response) =
+                disk_candidate(&state.config.web_dir, &candidate, if_none_match, head_only).await
+        {
+            return response;
+        }
+        if let Some(response) = embedded_candidate(&candidate, if_none_match, head_only) {
+            return response;
+        }
+    }
+    StatusCode::NOT_FOUND.into_response()
 }
 
 pub(crate) async fn runtime_config_handler(State(state): State<AppState>) -> Response {
@@ -386,18 +404,21 @@ impl AssetHeaders {
         response
     }
 }
-
-/// `None` where the disk tree cannot answer, which is what lets the caller
-/// fall through to the embedded store by composition rather than by reading a
-/// status code back off a response it just built.
-pub(crate) async fn static_response(
+/// One already-resolved candidate against the disk tree.
+///
+/// The candidate arrives resolved because `static_candidates` runs once for
+/// both stores: expanding it again here would be a second copy of the rule that
+/// decides what a URL may name, which is the one rule in this file that must
+/// not have two.
+async fn disk_candidate(
     root: &Path,
-    path: &str,
+    candidate: &str,
     if_none_match: Option<&HeaderValue>,
     head_only: bool,
 ) -> Option<Response> {
-    let (key, path, metadata) = static_file_meta(root, path).await?;
-    let headers = AssetHeaders::new(&key, file_etag(&metadata), metadata.len());
+    let path = root.join(candidate);
+    let metadata = file_metadata(&path).await?;
+    let headers = AssetHeaders::new(candidate, file_etag(&metadata), metadata.len());
     if let Some(not_modified) = headers.not_modified(if_none_match) {
         return Some(not_modified);
     }
@@ -409,25 +430,22 @@ pub(crate) async fn static_response(
     Some(headers.respond(Some(Body::from(bytes))))
 }
 
-/// The same rules against the web tree compiled into the executable.
-///
-/// The shipped binary has no `web/` at all, so this is the only path a
-/// released install takes. That is why it carries the disk path's caching
-/// rather than a simpler set: answering 37 MB of pinned wasm with a bare
-/// `no-cache` and no validator would re-send the tree on every navigation.
-fn embedded_static_response(
-    path: &str,
+/// One already-resolved candidate against the embedded tree.
+fn embedded_candidate(
+    candidate: &str,
     if_none_match: Option<&HeaderValue>,
     head_only: bool,
 ) -> Option<Response> {
-    let (key, file) = static_candidates(path)?
-        .into_iter()
-        .find_map(|candidate| EmbeddedWeb::get(&candidate).map(|file| (candidate, file)))?;
+    let file = EmbeddedWeb::get(candidate)?;
 
     // Strong, unlike the disk path's modification-time heuristic: these bytes
     // cannot change without a rebuild, and `rust-embed` already carries their
     // SHA-256, so nothing is hashed per request.
-    let headers = AssetHeaders::new(&key, Some(embedded_etag(&file)), file.data.len() as u64);
+    let headers = AssetHeaders::new(
+        candidate,
+        Some(embedded_etag(&file)),
+        file.data.len() as u64,
+    );
     if let Some(not_modified) = headers.not_modified(if_none_match) {
         return Some(not_modified);
     }

--- a/src/web/assets.rs
+++ b/src/web/assets.rs
@@ -87,11 +87,15 @@ pub(crate) fn warn_about_unfetched_vendor(web_dir: &Path) {
     }
 }
 
-/// The resolved path together with the `stat` that resolved it. Handed back
-/// rather than thrown away because `static_response` needs the same metadata
-/// for
-/// the ETag and the content length, and asking the kernel twice for an answer
-/// this walk already has is one syscall per request for nothing.
+/// The first candidate that exists on disk, with the `stat` that found it.
+///
+/// The handler resolves one candidate at a time now, because candidate order
+/// has to beat store order, so nothing on the request path walks the whole list
+/// against a single store any more. What is left is the shape the resolution
+/// tests want: a question about which file a URL names, answered without a
+/// server. It shares `static_candidates` with the handler, so the rule that
+/// decides what a URL may name still has one owner and these tests still ask
+/// the real one.
 pub async fn static_file_meta(
     root: &Path,
     path: &str,

--- a/tests/browser/avatar.test.js
+++ b/tests/browser/avatar.test.js
@@ -592,3 +592,19 @@ test("avatar analyser reads Jim and never the candidate", () => {
   // A context built outside a user gesture starts suspended and reads silence.
   assert.match(script, /jimAnalyserContext\.state === "suspended"/);
 });
+
+test("avatar teardown cancels a deferred width retry", () => {
+  const release = functionBody(script, "stopWatchingStageWidth");
+  assert.match(release, /window\.removeEventListener\("resize", stageWidthWatch\);/);
+  assert.match(release, /stageWidthWatch = null;/);
+  // Both ends: teardown drops it, and so does a start that succeeds. Waiting
+  // for the next resize to notice would hold the handler for a session that
+  // never resizes again.
+  for (const caller of ["stopAvatar", "startAvatar"]) {
+    assert.match(
+      functionBody(script, caller),
+      /stopWatchingStageWidth\(\)/,
+      `${caller} must release the width watch`,
+    );
+  }
+});

--- a/tests/browser/avatar.test.js
+++ b/tests/browser/avatar.test.js
@@ -9,7 +9,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { captures, firstPartyScripts, functionBody, read, root } from "./source.js";
+import { captures, firstPartyScripts, functionBody, interviewSource, read, root } from "./source.js";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
@@ -33,7 +33,7 @@ import {
 } from "../../web/avatar/avatar.js";
 
 const page = read("web/interview.html");
-const script = read("web/interview.js");
+const script = interviewSource();
 
 // A mount is a dataset and nothing else, which is the whole reason avatar.js
 // may not reach for anything richer.
@@ -127,8 +127,12 @@ test("avatar dom contract", () => {
   assert.deepEqual(importers, ["avatar/vrm.js"]);
 
   // And it is loaded lazily, so a candidate who never starts an interview never
-  // downloads 730 KB of renderer.
-  assert.match(script, /import\("\.\/avatar\/vrm\.js"\)/);
+  // downloads 730 KB of renderer. The specifier is relative to the file that
+  // holds it, which is why this names the resolved path rather than the literal
+  // one: it followed the loader out of interview.js into web/avatar/, where the
+  // spelling that had been correct named a file one directory too deep.
+  const lazy = captures(read("web/avatar/stage.js"), /import\("(\.[^"]+)"\)/g);
+  assert.deepEqual(lazy, ["./vrm.js"], "the renderer is imported lazily, from beside the stage");
   assert.doesNotMatch(script, /^import .*avatar\/vrm\.js/m);
 });
 
@@ -429,7 +433,7 @@ test("avatar canvas has an accessible name", () => {
 });
 
 test("avatar stops rendering while the page is hidden", () => {
-  const script = read("web/interview.js");
+  const script = interviewSource();
   const pump = functionBody(script, "pumpAvatar");
   assert.match(
     pump,
@@ -530,6 +534,15 @@ test("captions size to the turn and retire when nobody is speaking", () => {
   assert.match(show, /setTimeout\([\s\S]*?nodes\.captionsBar\.hidden = true;[\s\S]*?CAPTION_IDLE_HIDE_MS\)/);
   assert.match(script, /nodes\.captionsText\.textContent = `\[\$\{speaker[^`]*`;\n\s*showCaptions\(\);/,
     "every caption update must un-hide the bar");
+
+  // The reveal has to keep asking for the next tick while there is more of the
+  // turn to show. Dropping the re-arm leaves Jim's line frozen part-way through
+  // a sentence, which reads as a stall rather than as a bug.
+  const pace = functionBody(script, "paceInterviewerCaption");
+  assert.match(pace, /caption\.timer = setTimeout\(paceInterviewerCaption, CAPTION_TICK_MS\);/,
+    "an unfinished turn must schedule its next tick");
+  assert.match(pace, /caption\.shown < caption\.text\.length/,
+    "and stop scheduling once the whole turn is on screen");
 });
 
 test("avatar analyser reads Jim and never the candidate", () => {
@@ -548,7 +561,7 @@ test("avatar analyser reads Jim and never the candidate", () => {
   assert.match(functionBody(script, "attachAvatarAnalyser"), /if \(!isAgent\(participant\)\) return;/);
   // And the teardown is gated on the analyser's own track, or a second
   // participant leaving killed lip sync for the rest of the session.
-  assert.match(script, /if \(track !== jimAnalyserTrack\) return;/);
+  assert.match(script, /if \(!isAvatarAnalyserTrack\(track\)\) return;/);
   // Never the microphone, checked across the whole file rather than inside one
   // function slice: wiring the candidate's stream in from anywhere else would
   // have passed a slice-scoped assertion while the avatar watched the candidate.
@@ -567,7 +580,7 @@ test("avatar analyser reads Jim and never the candidate", () => {
   // case the audio-driven mouth exists to survive, and a review caught it after
   // it had already been written back in once.
   const branch = functionBody(script, "updateAgentState").split("state.sawAgent = true")[0];
-  assert.doesNotMatch(branch, /setSpeaking\(/,
+  assert.doesNotMatch(branch, /setAvatarSpeaking\(/,
     "the no-agent branch must not mute the mouth; silence closes it on its own");
 
   // The source node is released, not just dropped. LiveKit re-subscribes Jim on

--- a/tests/browser/dom-contract.test.js
+++ b/tests/browser/dom-contract.test.js
@@ -8,13 +8,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
-  firstPartyScripts,
   INTERVIEW_SOURCES,
   captures as matchAll,
   functionBody,
   initialisedModules,
   interviewSource,
   root,
+  firstPartyScripts,
 } from "./source.js";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -458,14 +458,6 @@ test("the interview path is read whole", () => {
   );
 });
 
-test("runner progress statuses stay wired to each execution path", () => {
-  const script = read("runners.js");
-
-  assert.match(script, /onStatus = null/);
-  assert.match(script, /reportStatus\??\.\("booting"\)|reportStatus\("booting"\)/);
-  assert.match(script, /reportStatus\??\.\("compiling"\)|reportStatus\("compiling"\)/);
-  assert.match(script, /reportStatus\??\.\("running"\)|reportStatus\("running"\)/);
-});
 
 /// Every relative import in every first-party script resolves to a file.
 ///
@@ -489,4 +481,13 @@ test("relative imports resolve to files that exist", () => {
     }
   }
   assert.deepEqual(missing, [], "these specifiers name nothing on disk");
+});
+
+test("runner progress statuses stay wired to each execution path", () => {
+  const script = read("runners.js");
+
+  assert.match(script, /onStatus = null/);
+  assert.match(script, /reportStatus\??\.\("booting"\)|reportStatus\("booting"\)/);
+  assert.match(script, /reportStatus\??\.\("compiling"\)|reportStatus\("compiling"\)/);
+  assert.match(script, /reportStatus\??\.\("running"\)|reportStatus\("running"\)/);
 });

--- a/tests/browser/dom-contract.test.js
+++ b/tests/browser/dom-contract.test.js
@@ -7,9 +7,17 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { captures as matchAll, functionBody, root } from "./source.js";
-import { readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import {
+  firstPartyScripts,
+  INTERVIEW_SOURCES,
+  captures as matchAll,
+  functionBody,
+  initialisedModules,
+  interviewSource,
+  root,
+} from "./source.js";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 
 const web = join(root, "web");
 const read = (name) => readFileSync(join(web, name), "utf8");
@@ -229,7 +237,7 @@ test("the interview page keeps the structure the script drives", () => {
   );
   assert.match(page, /data-language="python"/, "the language tabs drive setLanguage");
   assert.match(page, /C, C\+\+ and Java runs are sent to Compiler Explorer/, "compiled language runs need third-party disclosure");
-  const script = read("interview.js");
+  const script = interviewSource();
   assert.match(script, /CODETRIAL_COMPILER_EXPLORER_ENABLED !== false/);
   assert.match(script, /C, C\+\+ and Java test runs are disabled by this server/);
   assert.match(page, /id="audio-step-camera"/, "preflight must expose camera readiness");
@@ -251,7 +259,7 @@ test("the interview page keeps the structure the script drives", () => {
 });
 
 test("output confirmation is required but not blocked by tone timing", () => {
-  const script = read("interview.js");
+  const script = interviewSource();
   const heardHandler = script.slice(
     script.indexOf("const confirmOutput ="),
     script.indexOf("nodes.audioJoin.addEventListener"),
@@ -300,7 +308,7 @@ test("a replacement preflight camera gets a fresh face check", () => {
 // than an error, so nothing asked the pool to look again and the media gate,
 // which has no bypass, stayed shut for the rest of the preflight.
 test("a preflight microphone that goes away is asked for again", () => {
-  const script = read("interview.js");
+  const script = interviewSource();
   // One loop covers both kinds, so the microphone is no longer the case that
   // can be forgotten: naming a kind here is what asks the pool to look again.
   assert.match(script,
@@ -344,7 +352,7 @@ test("runtime config can withdraw compiled language test runs", async () => {
 // microphone and camera live and the integrity heartbeat still sampling while
 // the candidate read their result.
 test("every report path releases the camera and microphone", () => {
-  const script = read("interview.js");
+  const script = interviewSource();
   const body = functionBody(script, "renderReport");
 
   assert.match(body, /stopLocalMedia\(\);/, "renderReport must release the devices");
@@ -361,7 +369,7 @@ test("every report path releases the camera and microphone", () => {
 // stayed true, the UI said nothing, and `publish` silently discarded every code
 // update, test result and integrity event for the rest of the session.
 test("a dropped connection is visible and recovers its state", () => {
-  const script = read("interview.js");
+  const script = interviewSource();
   const connect = functionBody(script, "connectLiveKit");
 
   for (const event of ["Reconnecting", "Reconnected", "Disconnected"]) {
@@ -379,7 +387,7 @@ test("a dropped connection is visible and recovers its state", () => {
 // writes candidate-facing text for exactly this; dropping it on the floor is
 // what makes a refusal indistinguishable from the product working.
 test("a refused interview says why instead of silently practising", () => {
-  const script = read("interview.js");
+  const script = interviewSource();
   const connect = functionBody(script, "connect");
 
   assert.match(connect, /setBanner\("connection", `\$\{error\?\.message/);
@@ -393,7 +401,7 @@ test("a refused interview says why instead of silently practising", () => {
 // One banner element with several owners, ranked, so a new owner is a row here
 // rather than another boolean lock and another branch.
 test("the presence banner ranks its owners instead of racing them", () => {
-  const script = read("interview.js");
+  const script = interviewSource();
   assert.match(script, /const BANNER_RANK = \{[^}]*session[^}]*connection[^}]*interviewer[^}]*face[^}]*\}/);
   // Every owner keeps a slot, so a warning raised behind a higher-ranked one is
   // deferred rather than discarded.
@@ -430,6 +438,26 @@ test("no test runner executes candidate code on the main thread", () => {
   assert.doesNotMatch(script, /cdn\.jsdelivr\.net/);
 });
 
+
+/// The whole-path assertions in this file and four others read
+/// `INTERVIEW_SOURCES`. A cluster split out of `interview.js` and not added to
+/// it is not a failing test: it is five tests that quietly stop covering the
+/// code that moved, which is the fail-open `source.js` was written to warn
+/// about. So the list is checked against the source rather than trusted.
+test("the interview path is read whole", () => {
+  const derived = initialisedModules().sort();
+  const listed = INTERVIEW_SOURCES.filter((name) => name !== "web/interview.js").sort();
+  assert.deepEqual(
+    derived,
+    listed,
+    "every module interview.js hands its bindings to must be in INTERVIEW_SOURCES, and nothing else",
+  );
+  assert.ok(
+    INTERVIEW_SOURCES.includes("web/interview.js"),
+    "the page script itself is part of the path",
+  );
+});
+
 test("runner progress statuses stay wired to each execution path", () => {
   const script = read("runners.js");
 
@@ -437,4 +465,28 @@ test("runner progress statuses stay wired to each execution path", () => {
   assert.match(script, /reportStatus\??\.\("booting"\)|reportStatus\("booting"\)/);
   assert.match(script, /reportStatus\??\.\("compiling"\)|reportStatus\("compiling"\)/);
   assert.match(script, /reportStatus\??\.\("running"\)|reportStatus\("running"\)/);
+});
+
+/// Every relative import in every first-party script resolves to a file.
+///
+/// A specifier is relative to the file holding it, so moving code between
+/// directories silently breaks one: the avatar stage carried
+/// `import("./avatar/vrm.js")` out of `web/interview.js` into `web/avatar/`,
+/// where it named `web/avatar/avatar/vrm.js`. Nothing caught it, because a
+/// source-text assertion matches the string and the dynamic import only runs
+/// after the model HEAD succeeds, which needs a published model.
+test("relative imports resolve to files that exist", () => {
+  const missing = [];
+  for (const name of firstPartyScripts()) {
+    const source = read(name);
+    const dir = dirname(join(root, "web", name));
+    const specifiers = [
+      ...matchAll(source, /(?:^|[^\w])import\s+[^;]*?from\s+"(\.[^"]+)"/g),
+      ...matchAll(source, /import\("(\.[^"]+)"\)/g),
+    ];
+    for (const specifier of specifiers) {
+      if (!existsSync(resolve(dir, specifier))) missing.push(`web/${name} -> ${specifier}`);
+    }
+  }
+  assert.deepEqual(missing, [], "these specifiers name nothing on disk");
 });

--- a/tests/browser/face-detector.test.js
+++ b/tests/browser/face-detector.test.js
@@ -11,6 +11,8 @@
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
@@ -25,10 +27,22 @@ try {
   chromium = null;
 }
 
-const PORT = 38431;
-const BASE = `http://127.0.0.1:${PORT}/`;
+/// Asked for rather than picked. A fixed port collides with a second copy of
+/// this suite and with whatever else on the machine happened to want it, and
+/// the failure reads as a broken server rather than a busy port.
+async function freePort() {
+  const probe = createServer();
+  await new Promise((ready) => probe.listen(0, "127.0.0.1", ready));
+  const { port } = probe.address();
+  await new Promise((closed) => probe.close(closed));
+  return port;
+}
+
+let PORT = 0;
+let BASE = "";
 let server = null;
 let browser = null;
+const configPath = resolve(root, "target/face-detector-test.env");
 
 async function reachable() {
   for (let attempt = 0; attempt < 100; attempt += 1) {
@@ -45,6 +59,8 @@ async function reachable() {
 
 before(async () => {
   if (!chromium) return;
+  PORT = await freePort();
+  BASE = `http://127.0.0.1:${PORT}/`;
   try {
     browser = await chromium.launch();
   } catch {
@@ -52,13 +68,18 @@ before(async () => {
     browser = null;
     return;
   }
+  // `target/` is missing on a clean checkout. Creating it keeps a missing
+  // build a skipped suite, which is what the chromium guard above already
+  // does, rather than an ENOENT thrown out of `before`.
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, "LIVEKIT_URL=wss://example.livekit.cloud\nLIVEKIT_API_KEY=face-detector-key\nLIVEKIT_API_SECRET=face-detector-secret\n");
   server = spawn(
     resolve(root, "target/debug/codetrial"),
-    ["web", "--web-addr", `127.0.0.1:${PORT}`, "--web-dir", resolve(root, "web")],
+    ["web", "--config", configPath, "--web-addr", `127.0.0.1:${PORT}`, "--web-dir", resolve(root, "web")],
     {
       cwd: root,
       stdio: "ignore",
-      env: { ...process.env, CODETRIAL_SKIP_CONFIG: "1", CODETRIAL_DB_PATH: resolve(root, "target/face-detector-test.db") },
+      env: { ...process.env, CODETRIAL_DB_PATH: resolve(root, "target/face-detector-test.db") },
     },
   );
   if (!(await reachable())) {
@@ -70,6 +91,7 @@ before(async () => {
 after(async () => {
   await browser?.close();
   server?.kill();
+  rmSync(configPath, { force: true });
 });
 
 /// Draws something BlazeFace recognises without needing a photograph checked

--- a/tests/browser/face-detector.test.js
+++ b/tests/browser/face-detector.test.js
@@ -12,7 +12,7 @@ import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { createServer } from "node:net";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
@@ -28,8 +28,14 @@ try {
 }
 
 /// Asked for rather than picked. A fixed port collides with a second copy of
-/// this suite and with whatever else on the machine happened to want it, and
-/// the failure reads as a broken server rather than a busy port.
+/// this suite and with whatever else on the machine happened to want it.
+///
+/// The probe frees the port before the server binds it, so this is a hint and
+/// not a reservation: two concurrent runs can be handed the same just-freed
+/// number. `startServer` retries on that rather than pretending it cannot
+/// happen, and a server that still will not come up fails the suite instead of
+/// skipping, because a skip here reads as "nothing to test" when what happened
+/// is "the test never ran".
 async function freePort() {
   const probe = createServer();
   await new Promise((ready) => probe.listen(0, "127.0.0.1", ready));
@@ -40,6 +46,7 @@ async function freePort() {
 
 let PORT = 0;
 let BASE = "";
+const binary = resolve(root, "target/debug/codetrial");
 let server = null;
 let browser = null;
 const configPath = resolve(root, "target/face-detector-test.env");
@@ -59,8 +66,6 @@ async function reachable() {
 
 before(async () => {
   if (!chromium) return;
-  PORT = await freePort();
-  BASE = `http://127.0.0.1:${PORT}/`;
   try {
     browser = await chromium.launch();
   } catch {
@@ -68,24 +73,39 @@ before(async () => {
     browser = null;
     return;
   }
+  // An unbuilt checkout is the one honest reason to skip, so it is the only
+  // one: everything past this point either serves or fails.
+  if (!existsSync(binary)) {
+    server = null;
+    return;
+  }
   // `target/` is missing on a clean checkout. Creating it keeps a missing
   // build a skipped suite, which is what the chromium guard above already
   // does, rather than an ENOENT thrown out of `before`.
   mkdirSync(dirname(configPath), { recursive: true });
   writeFileSync(configPath, "LIVEKIT_URL=wss://example.livekit.cloud\nLIVEKIT_API_KEY=face-detector-key\nLIVEKIT_API_SECRET=face-detector-secret\n");
-  server = spawn(
-    resolve(root, "target/debug/codetrial"),
-    ["web", "--config", configPath, "--web-addr", `127.0.0.1:${PORT}`, "--web-dir", resolve(root, "web")],
-    {
-      cwd: root,
-      stdio: "ignore",
-      env: { ...process.env, CODETRIAL_DB_PATH: resolve(root, "target/face-detector-test.db") },
-    },
-  );
-  if (!(await reachable())) {
+
+  // Three ports before giving up. A lost race is a fresh number and another
+  // try; three lost in a row is not a race any more.
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    PORT = await freePort();
+    BASE = `http://127.0.0.1:${PORT}/`;
+    server = spawn(
+      binary,
+      ["web", "--config", configPath, "--web-addr", `127.0.0.1:${PORT}`, "--web-dir", resolve(root, "web")],
+      {
+        cwd: root,
+        stdio: "ignore",
+        env: { ...process.env, CODETRIAL_DB_PATH: resolve(root, "target/face-detector-test.db") },
+      },
+    );
+    if (await reachable()) return;
     server.kill();
     server = null;
   }
+  // Built, launched, and never answered. Skipping here would report the same
+  // thing as an unbuilt checkout, and the two are not the same thing at all.
+  throw new Error(`the server never answered on 127.0.0.1:${PORT} after three ports`);
 });
 
 after(async () => {

--- a/tests/browser/face-detector.test.js
+++ b/tests/browser/face-detector.test.js
@@ -12,10 +12,10 @@ import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { createServer } from "node:net";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 const require = createRequire(import.meta.url);
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -49,7 +49,17 @@ let BASE = "";
 const binary = resolve(root, "target/debug/codetrial");
 let server = null;
 let browser = null;
-const configPath = resolve(root, "target/face-detector-test.env");
+
+/// The config file and the account database, in a directory this run owns.
+///
+/// Fixed paths under `target/` were the other half of the port collision. Two
+/// copies of this suite wrote the same config, and whichever finished first
+/// removed it in `after` while the other was still starting its server, which
+/// the binary answers by refusing to boot: a missing primary config is a
+/// refusal now, not a fall back to the environment. They shared one SQLite file
+/// on top of that. Made per run rather than reference-counted, because a
+/// directory is the smallest thing that makes the question not arise.
+let workDir = null;
 
 async function reachable() {
   for (let attempt = 0; attempt < 100; attempt += 1) {
@@ -79,10 +89,13 @@ before(async () => {
     server = null;
     return;
   }
-  // `target/` is missing on a clean checkout. Creating it keeps a missing
-  // build a skipped suite, which is what the chromium guard above already
-  // does, rather than an ENOENT thrown out of `before`.
-  mkdirSync(dirname(configPath), { recursive: true });
+  // `target/` is missing on a clean checkout, and `mkdtemp` needs its parent.
+  // Creating it keeps a missing build a skipped suite, which is what the
+  // chromium guard above already does, rather than an ENOENT thrown out of
+  // `before`.
+  mkdirSync(resolve(root, "target"), { recursive: true });
+  workDir = mkdtempSync(join(root, "target", "face-detector-"));
+  const configPath = join(workDir, "codetrial.env.local");
   writeFileSync(configPath, "LIVEKIT_URL=wss://example.livekit.cloud\nLIVEKIT_API_KEY=face-detector-key\nLIVEKIT_API_SECRET=face-detector-secret\n");
 
   // Three ports before giving up. A lost race is a fresh number and another
@@ -96,7 +109,7 @@ before(async () => {
       {
         cwd: root,
         stdio: "ignore",
-        env: { ...process.env, CODETRIAL_DB_PATH: resolve(root, "target/face-detector-test.db") },
+        env: { ...process.env, CODETRIAL_DB_PATH: join(workDir, "accounts.db") },
       },
     );
     if (await reachable()) return;
@@ -111,7 +124,7 @@ before(async () => {
 after(async () => {
   await browser?.close();
   server?.kill();
-  rmSync(configPath, { force: true });
+  if (workDir) rmSync(workDir, { recursive: true, force: true });
 });
 
 /// Draws something BlazeFace recognises without needing a photograph checked

--- a/tests/browser/meet-tab-audio.test.js
+++ b/tests/browser/meet-tab-audio.test.js
@@ -113,6 +113,13 @@ test("sink routing keeps the preference and the real sink in agreement", () => {
   // Refused with nothing to fall back to: no preference at all, so the caller
   // clears the key rather than persisting the device that just failed.
   assert.equal(outputAfterRouting(null, "new", false), null);
+  // Reapplying a stored preference passes the same id as both, so there is no
+  // earlier device to fall back to. Returning it would write the refused id
+  // back and retry it on every reload.
+  assert.equal(outputAfterRouting("same", "same", false), "",
+    "a refused reapply must clear the preference, not re-store it");
+  assert.equal(outputAfterRouting("same", "same", true), "same",
+    "and a reapply that works keeps it");
 });
 
 // What the executable tests above cannot see: that interview.js actually wires
@@ -126,10 +133,24 @@ test("sink routing", () => {
   assert.match(script, /outputOptions\(devices, readStored\(AUDIO_OUTPUT_KEY\)\)/, "the selector is built from the shared decision");
   // Persist before routing. A choice made during the preflight, before Jim's
   // track exists, is dropped if it only survives a successful setSinkId.
-  const apply = script.slice(script.indexOf("async function applyAudioOutput"));
+  // `applyAudioOutput` is the queue in front of this; the routing itself is
+  // what has to get the order right.
+  const apply = script.slice(script.indexOf("async function routeAudioOutput"));
   assert.ok(
     apply.indexOf("writeStored(AUDIO_OUTPUT_KEY") < apply.indexOf(".setSinkId("),
-    "applyAudioOutput must persist before it routes",
+    "routing must persist before it routes",
+  );
+  // Serialized and stamped. Two picks in flight can settle in either order, and
+  // the older one must not write its device over the newer one's.
+  assert.match(
+    script,
+    /routingChain = routingChain\.then\(\(\) => routeAudioOutput\(deviceId, \+\+routingRequest\)\)/,
+    "routing requests are serialized",
+  );
+  assert.match(
+    apply,
+    /if \(request !== routingRequest\) return;/,
+    "and a superseded request does not get the last word on the preference",
   );
   assert.match(apply, /outputAfterRouting\(previous, deviceId, routed\)/, "rollback comes from the tested decision");
   // One element for the session, and it is released on unsubscribe.

--- a/tests/browser/meet-tab-audio.test.js
+++ b/tests/browser/meet-tab-audio.test.js
@@ -11,13 +11,13 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { firstPartyScripts as webScripts, root } from "./source.js";
+import { firstPartyScripts as webScripts, interviewSource, root } from "./source.js";
 import { outputAfterRouting, outputOptions } from "../../web/meet-audio.js";
 
 const web = join(root, "web");
 const read = (name) => readFileSync(join(web, name), "utf8");
 const page = read("interview.html");
-const script = read("interview.js");
+const script = interviewSource();
 
 // vendor/ is third-party and legitimately contains these strings, so the shared
 // helper excludes it by path. Recursive, so a bridge added under web/avatar/ or

--- a/tests/browser/recording-consent.test.js
+++ b/tests/browser/recording-consent.test.js
@@ -13,10 +13,13 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { functionBody, read } from "./source.js";
+import { functionBody, interviewSource, read } from "./source.js";
 
 const page = read("web/interview.html");
-const script = read("web/interview.js");
+// The consent path spans the page script and the replay queue it starts
+// and stops, so both read as one text: an assertion that consent closes
+// the feed must not be satisfiable by the feed moving to a sibling file.
+const script = interviewSource();
 
 /// Source with line comments removed.
 ///
@@ -159,6 +162,21 @@ test("recording-consent is recorded before a token is asked for", () => {
     /interviewId/.test(body.slice(token)),
     "and the token request carries the interview the consent belongs to",
   );
+});
+
+
+/// The poll outlives the room otherwise: a request every fifteen seconds about
+/// an interview that ended, asking for a word that will not change again.
+test("the recording poll is stopped, not just abandoned", () => {
+  const stop = withoutComments(functionBody(script, "stopRecordingPoll"));
+  assert.ok(stop.includes("clearInterval(recordingPoll);"), "the interval must be cleared");
+  assert.ok(stop.includes("recordingPoll = null;"), "and the handle dropped so a restart cannot double it");
+  for (const caller of ["pollRecordingState", "showRecordingState"]) {
+    assert.ok(
+      withoutComments(functionBody(script, caller)).includes("stopRecordingPoll()"),
+      `${caller} must stop the poll rather than leave it running`,
+    );
+  }
 });
 
 test("recording-consent sends the version it displayed", () => {

--- a/tests/browser/recording-template.test.js
+++ b/tests/browser/recording-template.test.js
@@ -306,14 +306,29 @@ test("replay-producer envelope", () => {
     "the version comes from the server, because a second spelling of it refuses every event",
   );
 
-  const flush = withoutComments(functionBody(interview, "flushReplay"));
+  // The batch send lives in `sendQueuedBatch`; `flushReplay` is the queue in
+  // front of it that keeps two POSTs from committing out of order.
+  const flush = withoutComments(functionBody(interview, "sendQueuedBatch"));
   assert.ok(
     flush.includes("replayQueue.splice(0, REPLAY_MAX_BATCH)"),
     "batched to the server's own limit",
   );
+  const chain = withoutComments(functionBody(interview, "flushReplay"));
   assert.ok(
-    flush.includes("if (response.status === 413 || response.status === 404) closeReplay();"),
-    "over quota or consent withdrawn: the server will refuse everything after this",
+    chain.includes("flushChain = flushChain.then(sendQueuedBatch);"),
+    "flushes are serialized, or the replay is ordered by whichever request finished first",
+  );
+  assert.ok(
+    flush.includes("if (response.status === 404) {") && flush.includes("closeReplay();"),
+    "consent withdrawn: the server will refuse everything after this",
+  );
+  assert.ok(
+    flush.includes('if (code === "replay_quota_exceeded") closeReplay();'),
+    "and quota, which is the only 413 that is about the interview rather than the batch",
+  );
+  assert.ok(
+    !/status === 413\s*\|\|/.test(flush) && !/\|\|\s*response\.status === 413/.test(flush),
+    "a `replay_batch_too_large` must not close the feed: one oversized paste would end the replay",
   );
   const close = withoutComments(functionBody(interview, "closeReplay"));
   assert.ok(close.includes("replayClosed = true;"));
@@ -377,9 +392,14 @@ test("replay-producer tests", () => {
 });
 
 test("replay-producer stage", () => {
+  const payload = withoutComments(functionBody(interview, "stagePayload"));
+  assert.ok(
+    payload.includes("title: problem.title, meta: nodes.meta.textContent"),
+    "the problem heading is assembled in one place",
+  );
   const stage = withoutComments(functionBody(interview, "recordStage"));
   assert.ok(
-    stage.includes('recordReplay("stage", { title: problem.title, meta: nodes.meta.textContent });'),
+    stage.includes('recordReplay("stage", stagePayload());'),
     "the problem heading is sent, not assembled twice",
   );
   const problem = withoutComments(functionBody(interview, "renderProblem"));
@@ -404,7 +424,13 @@ test("replay-producer stage", () => {
     stageTick.includes("Date.now() - replayStageAt < REPLAY_STAGE_MS"),
     "the stage repeat must still be throttled, wherever the guard lives",
   );
-  assert.ok(stageTick.includes('recordReplay("stage", { remainingSeconds });'));
+  // Through `stagePayload`, so the tick carries the heading too. `stage` is a
+  // snapshot kind: the newest one supersedes the rest, so a tick that sent only
+  // the seconds would blank the problem title for a late replay reader.
+  assert.ok(
+    stageTick.includes('recordReplay("stage", stagePayload({ remainingSeconds }));'),
+    "every stage event carries the heading, or the newest one erases it",
+  );
   assert.ok(
     /const REPLAY_STAGE_MS = 15000;/.test(interview),
     "a second-by-second clock would be most of the per-interview budget",

--- a/tests/browser/recording-template.test.js
+++ b/tests/browser/recording-template.test.js
@@ -12,9 +12,9 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { functionBody, read } from "./source.js";
+import { functionBody, read, interviewSource } from "./source.js";
 
-const interview = withoutInterviewComments(read("web/interview.js"));
+const interview = withoutInterviewComments(interviewSource());
 const page = read("web/recording/index.html");
 const script = read("web/recording/recording.js");
 const styles = read("web/recording/recording.css");
@@ -396,10 +396,15 @@ test("replay-producer stage", () => {
 
   const timer = withoutComments(functionBody(interview, "tickTimer"));
   assert.ok(
-    timer.includes("if (Date.now() - replayStageAt >= REPLAY_STAGE_MS) {"),
+    timer.includes("recordStageTick(tick.remaining);"),
     "the clock is restated on an interval, not on every tick",
   );
-  assert.ok(timer.includes('recordReplay("stage", { remainingSeconds: tick.remaining });'));
+  const stageTick = withoutComments(functionBody(interview, "recordStageTick"));
+  assert.ok(
+    stageTick.includes("Date.now() - replayStageAt < REPLAY_STAGE_MS"),
+    "the stage repeat must still be throttled, wherever the guard lives",
+  );
+  assert.ok(stageTick.includes('recordReplay("stage", { remainingSeconds });'));
   assert.ok(
     /const REPLAY_STAGE_MS = 15000;/.test(interview),
     "a second-by-second clock would be most of the per-interview budget",
@@ -408,11 +413,15 @@ test("replay-producer stage", () => {
 
 test("replay-producer avatar", () => {
   assert.ok(
-    interview.includes('recordReplay("avatar", { state: value });'),
+    withoutComments(functionBody(interview, "recordAvatarState")).includes(
+      'recordReplay("avatar", { state: value });',
+    ),
     "the interviewer's state is recorded",
   );
   assert.ok(
-    interview.includes("if (value !== replayAvatarState) {"),
+    withoutComments(functionBody(interview, "recordAvatarState")).includes(
+      "if (value === replayAvatarState) return;",
+    ),
     "on the change, not on the participant event that happened to carry it",
   );
 });

--- a/tests/browser/source.js
+++ b/tests/browser/source.js
@@ -18,6 +18,54 @@ export function read(name) {
   return readFileSync(join(root, name), "utf8");
 }
 
+/// `web/interview.js` and the modules it hands its bindings to.
+///
+/// One list, in one place, because every assertion that reads it is a
+/// whole-path one. "setSinkId targets Jim and nothing else" and "the avatar
+/// never reads the candidate's microphone" are properties of the interview
+/// path, not of a filename, and a per-test subset of that path quietly stops
+/// covering whatever moves outside it. Five copies of this list would mean a
+/// seventh module is covered by none of them until all five are edited, which
+/// is the fail-open this file exists to warn about.
+///
+/// `interview_path_is_read_whole` in dom-contract.test.js keeps it honest: it
+/// derives the same set from the source and fails when the two disagree.
+export const INTERVIEW_SOURCES = [
+  "web/interview.js",
+  "web/audio-output.js",
+  "web/captions.js",
+  "web/integrity.js",
+  "web/recording-state.js",
+  "web/replay-feed.js",
+  "web/avatar/stage.js",
+];
+
+/// The interview path as one text.
+///
+/// The whole-file checks that read this are the kind a split defeats:
+/// `doesNotMatch` over one file says nothing about the sibling the code moved
+/// into, and an allowlist counted per file stops counting the call sites that
+/// left. Read together, the property the assertion was written for survives the
+/// move, because it was a property of the path and not of a filename.
+export function interviewSource() {
+  return INTERVIEW_SOURCES.map(read).join("\n");
+}
+
+/// The modules `interview.js` initialises, read back out of the source rather
+/// than listed a second time. A cluster split out of the page script announces
+/// itself with an `init*` export and an `init*(...)` call, so this finds the
+/// ones a hand-written list would have missed.
+export function initialisedModules() {
+  const page = read("web/interview.js");
+  const called = new Set(captures(page, /^(init[A-Z]\w*)\(/gm));
+  return firstPartyScripts()
+    .map((name) => `web/${name}`)
+    .filter((path) => {
+      const exported = captures(read(path), /^export function (init[A-Z]\w*)\(/gm);
+      return exported.some((name) => called.has(name));
+    });
+}
+
 /// Every first-party browser script, `web/vendor/` excluded by path. Recursive,
 /// so a bridge added under `web/avatar/` or `web/recording/` is covered too.
 export function firstPartyScripts() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -549,3 +549,79 @@ fn binary_agent_can_skip_auto_local_config_file() {
     assert_eq!(output.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&output.stderr).contains("missing required config keys"));
 }
+
+#[test]
+fn binary_help_exits_without_loading_config() {
+    for (args, usage) in [
+        (&["--help"][..], "usage: codetrial MODE [OPTIONS]"),
+        (&["web", "-h"][..], "usage: codetrial web [OPTIONS]"),
+        // Help beats parsing. Both of these are a flag missing its value, and
+        // answering a request for help with a parse error is the wrong answer
+        // to the question that was asked.
+        (
+            &["web", "--config", "--help"][..],
+            "usage: codetrial web [OPTIONS]",
+        ),
+        (
+            &["--help", "--config"][..],
+            "usage: codetrial MODE [OPTIONS]",
+        ),
+    ] {
+        let (code, stdout, stderr) = run_cli_args(args);
+
+        assert_eq!(code, 0, "{args:?}");
+        assert!(stdout.contains(usage), "{args:?}: {stdout}");
+        assert!(stderr.is_empty(), "{args:?}: {stderr}");
+
+        // The options, not just the usage line. Help that names the modes and
+        // stops is help that does not answer "how do I point it at my config".
+        for flag in ["--config PATH", "--web-addr ADDR", "-h, --help"] {
+            assert!(
+                stdout.contains(flag),
+                "{args:?} must document {flag}: {stdout}"
+            );
+        }
+        assert!(
+            stdout.contains("--flag=value"),
+            "{args:?} must say how to pass a dash-prefixed value: {stdout}"
+        );
+    }
+}
+
+/// `--flag=value` is the only way to pass a value that starts with a dash, and
+/// `--` is the only way to pass a positional that does. Without both, the guard
+/// that stops `--config --help` from naming a file `--help` also makes a real
+/// path like `-dashfile.env` unreachable.
+#[test]
+fn binary_accepts_dash_prefixed_values_through_the_attached_form() {
+    let dir = temp_path("dash-values");
+    std::fs::create_dir_all(&dir).unwrap();
+    let config = dir.join("-dashfile.env");
+    write_config(&config, &dir, "127.0.0.1:1");
+    let (code, _, stderr) = run_cli_args(&[
+        "web",
+        &format!("--config={}", config.to_str().unwrap()),
+        "--web-addr=127.0.0.1:1",
+    ]);
+    let _ = std::fs::remove_dir_all(dir);
+
+    // It read the file: the only complaint left is the port it cannot bind.
+    assert_eq!(code, 1, "{stderr}");
+    assert!(stderr.contains("failed to bind"), "{stderr}");
+    assert!(
+        !stderr.contains("required configuration file is missing"),
+        "the attached form must reach a dash-prefixed path: {stderr}"
+    );
+}
+
+/// A flag in the value slot is a missing value, not the value. Without that,
+/// `--config` followed by another flag reports a configuration file named
+/// `--web-addr`, and the operator goes looking for a path that never existed.
+#[test]
+fn binary_rejects_a_flag_standing_in_for_a_flag_value() {
+    let (code, stdout, stderr) = run_cli_args(&["web", "--config", "--web-addr"]);
+
+    assert_eq!(code, 2);
+    assert!(stdout.is_empty());
+    assert!(stderr.contains("--config requires a value"), "{stderr}");
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -235,25 +235,159 @@ fn binary_livekit_runner_requires_room_name() {
 }
 
 #[test]
-fn binary_livekit_runner_fails_closed_on_missing_config() {
-    let (code, stdout, stderr) = run_cli_args(&["run-livekit", "interview-fixed"]);
+fn binary_help_exits_without_loading_config() {
+    for (args, usage) in [
+        (&["--help"][..], "usage: codetrial MODE [OPTIONS]"),
+        (&["web", "-h"][..], "usage: codetrial web [OPTIONS]"),
+        // Help beats parsing. Both of these are a flag missing its value, and
+        // answering a request for help with a parse error is the wrong answer
+        // to the question that was asked.
+        (
+            &["web", "--config", "--help"][..],
+            "usage: codetrial web [OPTIONS]",
+        ),
+        (
+            &["--help", "--config"][..],
+            "usage: codetrial MODE [OPTIONS]",
+        ),
+    ] {
+        let (code, stdout, stderr) = run_cli_args(args);
 
-    assert_eq!(code, 1);
+        assert_eq!(code, 0, "{args:?}");
+        assert!(stdout.contains(usage), "{args:?}: {stdout}");
+        assert!(stderr.is_empty(), "{args:?}: {stderr}");
+
+        // The options, not just the usage line. Help that names the modes and
+        // stops is help that does not answer "how do I point it at my config".
+        for flag in ["--config PATH", "--web-addr ADDR", "-h, --help"] {
+            assert!(
+                stdout.contains(flag),
+                "{args:?} must document {flag}: {stdout}"
+            );
+        }
+        assert!(
+            stdout.contains("--flag=value"),
+            "{args:?} must say how to pass a dash-prefixed value: {stdout}"
+        );
+    }
+}
+
+/// `--flag=value` is the only way to pass a value that starts with a dash, and
+/// `--` is the only way to pass a positional that does. Without both, the guard
+/// that stops `--config --help` from naming a file `--help` also makes a real
+/// path like `-dashfile.env` unreachable.
+#[test]
+fn binary_accepts_dash_prefixed_values_through_the_attached_form() {
+    let dir = temp_path("dash-values");
+    std::fs::create_dir_all(&dir).unwrap();
+    let config = dir.join("-dashfile.env");
+    write_config(&config, &dir, "127.0.0.1:1");
+    let (code, _, stderr) = run_cli_args(&[
+        "web",
+        &format!("--config={}", config.to_str().unwrap()),
+        "--web-addr=127.0.0.1:1",
+    ]);
+    let _ = std::fs::remove_dir_all(dir);
+
+    // It read the file: the only complaint left is the port it cannot bind.
+    assert_eq!(code, 1, "{stderr}");
+    assert!(stderr.contains("failed to bind"), "{stderr}");
+    assert!(
+        !stderr.contains("required configuration file is missing"),
+        "the attached form must reach a dash-prefixed path: {stderr}"
+    );
+}
+
+/// A flag in the value slot is a missing value, not the value. Without that,
+/// `--config` followed by another flag reports a configuration file named
+/// `--web-addr`, and the operator goes looking for a path that never existed.
+#[test]
+fn binary_rejects_a_flag_standing_in_for_a_flag_value() {
+    let (code, stdout, stderr) = run_cli_args(&["web", "--config", "--web-addr"]);
+
+    assert_eq!(code, 2);
     assert!(stdout.is_empty());
-    assert!(stderr.contains("missing required config keys: LIVEKIT_URL"));
+    assert!(stderr.contains("--config requires a value"), "{stderr}");
+}
+
+/// The message names the file that was read, not a fixed `config/` path. A
+/// server started with `--config` elsewhere would otherwise send whoever runs
+/// it to edit a file it never opened.
+/// `--` ends the options, so what follows is a positional whatever it looks
+/// like, and the separator itself is not one of them.
+///
+/// `run-livekit` takes a room name, which is what makes the count observable
+/// from outside: exactly one positional after the mode word gets past the arity
+/// check and on to loading a config, and a separator left in the list, or a
+/// value dropped from it, stops there with a usage line instead.
+#[test]
+fn binary_treats_everything_after_a_double_dash_as_positional() {
+    let (code, stdout, stderr) = run_cli_args(&["run-livekit", "--", "-interview-dash"]);
+
+    assert_eq!(
+        code, 1,
+        "the room name must have been the only positional: {stderr}"
+    );
+    assert!(stdout.is_empty());
+    assert!(
+        stderr.contains("required configuration file is missing"),
+        "it got past the arity check and on to the config: {stderr}"
+    );
+    assert!(!stderr.contains("unknown flag"), "{stderr}");
+
+    // `web` takes no positional at all, so the same separator is refused there.
+    // Together the two pin the count rather than just the parse.
+    let (code, _, stderr) = run_cli_args(&["web", "--", "--web-addr"]);
+    assert_eq!(code, 2, "{stderr}");
+    assert!(stderr.contains("usage: codetrial web"), "{stderr}");
+    assert!(!stderr.contains("unknown flag"), "{stderr}");
 }
 
 #[test]
-fn binary_gemini_check_fails_closed_on_missing_config() {
-    let (code, stdout, stderr) = run_cli_args(&["check-gemini"]);
+fn binary_web_names_the_config_it_read_when_credentials_are_missing() {
+    let dir = temp_path("credential-less");
+    std::fs::create_dir_all(&dir).unwrap();
+    let config = dir.join("codetrial.env.local");
+    std::fs::write(&config, "CODETRIAL_WEB_ADDR=127.0.0.1:1\n").unwrap();
+    let (code, stdout, stderr) = run_cli_args(&["web", "--config", config.to_str().unwrap()]);
+    let _ = std::fs::remove_dir_all(dir);
 
     assert_eq!(code, 1);
     assert!(stdout.is_empty());
-    assert!(stderr.contains("missing required config keys: LIVEKIT_URL"));
+    assert!(
+        stderr.contains("missing required LiveKit credentials"),
+        "{stderr}"
+    );
+    assert!(stderr.contains(config.to_str().unwrap()), "{stderr}");
+}
+
+/// Every mode that reads configuration refuses without a file, and says which
+/// file it wanted. One test over the modes rather than one test each: the
+/// assertion is the same sentence three times, and a mode added to MODES that
+/// forgets this belongs in this list rather than in a fourth copy.
+///
+/// `serve` is not here. It needs a free address to reach the same refusal, so
+/// it carries its own test below.
+#[test]
+fn binary_modes_that_read_configuration_require_a_primary_config_file() {
+    for args in [
+        &["run-livekit", "interview-fixed"][..],
+        &["check-gemini"][..],
+        &["web"][..],
+    ] {
+        let (code, stdout, stderr) = run_cli_args(args);
+
+        assert_eq!(code, 1, "{args:?}: {stderr}");
+        assert!(stdout.is_empty(), "{args:?}: {stdout}");
+        assert!(
+            stderr.contains("required configuration file is missing"),
+            "{args:?}: {stderr}"
+        );
+    }
 }
 
 #[test]
-fn binary_serve_fails_closed_on_missing_config_after_web_bind() {
+fn binary_serve_requires_a_primary_config_file() {
     let (code, stdout, stderr) = with_free_addr(|addr| {
         let result = run_cli_args(&["serve", "--web-addr", addr]);
         (!result.2.contains("failed to bind")).then_some(result)
@@ -261,7 +395,7 @@ fn binary_serve_fails_closed_on_missing_config_after_web_bind() {
 
     assert_eq!(code, 1);
     assert!(stdout.is_empty());
-    assert!(stderr.contains("missing required config keys: LIVEKIT_URL"));
+    assert!(stderr.contains("required configuration file is missing"));
 }
 
 /// `serve` runs one agent in one room, and `/api/token` only hands that room
@@ -375,15 +509,25 @@ fn binary_web_does_not_require_github_oauth_config() {
 }
 
 #[test]
-fn binary_serve_reports_web_bind_failure_without_requiring_credentials() {
+fn binary_serve_reports_web_bind_failure_after_config_validation() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("occupied port should bind");
     let addr = listener.local_addr().unwrap().to_string();
-    let (code, stdout, stderr) = run_cli_args(&["serve", "--web-addr", &addr]);
+    let dir = temp_path("occupied-port");
+    std::fs::create_dir_all(&dir).unwrap();
+    let config = dir.join("codetrial.env.local");
+    write_config(&config, &dir, "127.0.0.1:1");
+    let (code, stdout, stderr) = run_cli_args(&[
+        "serve",
+        "--web-addr",
+        &addr,
+        "--config",
+        config.to_str().unwrap(),
+    ]);
+    let _ = std::fs::remove_dir_all(dir);
 
     assert_eq!(code, 1);
     assert!(stdout.is_empty());
     assert!(stderr.contains("web side failed to bind"));
-    assert!(!stderr.contains("missing required config keys"));
 }
 
 #[test]
@@ -467,18 +611,12 @@ fn binary_agent_web_uses_config_and_cli_override_precedence() {
 }
 
 #[test]
-fn binary_agent_web_auto_loads_local_config_file() {
+fn binary_agent_web_loads_primary_config_from_the_current_directory() {
     let cwd = temp_path("cwd");
     let web_dir = cwd.join("site");
-    let config_dir = cwd.join("config");
     std::fs::create_dir_all(&web_dir).expect("web dir should create");
-    std::fs::create_dir_all(&config_dir).expect("config dir should create");
     std::fs::write(web_dir.join("index.html"), "from local config").expect("index should write");
-    write_config(
-        &config_dir.join("codetrial.env.local"),
-        &web_dir,
-        "127.0.0.1:1",
-    );
+    write_config(&cwd.join("codetrial.env.local"), &web_dir, "127.0.0.1:1");
 
     let (cli_addr, mut child) = spawn_server(|addr| {
         let mut command = Command::new(env!("CARGO_BIN_EXE_codetrial"));
@@ -516,112 +654,4 @@ fn binary_agent_web_auto_loads_local_config_file() {
 
     stop_child(&mut child);
     let _ = std::fs::remove_dir_all(cwd);
-}
-
-#[test]
-fn binary_agent_can_skip_auto_local_config_file() {
-    let cwd = temp_path("cwd");
-    let web_dir = cwd.join("site");
-    let config_dir = cwd.join("config");
-    std::fs::create_dir_all(&web_dir).expect("web dir should create");
-    std::fs::create_dir_all(&config_dir).expect("config dir should create");
-    write_config(
-        &config_dir.join("codetrial.env.local"),
-        &web_dir,
-        "127.0.0.1:1",
-    );
-
-    let output = Command::new(env!("CARGO_BIN_EXE_codetrial"))
-        .arg("check-gemini")
-        .current_dir(&cwd)
-        .env("CODETRIAL_SKIP_CONFIG", "1")
-        .env_remove("LIVEKIT_URL")
-        .env_remove("LIVEKIT_API_KEY")
-        .env_remove("LIVEKIT_API_SECRET")
-        .env_remove("GOOGLE_API_KEY")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("codetrial should exit");
-
-    let _ = std::fs::remove_dir_all(cwd);
-
-    assert_eq!(output.status.code(), Some(1));
-    assert!(String::from_utf8_lossy(&output.stderr).contains("missing required config keys"));
-}
-
-#[test]
-fn binary_help_exits_without_loading_config() {
-    for (args, usage) in [
-        (&["--help"][..], "usage: codetrial MODE [OPTIONS]"),
-        (&["web", "-h"][..], "usage: codetrial web [OPTIONS]"),
-        // Help beats parsing. Both of these are a flag missing its value, and
-        // answering a request for help with a parse error is the wrong answer
-        // to the question that was asked.
-        (
-            &["web", "--config", "--help"][..],
-            "usage: codetrial web [OPTIONS]",
-        ),
-        (
-            &["--help", "--config"][..],
-            "usage: codetrial MODE [OPTIONS]",
-        ),
-    ] {
-        let (code, stdout, stderr) = run_cli_args(args);
-
-        assert_eq!(code, 0, "{args:?}");
-        assert!(stdout.contains(usage), "{args:?}: {stdout}");
-        assert!(stderr.is_empty(), "{args:?}: {stderr}");
-
-        // The options, not just the usage line. Help that names the modes and
-        // stops is help that does not answer "how do I point it at my config".
-        for flag in ["--config PATH", "--web-addr ADDR", "-h, --help"] {
-            assert!(
-                stdout.contains(flag),
-                "{args:?} must document {flag}: {stdout}"
-            );
-        }
-        assert!(
-            stdout.contains("--flag=value"),
-            "{args:?} must say how to pass a dash-prefixed value: {stdout}"
-        );
-    }
-}
-
-/// `--flag=value` is the only way to pass a value that starts with a dash, and
-/// `--` is the only way to pass a positional that does. Without both, the guard
-/// that stops `--config --help` from naming a file `--help` also makes a real
-/// path like `-dashfile.env` unreachable.
-#[test]
-fn binary_accepts_dash_prefixed_values_through_the_attached_form() {
-    let dir = temp_path("dash-values");
-    std::fs::create_dir_all(&dir).unwrap();
-    let config = dir.join("-dashfile.env");
-    write_config(&config, &dir, "127.0.0.1:1");
-    let (code, _, stderr) = run_cli_args(&[
-        "web",
-        &format!("--config={}", config.to_str().unwrap()),
-        "--web-addr=127.0.0.1:1",
-    ]);
-    let _ = std::fs::remove_dir_all(dir);
-
-    // It read the file: the only complaint left is the port it cannot bind.
-    assert_eq!(code, 1, "{stderr}");
-    assert!(stderr.contains("failed to bind"), "{stderr}");
-    assert!(
-        !stderr.contains("required configuration file is missing"),
-        "the attached form must reach a dash-prefixed path: {stderr}"
-    );
-}
-
-/// A flag in the value slot is a missing value, not the value. Without that,
-/// `--config` followed by another flag reports a configuration file named
-/// `--web-addr`, and the operator goes looking for a path that never existed.
-#[test]
-fn binary_rejects_a_flag_standing_in_for_a_flag_value() {
-    let (code, stdout, stderr) = run_cli_args(&["web", "--config", "--web-addr"]);
-
-    assert_eq!(code, 2);
-    assert!(stdout.is_empty());
-    assert!(stderr.contains("--config requires a value"), "{stderr}");
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2,9 +2,11 @@ use codetrial::config::{
     DEFAULT_COMPILER_EXPLORER_ENABLED, DEFAULT_DURATION_MIN,
     DEFAULT_GEMINI_CANDIDATE_VIDEO_ENABLED, DEFAULT_GEMINI_LIVE_MODEL, DEFAULT_GEMINI_REPORT_MODEL,
     DEFAULT_GEMINI_SILENCE_MS, DEFAULT_GEMINI_START_SENSITIVITY, DEFAULT_GEMINI_VOICE,
-    DEFAULT_ROOM_PREFIX, DEFAULT_WEB_ADDR, DEFAULT_WEB_DIR, MAX_GEMINI_SILENCE_MS, load_from_pairs,
+    DEFAULT_MAX_CONCURRENT_INTERVIEWS, DEFAULT_ROOM_PREFIX, DEFAULT_WEB_ADDR, DEFAULT_WEB_DIR,
+    MAX_GEMINI_SILENCE_MS, load_from_pairs, max_concurrent_interviews,
 };
 use serde_json::Value;
+use std::collections::BTreeMap;
 
 #[test]
 fn config_accepts_current_env_names() {
@@ -1342,4 +1344,59 @@ mod recording {
             );
         }
     }
+}
+
+/// A cap the operator set and the server cannot honor is said out loud.
+///
+/// Falling back silently gives a node that was meant to be draining sixteen
+/// fresh interviews, with nothing in the log to explain why the number in the
+/// config file had no effect.
+#[test]
+fn an_unusable_interview_cap_falls_back_and_says_so() {
+    let cap = |value: &str| {
+        let mut warnings = Vec::new();
+        let values: BTreeMap<String, String> = std::iter::once((
+            "CODETRIAL_MAX_CONCURRENT_INTERVIEWS".to_string(),
+            value.to_string(),
+        ))
+        .collect();
+        let resolved = max_concurrent_interviews(&values, &mut warnings);
+        (resolved, warnings)
+    };
+    let default = DEFAULT_MAX_CONCURRENT_INTERVIEWS;
+
+    assert_eq!(
+        cap("4"),
+        (4, Vec::new()),
+        "a usable cap is taken and not remarked on"
+    );
+
+    let (zero, warnings) = cap("0");
+    assert_eq!(zero, default);
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("refuse every interview")),
+        "zero must say what it would have done: {warnings:?}"
+    );
+
+    let (typo, warnings) = cap("sixteeen");
+    assert_eq!(typo, default);
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("not a positive whole number")),
+        "an unreadable cap must name itself: {warnings:?}"
+    );
+
+    // Unset is the default, and the default is not worth a word.
+    let mut warnings = Vec::new();
+    assert_eq!(
+        max_concurrent_interviews(&BTreeMap::new(), &mut warnings),
+        default
+    );
+    assert!(
+        warnings.is_empty(),
+        "an unset cap is not a warning: {warnings:?}"
+    );
 }

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -549,6 +549,28 @@ async fn embedded_assets_fill_gaps_in_a_partial_web_directory() {
         .unwrap();
     assert_eq!(response.status(), 200);
 
+    // The same for a route with no extension, which is the harder half. Those
+    // expand to four candidates ending in `index.html`, the single-page
+    // fallback, so a disk store searched to exhaustion first would answer with
+    // the one file it has and hand back the wrong page with a 200. Candidate
+    // order has to beat store order.
+    let interview = reqwest::get(&format!("{base}/interview"))
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        !interview.contains("disk wins"),
+        "an extensionless route must not fall back to a stale disk index: {}",
+        &interview[..interview.len().min(200)]
+    );
+    assert!(
+        interview.contains("<title>CodeTrial"),
+        "it must be the real interview page: {}",
+        &interview[..interview.len().min(200)]
+    );
+
     server.abort();
     fs::remove_dir_all(root).unwrap();
 }

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -1487,7 +1487,15 @@ fn rust_problem_bank_matches_the_browser_problem_bank() {
 async fn server_check_accepts_running_rust_server() {
     let (mut config, cookie, db_path) = signed_in_web_config("server-check");
     config.web_dir = Path::new("web").to_path_buf();
-    config.pool = Default::default();
+
+    // A credentialled pool, because an empty one is no longer a server that can
+    // exist: `run_web` refuses to start without LiveKit credentials, so the
+    // check asserts `/api/token` mints rather than 500s.
+    config.pool = primary_pool(
+        "wss://example.livekit.cloud",
+        "server-check-key",
+        "server-check-secret",
+    );
     let (base, server) = spawn_web_server(config).await;
     let output = tokio::task::spawn_blocking(move || {
         Command::new("scripts/server-check.sh")
@@ -1515,7 +1523,11 @@ async fn server_check_accepts_running_rust_server() {
 async fn server_check_signs_itself_in_against_an_external_server() {
     let (mut config, _, db_path) = signed_in_web_config("server-check-cookie");
     config.web_dir = Path::new("web").to_path_buf();
-    config.pool = Default::default();
+    config.pool = primary_pool(
+        "wss://example.livekit.cloud",
+        "server-check-key",
+        "server-check-secret",
+    );
     let (base, server) = spawn_web_server(config).await;
     let output = tokio::task::spawn_blocking(move || {
         Command::new("scripts/server-check.sh")

--- a/web/audio-output.js
+++ b/web/audio-output.js
@@ -53,7 +53,24 @@ export async function refreshAudioOutputs() {
   showOutputNote(options.length ? "" : OUTPUT_NOTES.empty);
 }
 
-export async function applyAudioOutput(deviceId) {
+/// The routing request this one has to finish behind, and the number that says
+/// which request is the newest.
+///
+/// `setSinkId` is asynchronous and the candidate can pick again before it
+/// settles. Two in flight can resolve in either order, and the older one would
+/// then write its device into the preference and the select, undoing a choice
+/// the candidate made after it. Serialized so they resolve in the order they
+/// were asked for, and stamped so a request that is no longer the newest
+/// routes but does not get the last word on what is stored or shown.
+let routingChain = Promise.resolve();
+let routingRequest = 0;
+
+export function applyAudioOutput(deviceId) {
+  routingChain = routingChain.then(() => routeAudioOutput(deviceId, ++routingRequest));
+  return routingChain;
+}
+
+async function routeAudioOutput(deviceId, request) {
   if (!deviceId) return;
   const previous = readStored(AUDIO_OUTPUT_KEY);
   writeStored(AUDIO_OUTPUT_KEY, deviceId);
@@ -67,6 +84,10 @@ export async function applyAudioOutput(deviceId) {
   // refused id was written before routing was attempted, so leaving it would
   // persist a device Jim never played through: the next reload would pre-select
   // it and retry the same refusal.
+  // A newer pick arrived while this one was routing. It has already routed, so
+  // Jim plays through whatever the last `setSinkId` chose, and the newest
+  // request is the one entitled to say so in the preference and the select.
+  if (request !== routingRequest) return;
   const stored = outputAfterRouting(previous, deviceId, routed);
   writeStored(AUDIO_OUTPUT_KEY, stored);
   nodes.meetOutputSelect.value = stored || "";

--- a/web/audio-output.js
+++ b/web/audio-output.js
@@ -1,0 +1,102 @@
+/// Which speaker plays the tab's audio, and the two preferences that outlive a
+/// reload.
+///
+/// No mixer and no synthetic microphone: Meet captures the tab, and CodeTrial
+/// only decides which output device the tab's own audio lands on. Split out of
+/// `interview.js` because routing, the stored preference and the note the
+/// candidate reads about it are one decision made in three places, and the
+/// order they happen in is the part that matters.
+
+import { OUTPUT_NOTES, outputAfterRouting, outputOptions } from "./meet-audio.js";
+
+let nodes = null;
+/// Read through a function rather than held: `playRemoteAudio` creates and
+/// drops Jim's element as LiveKit re-subscribes him, and a copy taken at init
+/// would route the one from the previous subscription.
+let jimAudioElement = () => null;
+
+export function initAudioOutput(deps) {
+  ({ nodes, jimAudioElement } = deps);
+}
+
+export const AUDIO_OUTPUT_KEY = "codetrial:audioOutputId";
+export const MEET_PRESENTATION_KEY = "codetrial:meetPresentation";
+
+/// Lists output devices so Jim can be routed away from the shared tab's
+/// default. No mixer and no synthetic microphone: Meet captures the tab, and
+/// CodeTrial only decides which speaker plays the tab's own audio.
+export async function refreshAudioOutputs() {
+  const mediaDevices = navigator.mediaDevices;
+  if (!mediaDevices?.enumerateDevices || !("setSinkId" in HTMLMediaElement.prototype)) {
+    // Hide the row, not just the control: a label pointing at a hidden select
+    // renders as a heading with nothing under it.
+    nodes.meetOutputRow.hidden = true;
+    showOutputNote(OUTPUT_NOTES.unsupported);
+    return;
+  }
+  let devices = [];
+  try {
+    devices = await mediaDevices.enumerateDevices();
+  } catch {
+    showOutputNote(OUTPUT_NOTES.listFailed);
+    return;
+  }
+  const options = outputOptions(devices, readStored(AUDIO_OUTPUT_KEY));
+  nodes.meetOutputSelect.replaceChildren();
+  for (const option of options) {
+    const element = document.createElement("option");
+    element.value = option.deviceId;
+    element.textContent = option.label;
+    element.selected = option.selected;
+    nodes.meetOutputSelect.append(element);
+  }
+  showOutputNote(options.length ? "" : OUTPUT_NOTES.empty);
+}
+
+export async function applyAudioOutput(deviceId) {
+  if (!deviceId) return;
+  const previous = readStored(AUDIO_OUTPUT_KEY);
+  writeStored(AUDIO_OUTPUT_KEY, deviceId);
+  const jimAudio = jimAudioElement();
+  if (!jimAudio || typeof jimAudio.setSinkId !== "function") return;
+  const routed = await jimAudio
+    .setSinkId(deviceId)
+    .then(() => true)
+    .catch(() => false);
+  // Cleared, not left alone, when there is no previous device to restore. The
+  // refused id was written before routing was attempted, so leaving it would
+  // persist a device Jim never played through: the next reload would pre-select
+  // it and retry the same refusal.
+  const stored = outputAfterRouting(previous, deviceId, routed);
+  writeStored(AUDIO_OUTPUT_KEY, stored);
+  nodes.meetOutputSelect.value = stored || "";
+  // An empty list keeps its explanation: routing succeeding says nothing about
+  // whether there was anything to choose from.
+  const note = routed ? "" : OUTPUT_NOTES.refused;
+  if (note || nodes.meetOutputSelect.length) showOutputNote(note);
+}
+
+export function showOutputNote(text) {
+  nodes.meetOutputNote.textContent = text;
+  nodes.meetOutputNote.hidden = !text;
+}
+
+export function readStored(key, storage = localStorage) {
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/// An empty value clears the key: "no preference" and "the empty preference"
+/// are the same thing, and a separate clearStored existed only so one call site
+/// could pick between them.
+export function writeStored(key, value, storage = localStorage) {
+  try {
+    if (value) storage.setItem(key, value);
+    else storage.removeItem(key);
+  } catch {
+    // Private browsing refuses writes; a preference is not worth failing on.
+  }
+}

--- a/web/avatar/stage.js
+++ b/web/avatar/stage.js
@@ -1,0 +1,251 @@
+/// Jim's face and the analyser that drives its mouth.
+///
+/// Presentation only: no frame this renders is published, recorded, or sent
+/// anywhere, and the analyser reads Jim's own track, never the candidate's
+/// microphone.
+///
+/// Split out of `interview.js` because none of it touches interview state. It
+/// needs the page's element handles and nothing else, so it takes them once in
+/// `startAvatar` and keeps the rest to itself: the renderer, the frame handle,
+/// the analyser and its buffers are private to this file and reachable only
+/// through the functions below.
+
+import { isAgent } from "../lib.js";
+import { peakLevel } from "../audio-check.js";
+import {
+  ANALYSER_FFT_SIZE,
+  ANALYSER_WINDOW,
+  MODEL_URL,
+  createAvatar,
+  mouthFromAmplitude,
+} from "./avatar.js";
+
+/// The page handles this stage draws into. Held rather than passed to every
+/// function because the render loop reads them sixty times a second and
+/// threading them through `requestAnimationFrame` would mean a closure per
+/// frame.
+let nodes = null;
+
+export function initAvatarStage(deps) {
+  ({ nodes } = deps);
+}
+
+let avatar = null;
+let avatarFrame = null;
+let jimAnalyser = null;
+let jimAnalyserSource = null;
+let jimAnalyserSamples = null;
+let jimAnalyserTrack = null;
+let jimAnalyserContext = null;
+const jimAnalyserPeaks = [];
+
+export function startAvatar() {
+  if (avatar) return;
+  // Below the stylesheet's breakpoint the avatar is `display: none`, and a
+  // hidden element is not worth 11 MB of model, 730 KB of renderer, one of the
+  // page's ~16 WebGL contexts and a 60 Hz loop drawing into a 1x1 canvas. The
+  // computed style is asked rather than the breakpoint restated, so the CSS
+  // stays the only place that decides where the avatar is shown.
+  if (!nodes.jimAvatar || window.getComputedStyle(nodes.jimAvatar).display === "none") return;
+  const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true;
+  avatar = createAvatar({
+    mount: nodes.jimAvatar,
+    reducedMotion,
+    // The panel says which of the two things happened, because "Jim is here by
+    // voice" under a blank box is indistinguishable from a broken page.
+    onState: (next) => {
+      if (next !== "unavailable") return;
+      nodes.jimAvatarNote.textContent = "Jim is here by voice; his avatar is unavailable in this browser.";
+    },
+    loadModel: async () => {
+      // Ask whether the model is published before importing the renderer.
+      // Without this every candidate downloads 730 KB of Three.js only to
+      // discover a 404, which is exactly the state of the repo today.
+      const published = await fetch(MODEL_URL, { method: "HEAD" });
+      if (!published.ok) throw new Error(`${MODEL_URL} is not published`);
+      const renderer = await import("./vrm.js");
+      return renderer.loadVrm({ mount: nodes.jimAvatar });
+    },
+  });
+  // Started only once something can actually render. Pumping regardless meant
+  // every session without a model, which is all of them today, ran a 60 Hz
+  // loop that read the analyser and threw the result away.
+  void avatar.ready.then((rendered) => {
+    if (!rendered) return;
+    // Read by the avatar browser check, which has no other way to tell a
+    // running render loop from a canvas that was created once and abandoned.
+    window.__codetrialAvatarFrames = () => avatar?.frames() ?? 0;
+    // Through `resumeAvatar`, not straight into the loop. A tab that became
+    // visible while the model was still loading has already started one, and
+    // two loops is two analyser reads and two poses a frame.
+    resumeAvatar();
+  });
+}
+
+export function pumpAvatar(at) {
+  if (!avatar) return;
+  // A hidden document stops asking for frames rather than asking and returning
+  // early. Browsers already throttle `requestAnimationFrame` in a background
+  // tab, so what this buys is small and it is not nothing: the analyser read
+  // and the humanoid update stop too, and `resumeAvatar` below is what starts
+  // them again. Written as "stop scheduling" rather than "skip a frame"
+  // because a loop that keeps scheduling is a loop that is still running.
+  if (document.hidden) {
+    avatarFrame = null;
+    return;
+  }
+  avatarFrame = requestAnimationFrame(pumpAvatar);
+  // Hidden by the CSS breakpoint, which the candidate can cross at any time by
+  // narrowing the window or docking devtools. startAvatar only samples this
+  // once, so without the check the humanoid rig, expressions and constraints
+  // kept running 60 times a second to produce no pixels.
+  //
+  // The preflight overlay is the same argument by a different route: it is
+  // opaque and covers the stage, so a model that finishes loading while the
+  // candidate is still granting a camera would otherwise render behind it,
+  // taking main-thread frames away from the level meter and the face detector.
+  // The width check cannot see this, because an element under an overlay still
+  // has its width. Loading early is the point; drawing early is not.
+  if (!nodes.jimAvatar.clientWidth || !nodes.audioCheck.hidden) return;
+  avatar.setMouth(mouthFromAmplitude(jimAmplitude()));
+  // The rAF timestamp is the frame's target time and is identical across every
+  // callback in that frame; performance.now() drifts by however long the loop
+  // took to reach us.
+  avatar.frame(at ?? performance.now());
+}
+
+/// Starts the render loop again after the tab comes back.
+///
+/// One listener for the life of the page, added beside the loop rather than
+/// inside it: a listener added per frame is sixty listeners a second.
+export function resumeAvatar() {
+  // `state()` and not just `avatar`: `createAvatar` returns before the model
+  // has loaded, so a visibility change during the load would otherwise start a
+  // loop that poses nothing sixty times a second.
+  if (!avatar || avatar.state() !== "ready" || document.hidden || avatarFrame !== null) return;
+  pumpAvatar();
+}
+
+document.addEventListener("visibilitychange", resumeAvatar);
+
+/// Jim's own track, never the candidate's. `createMediaElementSource` would be
+/// the obvious call and is the wrong one: it returns silence for a
+/// MediaStream-backed element, so the mouth would never open.
+export function attachAvatarAnalyser(track, participant) {
+  // Jim only. playRemoteAudio fires for every remote audio track, and this used
+  // to take whichever arrived first: a second participant, or a stray hosted
+  // agent of the kind scripts/browser-check.cjs already has to isolate, would
+  // have driven the mouth. Never the candidate, who is never subscribed here.
+  if (!isAgent(participant)) return;
+  if (!track?.mediaStreamTrack || track === jimAnalyserTrack) return;
+  // A new publication replaces the old analyser rather than being ignored.
+  // Bailing out on `jimAnalyser` alone left the analyser bound to the track
+  // that had just been replaced, and LiveKit does not promise the unsubscribe
+  // for the old publication arrives before the subscribe for the new one: when
+  // it arrived after, `dropRemoteAudio` tore down the only analyser there was
+  // and nothing rebuilt it, so lip sync died for the rest of the session.
+  if (jimAnalyser) releaseAvatarAnalyser();
+  try {
+    jimAnalyserContext ||= new (window.AudioContext || window.webkitAudioContext)();
+    // TrackSubscribed is not a user gesture, so a context first built here can
+    // arrive suspended and then read silence forever. The mouth would simply
+    // never open, with nothing anywhere saying why.
+    if (jimAnalyserContext.state === "suspended") void jimAnalyserContext.resume().catch(() => {});
+    jimAnalyserSource = jimAnalyserContext.createMediaStreamSource(new MediaStream([track.mediaStreamTrack]));
+    jimAnalyser = jimAnalyserContext.createAnalyser();
+    jimAnalyser.fftSize = ANALYSER_FFT_SIZE;
+    // One buffer for the session. Allocating it per frame produced 512 bytes of
+    // garbage 60 times a second for the whole interview.
+    jimAnalyserSamples = new Uint8Array(jimAnalyser.fftSize);
+    jimAnalyserTrack = track;
+    // Not connected to the destination: the audio element is already playing
+    // this track, and a second path would play Jim twice.
+    jimAnalyserSource.connect(jimAnalyser);
+    resumeAnalyserOnGesture();
+  } catch {
+    // No analyser means no lip-sync. Everything else about the avatar, and all
+    // of the audio, still works.
+    releaseAvatarAnalyser();
+  }
+}
+
+/// LiveKit re-subscribes Jim on every reconnect, so this runs more than once
+/// per session. Without disconnecting the source node, each reconnect left a
+/// live MediaStreamAudioSourceNode attached to the same context.
+export function releaseAvatarAnalyser() {
+  jimAnalyserSource?.disconnect();
+  jimAnalyserSource = null;
+  jimAnalyser = null;
+  jimAnalyserSamples = null;
+  jimAnalyserTrack = null;
+  jimAnalyserPeaks.length = 0;
+}
+
+/// Safari refuses `resume()` unless the call is inside a user gesture, and
+/// `TrackSubscribed` is not one, so a context first built there stays suspended
+/// for the rest of the interview. The analyser then reads silence forever: the
+/// avatar's mouth never opens, and the code above already predicted exactly
+/// that without being able to do anything about it. Chrome resumes from
+/// anywhere, which is why this survived.
+///
+/// The listeners are capturing and one-shot. A candidate who never touches the
+/// page again keeps a suspended context, which is the state it was already in.
+let gestureResumePending = false;
+
+export function resumeAnalyserOnGesture() {
+  if (!jimAnalyserContext || jimAnalyserContext.state !== "suspended") return;
+  // LiveKit re-subscribes Jim on every reconnect, so this runs more than once.
+  // Without the guard a context that stays suspended across two subscribes
+  // collects two pairs of listeners; they do unregister themselves on the first
+  // gesture, but registering them at all was pointless.
+  if (gestureResumePending) return;
+  gestureResumePending = true;
+  function stop() {
+    gestureResumePending = false;
+    document.removeEventListener("pointerdown", resume, true);
+    document.removeEventListener("keydown", resume, true);
+  }
+  function resume() {
+    if (!jimAnalyserContext || jimAnalyserContext.state !== "suspended") {
+      stop();
+      return;
+    }
+    void jimAnalyserContext.resume().then(stop).catch(() => {});
+  }
+  document.addEventListener("pointerdown", resume, true);
+  document.addEventListener("keydown", resume, true);
+}
+
+export function jimAmplitude() {
+  if (!jimAnalyser || !jimAnalyserSamples) return 0;
+  jimAnalyser.getByteTimeDomainData(jimAnalyserSamples);
+  jimAnalyserPeaks.push(peakLevel(jimAnalyserSamples));
+  if (jimAnalyserPeaks.length > ANALYSER_WINDOW) jimAnalyserPeaks.shift();
+  return jimAnalyserPeaks.reduce((total, peak) => total + peak, 0) / jimAnalyserPeaks.length;
+}
+
+export function stopAvatar() {
+  if (avatarFrame !== null) cancelAnimationFrame(avatarFrame);
+  avatarFrame = null;
+  avatar?.destroy();
+  avatar = null;
+  releaseAvatarAnalyser();
+  void jimAnalyserContext?.close?.().catch(() => {});
+  jimAnalyserContext = null;
+}
+
+/// The three questions `interview.js` still asks about the avatar, as functions
+/// rather than as exported state. A `let avatar` reachable from another module
+/// is a second owner of the renderer's lifetime, and the teardown order here is
+/// the whole reason this file exists.
+export function isAvatarAnalyserTrack(track) {
+  return track === jimAnalyserTrack;
+}
+
+export function setAvatarSpeaking(speaking) {
+  avatar?.setSpeaking(speaking);
+}
+
+export function setAvatarExpression(value) {
+  avatar?.setExpression(value);
+}

--- a/web/avatar/stage.js
+++ b/web/avatar/stage.js
@@ -41,6 +41,13 @@ const jimAnalyserPeaks = [];
 
 export function startAvatar() {
   if (avatar) return;
+  // Below the breakpoint the stage is hidden and nothing is built, but the
+  // candidate can cross it at any time by widening the window or undocking
+  // devtools. Without a retry, an interview that started narrow never gets an
+  // avatar however wide it gets. Registered once and only while there is
+  // nothing to render, so a session that starts wide adds no listener and a
+  // session that starts narrow drops it as soon as one is built.
+  watchForStageWidth();
   // Below the stylesheet's breakpoint the avatar is `display: none`, and a
   // hidden element is not worth 11 MB of model, 730 KB of renderer, one of the
   // page's ~16 WebGL contexts and a 60 Hz loop drawing into a 1x1 canvas. The
@@ -48,6 +55,7 @@ export function startAvatar() {
   // stays the only place that decides where the avatar is shown.
   if (!nodes.jimAvatar || window.getComputedStyle(nodes.jimAvatar).display === "none") return;
   const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true;
+  stopWatchingStageWidth();
   avatar = createAvatar({
     mount: nodes.jimAvatar,
     reducedMotion,
@@ -127,6 +135,28 @@ export function resumeAvatar() {
 }
 
 document.addEventListener("visibilitychange", resumeAvatar);
+
+/// Retries `startAvatar` when the stage becomes visible.
+///
+/// `resize` rather than a media query, because the stylesheet owns the
+/// breakpoint and `startAvatar` already asks the computed style rather than
+/// restating it. One listener at a time.
+let stageWidthWatch = null;
+
+function watchForStageWidth() {
+  if (avatar || stageWidthWatch) return;
+  stageWidthWatch = () => startAvatar();
+  window.addEventListener("resize", stageWidthWatch);
+}
+
+/// Dropped as soon as there is something to render, not on the next resize
+/// after that. A session that never resizes again would otherwise hold the
+/// handler, and the scope it closes over, for the length of the interview.
+function stopWatchingStageWidth() {
+  if (!stageWidthWatch) return;
+  window.removeEventListener("resize", stageWidthWatch);
+  stageWidthWatch = null;
+}
 
 /// Jim's own track, never the candidate's. `createMediaElementSource` would be
 /// the obvious call and is the wrong one: it returns silence for a
@@ -225,6 +255,7 @@ export function jimAmplitude() {
 }
 
 export function stopAvatar() {
+  stopWatchingStageWidth();
   if (avatarFrame !== null) cancelAnimationFrame(avatarFrame);
   avatarFrame = null;
   avatar?.destroy();

--- a/web/captions.js
+++ b/web/captions.js
@@ -1,0 +1,78 @@
+/// The live subtitle over the editor.
+///
+/// A subtitle, not a log: the transcript tab already keeps every turn, so this
+/// shows what is being said now and retires when nobody is speaking. Split out
+/// of `interview.js` because the pacing state is three variables and one timer
+/// that nothing else may touch, and the reveal is the only thing in the page
+/// that repaints on a 300ms tick.
+
+import { captionWindow } from "./lib.js";
+
+let nodes = null;
+
+export function initCaptions(deps) {
+  ({ nodes } = deps);
+}
+
+const CAPTION_TICK_MS = 300;
+const CAPTION_CHARS_PER_TICK = 8;
+
+// One uninterrupted spoken turn is unbounded, and the caption line sits in the
+// header: rendered whole, a long answer pushes the timer and the controls off
+// the screen. The tail is the part being spoken.
+const CAPTION_MAX_CHARS = 160;
+// Long enough to finish reading a sentence that just landed, short enough that
+// a silent pause clears the editor's corner.
+const CAPTION_IDLE_HIDE_MS = 12000;
+let captionIdleTimer = null;
+let interviewerCaption = { id: null, text: "", shown: 0, timer: null };
+
+export function updateCaptions(speaker, text, id = null) {
+  if (!nodes.captionsText) return;
+  if (speaker === "interviewer") {
+    if (interviewerCaption.id !== id) {
+      clearTimeout(interviewerCaption.timer);
+      interviewerCaption = { id, text: "", shown: 0, timer: null };
+    }
+    // The longest, not the latest. Every interim publish carries the whole turn
+    // so far on a stream of its own, so one that lands out of order is a
+    // shorter copy of what is already on screen, and taking it would rewind the
+    // reveal to a few characters and replay the line.
+    if (text.length > interviewerCaption.text.length) interviewerCaption.text = text;
+    if (!interviewerCaption.timer) paceInterviewerCaption();
+    return;
+  }
+  // Stop pacing Jim: the next tick would otherwise repaint his line over the
+  // candidate's. A later chunk of the same segment restarts it through the
+  // `!interviewerCaption.timer` check below.
+  clearTimeout(interviewerCaption.timer);
+  interviewerCaption.timer = null;
+  const clipped = captionWindow(text, CAPTION_MAX_CHARS);
+  nodes.captionsText.textContent = `[${speaker === "you" ? "You" : "Jim"}]: ${clipped}`;
+  showCaptions();
+}
+
+export function paceInterviewerCaption() {
+  const caption = interviewerCaption;
+  caption.shown = Math.min(caption.text.length, caption.shown + CAPTION_CHARS_PER_TICK);
+  nodes.captionsText.textContent = `[Jim]: ${captionWindow(caption.text.slice(0, caption.shown), CAPTION_MAX_CHARS)}`;
+  showCaptions();
+  if (caption.shown < caption.text.length) {
+    caption.timer = setTimeout(paceInterviewerCaption, CAPTION_TICK_MS);
+  } else {
+    caption.timer = null;
+  }
+}
+
+/// Captions are a live subtitle, not a log: the transcript tab already keeps
+/// every turn. Leaving the last thing anyone said pinned over the editor for
+/// the rest of the interview is just an obstruction, so the bar retires once
+/// nobody has spoken for a while and comes back on the next word.
+export function showCaptions() {
+  if (!nodes.captionsBar) return;
+  nodes.captionsBar.hidden = false;
+  clearTimeout(captionIdleTimer);
+  captionIdleTimer = setTimeout(() => {
+    nodes.captionsBar.hidden = true;
+  }, CAPTION_IDLE_HIDE_MS);
+}

--- a/web/integrity.js
+++ b/web/integrity.js
@@ -219,19 +219,29 @@ export async function postIntegrityFrame(source, track, video) {
   // unavailable. A transport the consumer cannot read is not an optimisation.
   // `createImageBitmap` decodes off the main thread, so this costs the editor
   // nothing.
+  //
+  // Either way of failing to get pixels says so in `analyzer=`. A
+  // metadata-only sample still counts frames, so without this the heartbeat
+  // reads exactly like one where the detector is running and simply never sees
+  // a face: the strongest possible statement about a candidate, made by a
+  // browser that never looked at them.
   let frame = null;
-  try {
-    if (typeof createImageBitmap === "function") {
+  if (typeof createImageBitmap === "function") {
+    try {
       frame = await createImageBitmap(video);
       message.frame = frame;
       message.transport = "ImageBitmap";
       worker.postMessage(message, [frame]);
       return;
+    } catch {
+      frame?.close?.();
+      delete message.frame;
+      state.integrityAnalysisDetail = "capture_failed";
     }
-  } catch {
-    frame?.close?.();
-    delete message.frame;
-    message.transport = "metadata";
+  } else {
+    state.integrityAnalysisDetail = "capture_unavailable";
   }
+  // Built with `transport: "metadata"`, so falling through here needs no
+  // assignment: the message already says the detector got no pixels.
   worker.postMessage(message);
 }

--- a/web/integrity.js
+++ b/web/integrity.js
@@ -1,0 +1,237 @@
+/// The integrity signal: whether the camera and microphone are still the ones
+/// the candidate started with.
+///
+/// Split out of `interview.js` because it is a set of timers and a worker with
+/// one lifetime, and the failure it guards against is silent. A sampler or a
+/// heartbeat left running after the room closes is a request every few seconds
+/// about an interview that ended; one stopped too early is a gap in the record
+/// with nothing saying there is a gap. Both are teardown-order bugs, and this
+/// file is where that order is written down.
+///
+/// `updatePresenceBanner` arrives as a function: the banner state belongs to
+/// the page, and importing it back would make the two files circular.
+
+import { TRACKING_INTERVAL_MS } from "./integrity-worker.js";
+
+// One row per presence event, so a new one is a row rather than another branch
+// on the same value in the worker message handler. `clears` empties the banner;
+// `endsInterview` is the only event allowed to close the session by itself.
+//
+// Here rather than in the page script because nothing in it touches the DOM or
+// the interview: it is the vocabulary of the worker's messages, which is what
+// this module is for. The page imports it for the banner text.
+export const PRESENCE_EVENTS = {
+  FACE_DETECTED: { clears: true },
+  FACE_MISSING: { banner: "Stay in front of the camera: no interviewee detected." },
+  MULTIPLE_FACES: { banner: "Take the interview alone: more than one face detected." },
+  FACE_DETECTOR_UNAVAILABLE: { banner: "Face detection is not running in this browser." },
+  FACE_MISSING_SEVERE: {
+    banner: "Interview ended automatically: away from the camera too long.",
+    endsInterview: true,
+  },
+};
+
+let state = null;
+let nodes = null;
+let updatePresenceBanner = () => {};
+/// The page owns the LiveKit publish path and the end-of-interview sequence.
+/// Both are called from here and neither belongs here.
+let publishIntegrityEvent = () => {};
+let endInterview = () => {};
+
+export function initIntegrity(deps) {
+  ({ state, nodes, updatePresenceBanner, publishIntegrityEvent, endInterview } = deps);
+}
+
+const INTEGRITY_HEARTBEAT_MS = 5000;
+
+export function monitorIntegrityTracks() {
+  // A released camera is simply not in the stream, so this watches nothing and
+  // no CAMERA_STOPPED is invented out of our own teardown.
+  watchIntegrityTrack(state.localUserStream?.getVideoTracks?.()[0], "CAMERA_STOPPED", "camera");
+  watchIntegrityTrack(state.localUserStream?.getAudioTracks?.()[0], "MICROPHONE_STOPPED", "microphone");
+  startIntegrityTrackStateMonitor();
+}
+
+export function watchIntegrityTrack(track, stoppedType, source) {
+  if (!track?.addEventListener) return;
+  track.addEventListener("ended", () => {
+    void publishIntegrityEvent({ type: stoppedType, source, severity: "high" });
+  });
+  track.addEventListener("mute", () => {
+    void publishIntegrityEvent({ type: `${source.toUpperCase()}_MUTED`, source, severity: "warning" });
+  });
+  track.addEventListener("unmute", () => {
+    void publishIntegrityEvent({ type: `${source.toUpperCase()}_UNMUTED`, source, severity: "info" });
+  });
+}
+
+export function startIntegrityHeartbeat() {
+  clearInterval(state.integrityHeartbeatTimer);
+  state.integrityHeartbeatTimer = setInterval(() => {
+    void publishIntegrityEvent({
+      type: "INTEGRITY_HEARTBEAT",
+      source: "heartbeat",
+      severity: "info",
+      detail: integrityHeartbeatDetail(),
+    });
+  }, INTEGRITY_HEARTBEAT_MS);
+}
+
+export function integrityHeartbeatDetail() {
+  const camera = state.localUserStream?.getVideoTracks?.()[0];
+  const mic = state.localUserStream?.getAudioTracks?.()[0];
+  const status = (track) => `${track?.readyState || "missing"}/${track?.enabled === false ? "off" : "on"}/${track?.muted ? "muted" : "unmuted"}`;
+  return `camera=${status(camera)};microphone=${status(mic)};analyzer=${state.integrityAnalysisDetail}`;
+}
+
+export function startIntegrityTrackStateMonitor() {
+  clearInterval(state.integrityTrackStateTimer);
+  state.integrityTrackStates.clear();
+  const tracks = () => [
+    ["camera", state.localUserStream?.getVideoTracks?.()[0]],
+    ["microphone", state.localUserStream?.getAudioTracks?.()[0]],
+  ];
+  const poll = () => {
+    for (const [source, track] of tracks()) {
+      if (!track) continue;
+      const current = `${track.readyState || "missing"}/${track.enabled === false ? "off" : "on"}`;
+      const previous = state.integrityTrackStates.get(source);
+      state.integrityTrackStates.set(source, current);
+      if (previous && previous !== current) {
+        void publishIntegrityEvent({
+          type: `${source.toUpperCase()}_STATE_CHANGED`,
+          source,
+          severity: current.includes("ended") || current.includes("/off") ? "warning" : "info",
+          detail: current,
+        });
+      }
+    }
+  };
+  poll();
+  state.integrityTrackStateTimer = setInterval(poll, 1000);
+}
+
+export function startIntegrityWorker() {
+  stopIntegrityWorker();
+  if (typeof Worker !== "function") {
+    state.integrityAnalysisDetail = "worker_unavailable";
+    return;
+  }
+  state.integrityAnalysisDetail = "worker_starting";
+  const worker = new Worker("/integrity-worker.js", { type: "module" });
+  state.integrityWorker = worker;
+  worker.onmessage = (event) => {
+    if (event.data?.type === "analysis") state.integrityAnalysisDetail = event.data.detail;
+    if (event.data?.type === "integrity-event") {
+      const eventType = event.data.eventType;
+      updatePresenceBanner(eventType);
+      const published = publishIntegrityEvent({
+        type: eventType,
+        source: event.data.source,
+        severity: event.data.severity,
+        durationMs: event.data.durationMs,
+        detail: event.data.detail,
+      });
+      // The event that caused the termination goes out before the end control
+      // does. The other order lets the agent start generating the report on the
+      // control message while the reason for it is still queued, and the report
+      // then omits why it exists.
+      if (PRESENCE_EVENTS[eventType]?.endsInterview) {
+        void published.then(() => endInterview("face_missing_severe"));
+      }
+    }
+  };
+
+  worker.onerror = () => {
+    state.integrityAnalysisDetail = "worker_error";
+  };
+  state.integrityFrameSamplers = [
+    startIntegrityFrameSampler("camera", state.localUserStream?.getVideoTracks?.()[0], nodes.cameraIntegrityVideo, TRACKING_INTERVAL_MS),
+  ].filter(Boolean);
+}
+
+export function stopIntegrityWorker() {
+  for (const stop of state.integrityFrameSamplers) stop();
+  state.integrityFrameSamplers = [];
+  state.integrityWorker?.terminate();
+  state.integrityWorker = null;
+  state.integrityAnalysisDetail = "not_configured";
+}
+
+export function startIntegrityFrameSampler(source, track, video, intervalMs) {
+  if (!track || !video || !state.integrityWorker) return null;
+  const ownsVideo = !video.srcObject;
+  if (ownsVideo) {
+    video.muted = true;
+    video.playsInline = true;
+    video.srcObject = new MediaStream([track]);
+    void video.play?.().catch(() => {});
+  }
+  const timer = setInterval(() => {
+    void postIntegrityFrame(source, track, video);
+  }, intervalMs);
+  void postIntegrityFrame(source, track, video);
+  return () => {
+    clearInterval(timer);
+    if (ownsVideo) video.srcObject = null;
+  };
+}
+
+export async function postIntegrityFrame(source, track, video) {
+  // `muted` as well as `readyState`. An ended track stops the sampler already,
+  // but a track another application has taken stays `live` and simply delivers
+  // nothing: the element keeps handing over its last frame, or a black one, and
+  // the detector charges every one of them as an absent candidate until the
+  // 15s severe threshold ends the interview. Opening the camera in Google Meet
+  // does exactly that. A camera that was taken away is a gap in sampling, and
+  // face-presence.js is explicit that a gap is not an observation. The `mute`
+  // listener still publishes CAMERA_MUTED, so the evidence survives for human
+  // review; it just no longer masquerades as the candidate walking off.
+  //
+  // The analyzer detail has to say so. The heartbeat publishes it every five
+  // seconds, and left at its last successful value it would keep reporting
+  // camera analyses while nothing has been sampled for minutes -- an integrity
+  // record claiming an observation that never happened.
+  if (track.muted) state.integrityAnalysisDetail = `${source}_muted`;
+  if (track.readyState !== "live" || track.muted || !state.integrityWorker) return;
+  const worker = state.integrityWorker;
+  const message = {
+    type: "frame",
+    source,
+    // Monotonic, not wall clock. A lid close, an OS suspend or an NTP step
+    // moves `Date.now()` forward by minutes between two frames, and the face
+    // tracker reads the difference as "absent for minutes" and ends the
+    // interview on the first frame after resume.
+    at: performance.now(),
+    width: video.videoWidth || 0,
+    height: video.videoHeight || 0,
+    transport: "metadata",
+  };
+  if (video.readyState < 2) {
+    worker.postMessage(message);
+    return;
+  }
+  // `ImageBitmap`, not the cheaper `VideoFrame` handle. The only consumer of
+  // these pixels is MediaPipe, which reads `image.width`: a `VideoFrame` carries
+  // `codedWidth`/`displayWidth` and no `width`, so it reached the detector as an
+  // undefined size and threw, and every interview reported face detection as
+  // unavailable. A transport the consumer cannot read is not an optimisation.
+  // `createImageBitmap` decodes off the main thread, so this costs the editor
+  // nothing.
+  let frame = null;
+  try {
+    if (typeof createImageBitmap === "function") {
+      frame = await createImageBitmap(video);
+      message.frame = frame;
+      message.transport = "ImageBitmap";
+      worker.postMessage(message, [frame]);
+      return;
+    }
+  } catch {
+    frame?.close?.();
+    delete message.frame;
+    message.transport = "metadata";
+  }
+  worker.postMessage(message);
+}

--- a/web/interview.js
+++ b/web/interview.js
@@ -1111,7 +1111,6 @@ function setLanguage(language) {
 /// another branch. The two-owner version this replaces needed a boolean lock, a
 /// deferred-text field that only one of the two owners got, and a lock-breaking
 /// special case for session-ending events.
-
 const BANNER_RANK = { session: 4, connection: 3, interviewer: 2, face: 1 };
 const banners = { session: "", connection: "", interviewer: "", face: "" };
 

--- a/web/interview.js
+++ b/web/interview.js
@@ -21,7 +21,6 @@ import {
 } from "./render.js";
 import {
   acceptsReport,
-  captionWindow,
   clamp,
   codeUpdatePayload,
   countdown,
@@ -36,30 +35,59 @@ import {
   timeWarningPayload,
   topics,
 } from "./lib.js";
-import { OUTPUT_NOTES, outputAfterRouting, outputOptions } from "./meet-audio.js";
 import {
-  ANALYSER_FFT_SIZE,
-  ANALYSER_WINDOW,
-  MODEL_URL,
-  createAvatar,
-  mouthFromAmplitude,
-} from "./avatar/avatar.js";
+  attachAvatarAnalyser,
+  initAvatarStage,
+  isAvatarAnalyserTrack,
+  releaseAvatarAnalyser,
+  setAvatarExpression,
+  setAvatarSpeaking,
+  startAvatar,
+  stopAvatar,
+} from "./avatar/stage.js";
+import {
+  flushReplay,
+  initReplay,
+  recordAvatarState,
+  recordConsent,
+  recordReplay,
+  recordStage,
+  recordStageTick,
+} from "./replay-feed.js";
+import {
+  AUDIO_OUTPUT_KEY,
+  MEET_PRESENTATION_KEY,
+  applyAudioOutput,
+  initAudioOutput,
+  readStored,
+  refreshAudioOutputs,
+  writeStored,
+} from "./audio-output.js";
+import {
+  PRESENCE_EVENTS,
+  initIntegrity,
+  monitorIntegrityTracks,
+  startIntegrityHeartbeat,
+  startIntegrityWorker,
+  stopIntegrityWorker,
+} from "./integrity.js";
+import { initCaptions, showCaptions, updateCaptions } from "./captions.js";
+import {
+  consentGiven,
+  initRecording,
+  startRecording,
+  withdrawRecordingConsent,
+} from "./recording-state.js";
 import { saveReportHistory } from "./history.js";
-import { TRACKING_INTERVAL_MS } from "./integrity-worker.js";
 import { createFacePresenceDetector, facePresenceVerdict } from "./face-presence.js";
 import { runBrowserTests } from "./runners.js";
 
 const languages = ["python", "javascript", "c", "cpp", "java"];
 let editorInitialized = false;
 let codePublishTimer = null;
-let recordingPoll = null;
 // The agent reads the editor once per 2s watch tick, so publishing every
 // keystroke sends ~10x more full-buffer packets than anyone consumes.
 const CODE_PUBLISH_DEBOUNCE_MS = 300;
-const CAPTION_TICK_MS = 300;
-const CAPTION_CHARS_PER_TICK = 8;
-const AUDIO_OUTPUT_KEY = "codetrial:audioOutputId";
-const MEET_PRESENTATION_KEY = "codetrial:meetPresentation";
 
 // From /runtime-config.js, which is the only thing allowed to name what the
 // server does. A literal here would be a second answer to "does this server
@@ -72,15 +100,6 @@ const consentVersion = globalThis.CODETRIAL_CONSENT_VERSION || "";
 /// every event is refused.
 const replayVersion = globalThis.CODETRIAL_REPLAY_VERSION || 1;
 
-/// Whether the recording notice has been agreed to, or does not apply.
-function consentGiven() {
-  return !recordingEnabled || nodes.recordingConsent.checked;
-}
-const INTEGRITY_HEARTBEAT_MS = 5000;
-/// Slower than the timer on purpose: the states a recording moves through are
-/// minutes apart, and a poll per second would be a request per second for a
-/// word that does not change.
-const RECORDING_POLL_MS = 15000;
 const params = new URLSearchParams(window.location.search);
 // Start this independent request while the problem data is loading. It has to
 // settle rather than reject: nothing awaits it until init() reaches the sign-in
@@ -201,17 +220,21 @@ const nodes = {
 // with a handle.
 let jimAudio = null;
 
-// Jim's face and the analyser that drives its mouth. Presentation only: no
-// frame this renders is published, recorded, or sent anywhere, and the analyser
-// reads Jim's own track, never the candidate's microphone.
-let avatar = null;
-let avatarFrame = null;
-let jimAnalyser = null;
-let jimAnalyserSource = null;
-let jimAnalyserSamples = null;
-let jimAnalyserTrack = null;
-let jimAnalyserContext = null;
-const jimAnalyserPeaks = [];
+
+// Before `init`, because the queue's first producer is inside it. The bindings
+// are handed over rather than re-derived: one `state` object, one `nodes` map.
+initReplay({ state, nodes, problem, recordingEnabled, consentVersion, replayVersion });
+initCaptions({ nodes });
+initAvatarStage({ nodes });
+initAudioOutput({ nodes, jimAudioElement: () => jimAudio });
+initRecording({ state, nodes, recordingEnabled, addTranscript, setBanner });
+initIntegrity({
+  state,
+  nodes,
+  updatePresenceBanner,
+  publishIntegrityEvent,
+  endInterview,
+});
 
 init();
 
@@ -730,144 +753,6 @@ async function connect(preflight, presenting = false) {
 }
 
 
-/// Asks the server to start recording, and then to keep saying whether it is.
-///
-/// The candidate agreed to be recorded and is owed the answer to "is it". A
-/// silent failure here is the worst outcome available: they believe the
-/// interview is being kept and it is not.
-async function startRecording() {
-  try {
-    const response = await fetch(`/api/interviews/${encodeURIComponent(state.interviewId)}/recording`, {
-      method: "POST",
-    });
-    if (!response.ok) throw new Error((await response.json())?.error || "The recording could not be started.");
-    showRecordingState(await response.json());
-  } catch (error) {
-    // Still polls. A refused start and a start that succeeded and could not be
-    // read back look the same from here, and the status route is the thing that
-    // can tell them apart: it answers 404 when there is nothing, and polling
-    // stops on that.
-    // Neutral, not a verdict. This call cannot tell a refused start from one
-    // that worked and could not be read back, and the status route can.
-    console.warn("codetrial recording_start_failed", error);
-    nodes.recordingState.hidden = false;
-    nodes.recordingState.textContent = "Checking whether the recording started.";
-  }
-  // One timer, cleared first. `connect` runs again on a reconnect, and an
-  // interval per attempt is a request per attempt per period forever. Armed
-  // only when the first answer was not already terminal, because
-  // `showRecordingState` clears it and an interval created afterwards would
-  // survive one pointless request.
-  clearInterval(recordingPoll);
-  if (!nodes.recordingState.dataset.settled) {
-    recordingPoll = setInterval(pollRecordingState, RECORDING_POLL_MS);
-  }
-}
-
-async function pollRecordingState() {
-  if (!state.interviewId) return;
-  try {
-    const response = await fetch(`/api/interviews/${encodeURIComponent(state.interviewId)}/recording`);
-    if (response.ok) {
-      showRecordingState(await response.json());
-      return;
-    }
-    // Gone, not ours, or signed out. None of these change by asking again, and
-    // a session that expired would otherwise be a request every fifteen seconds
-    // for the rest of the page's life.
-    if ([401, 403, 404].includes(response.status)) {
-      stopRecordingPoll();
-      if (response.status === 401) {
-        nodes.recordingState.hidden = false;
-        nodes.recordingState.textContent = "Sign in again to see the recording status.";
-      }
-    }
-  } catch (error) {
-    // The interview is the thing that matters; a status that cannot be read is
-    // left showing whatever it last said rather than blanked.
-    console.warn("codetrial recording_status_failed", error);
-  }
-}
-
-/// The state in words a candidate can act on. "failed" is not an instruction,
-/// so the recovery the server returns is what picks the sentence.
-function showRecordingState(status) {
-  const words = {
-    starting: "Recording is starting.",
-    recording: "Recording.",
-    finalizing: "Recording is finishing.",
-    transferring: "Recording is being saved.",
-    ready: "Recording saved. The link goes to your verified GitHub email.",
-    deleted: "Recording deleted.",
-  };
-  const recovery = {
-    start_again: "Recording stopped and was not kept.",
-    retry_delivery: "Recording was kept and has not been delivered yet.",
-    none: "Recording stopped at your request.",
-    wait_for_operator: "Recording is turned off on this server.",
-    // Neither of these means the recording is gone, and saying it was not kept
-    // would be the opposite of true: the media may still exist.
-    delete_by_hand: "Recording deletion needs an operator. It has not been deleted yet.",
-    clear_the_row_by_hand: "Recording was deleted. Its record needs an operator.",
-  };
-  nodes.recordingState.hidden = false;
-  // The recovery wins where there is one. A recording that is `transferring`
-  // with `drive_failed` is being saved and is also not delivered, and the
-  // second half is the half worth saying.
-  nodes.recordingState.textContent =
-    recovery[status?.recovery] || words[status?.state] || "Recording stopped and was not kept.";
-
-  // Nothing changes after a terminal state, so nothing keeps asking. Ending the
-  // interview is not the end of the recording: `transferring` and `ready` both
-  // happen afterwards, which is exactly when a candidate wants to know.
-  // A `failed` recording whose recovery is another delivery attempt is not
-  // finished: the transfer queue can still deliver it, and the candidate is the
-  // person who wants to know when it does.
-  const settled = ["ready", "deleted", "cleanup_failed"].includes(status?.state)
-    || (status?.state === "failed" && status?.recovery !== "retry_delivery");
-  // Recorded on the element rather than in a variable, because `startRecording`
-  // reads it after this runs and the two are not in the same call.
-  if (settled) {
-    nodes.recordingState.dataset.settled = "1";
-    stopRecordingPoll();
-  } else {
-    delete nodes.recordingState.dataset.settled;
-  }
-}
-
-/// Takes consent back, mid-interview.
-///
-/// No confirmation step. Stopping a recording is the safe direction of a
-/// misclick, because the other one cannot be undone, and a candidate reaching
-/// for this button is not in a mood to be asked twice.
-///
-/// The button does not come back. Consent that was withdrawn stays withdrawn:
-/// re-agreeing would be a new interview, and this page is already in one.
-async function withdrawRecordingConsent() {
-  if (!state.interviewId) return;
-  nodes.withdrawConsent.disabled = true;
-  try {
-    const response = await fetch(`/api/interviews/${encodeURIComponent(state.interviewId)}/consent`, {
-      method: "DELETE",
-    });
-    if (!response.ok) throw new Error("The server did not accept the request.");
-    // The replay stops here, not at the next refusal. The server will refuse
-    // it, so this changes nothing it can see; what it changes is that a
-    // candidate who has just said stop does not keep sending their editor and
-    // their words for another second while the answer comes back.
-    closeReplay();
-    // "Requested", not "stopped". This route records the withdrawal; stopping
-    // the provider and scheduling the deletion is the recording lifecycle's
-    // work, and a button that reports a completed action it did not perform is
-    // the worst possible place to be optimistic.
-    nodes.withdrawConsent.textContent = "Recording stop requested";
-    addTranscript("interviewer", "Your withdrawal is recorded. Recording will stop and the file is scheduled for deletion. Copies anyone already downloaded cannot be recalled.", true);
-  } catch (error) {
-    console.warn("codetrial withdraw_consent_failed", error);
-    nodes.withdrawConsent.disabled = false;
-    setBanner("connection", "Could not stop the recording. Try again, or end the interview.");
-  }
-}
 
 // The replay: what the candidate was looking at, sent to the server so the
 // recording template can render it and the replay page can play it back. The
@@ -875,105 +760,6 @@ async function withdrawRecordingConsent() {
 //
 // Batched, because an event per keystroke is a request per keystroke. Thirty
 // two events and a second are both the server's limits, not guesses.
-const REPLAY_FLUSH_MS = 1000;
-const REPLAY_MAX_BATCH = 32;
-
-/// How often the clock and the problem heading are restated.
-///
-/// Every second would be twenty-seven hundred events in a forty-five minute
-/// interview, most of the per-interview budget spent on a number the viewer
-/// can read off the video anyway. Fifteen seconds is a clock that is never
-/// more than fifteen seconds stale in a replay nobody scrubs to the second.
-const REPLAY_STAGE_MS = 15000;
-
-let replayQueue = [];
-let replayTimer = null;
-let replayClosed = false;
-let replayStageAt = 0;
-let replayAvatarState = "";
-
-/// One event onto the queue.
-///
-/// Every producer goes through here, so there is one answer to "is this server
-/// recording", one place the envelope is written, and one place the replay
-/// stops when the server says it has heard enough.
-function recordReplay(kind, payload) {
-  if (!recordingEnabled || !state.interviewId || replayClosed) return;
-  replayQueue.push({ v: replayVersion, kind, at: Date.now(), payload });
-  if (replayQueue.length >= REPLAY_MAX_BATCH) {
-    void flushReplay();
-    return;
-  }
-  replayTimer ||= setTimeout(() => void flushReplay(), REPLAY_FLUSH_MS);
-}
-
-/// Stop producing, and forget what has not gone yet.
-///
-/// Called when the candidate withdraws consent and when the server says it has
-/// heard enough. The queue is dropped rather than flushed: these are events
-/// from before a decision that says they should not be stored.
-function closeReplay() {
-  replayClosed = true;
-  replayQueue = [];
-  clearTimeout(replayTimer);
-  replayTimer = null;
-}
-
-/// Send what is queued.
-///
-/// Dropped rather than retried on a failure. The events are a description of an
-/// interview that is still happening, and a queue that grew through an outage
-/// would deliver a burst of stale state after it, on top of the newer state
-/// that had already arrived.
-async function flushReplay() {
-  clearTimeout(replayTimer);
-  replayTimer = null;
-  if (!replayQueue.length || replayClosed) return;
-  const batch = replayQueue.splice(0, REPLAY_MAX_BATCH);
-  try {
-    const response = await fetch(`/api/interviews/${encodeURIComponent(state.interviewId)}/events`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ events: batch }),
-    });
-    // Over quota, or an interview whose consent has been withdrawn. Both mean
-    // the server will refuse everything after this, and a producer that kept
-    // posting would spend the rest of the interview being told so.
-    if (response.status === 413 || response.status === 404) closeReplay();
-  } catch {
-    // Offline. The interview is what matters and it is still running.
-  }
-  if (replayQueue.length) replayTimer ||= setTimeout(() => void flushReplay(), REPLAY_FLUSH_MS);
-}
-
-/// The problem heading, as the recording shows it.
-function recordStage() {
-  recordReplay("stage", { title: problem.title, meta: nodes.meta.textContent });
-}
-
-/// Writes down what the candidate agreed to, and returns the interview id the
-/// token request then has to carry.
-///
-/// `null` where the server records nothing: there is no consent to take, and
-/// the token endpoint ignores the field.
-///
-/// A failure throws into `connect`'s catch, which is the right place: an
-/// interview that cannot record consent must not start, and the candidate gets
-/// the server's own sentence plus the offline practice editor rather than a
-/// recording nobody agreed to.
-async function recordConsent() {
-  if (!recordingEnabled) return null;
-  const response = await fetch("/api/interviews", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ consentVersion }),
-  });
-  if (!response.ok) {
-    throw new Error((await response.json())?.error || "Could not record your recording consent.");
-  }
-  return (await response.json()).interviewId;
-}
-
 /// `presenting` is threaded through explicitly. It was read here while only
 /// `connect` had it in scope, so every single interview threw
 /// `ReferenceError: presenting is not defined` immediately after joining the
@@ -1135,14 +921,6 @@ function setLocalAudioEnabled(enabled) {
   }
 }
 
-/// Stops asking about a recording once the interview is over.
-///
-/// The interval outlives the room otherwise: an inert timer at best, and a
-/// request every fifteen seconds for a word that will not change at worst.
-function stopRecordingPoll() {
-  clearInterval(recordingPoll);
-  recordingPoll = null;
-}
 
 function stopLocalMedia() {
   stopIntegrityWorker();
@@ -1209,10 +987,10 @@ function dropRemoteAudio(track) {
   // second participant leaving killed lip sync for the rest of the session, and
   // on reconnect a late unsubscribe for the OLD publication tore down the
   // analyser that had just been built for the new one.
-  if (track !== jimAnalyserTrack) return;
+  if (!isAvatarAnalyserTrack(track)) return;
   // The mouth is driven by an analyser whose track just went away. Left alone
   // it would freeze mid-syllable on whatever the last window held.
-  avatar?.setSpeaking(false);
+  setAvatarSpeaking(false);
   releaseAvatarAnalyser();
 }
 
@@ -1220,279 +998,6 @@ function dropRemoteAudio(track) {
 /// session that never reaches this point never downloads Three.js, and a
 /// browser without WebGL, or a checkout without a licensed jim.vrm, lands on
 /// the neutral panel that web/interview.html already carries.
-function startAvatar() {
-  if (avatar) return;
-  // Below the stylesheet's breakpoint the avatar is `display: none`, and a
-  // hidden element is not worth 11 MB of model, 730 KB of renderer, one of the
-  // page's ~16 WebGL contexts and a 60 Hz loop drawing into a 1x1 canvas. The
-  // computed style is asked rather than the breakpoint restated, so the CSS
-  // stays the only place that decides where the avatar is shown.
-  if (!nodes.jimAvatar || window.getComputedStyle(nodes.jimAvatar).display === "none") return;
-  const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true;
-  avatar = createAvatar({
-    mount: nodes.jimAvatar,
-    reducedMotion,
-    // The panel says which of the two things happened, because "Jim is here by
-    // voice" under a blank box is indistinguishable from a broken page.
-    onState: (next) => {
-      if (next !== "unavailable") return;
-      nodes.jimAvatarNote.textContent = "Jim is here by voice; his avatar is unavailable in this browser.";
-    },
-    loadModel: async () => {
-      // Ask whether the model is published before importing the renderer.
-      // Without this every candidate downloads 730 KB of Three.js only to
-      // discover a 404, which is exactly the state of the repo today.
-      const published = await fetch(MODEL_URL, { method: "HEAD" });
-      if (!published.ok) throw new Error(`${MODEL_URL} is not published`);
-      const renderer = await import("./avatar/vrm.js");
-      return renderer.loadVrm({ mount: nodes.jimAvatar });
-    },
-  });
-  // Started only once something can actually render. Pumping regardless meant
-  // every session without a model, which is all of them today, ran a 60 Hz
-  // loop that read the analyser and threw the result away.
-  void avatar.ready.then((rendered) => {
-    if (!rendered) return;
-    // Read by the avatar browser check, which has no other way to tell a
-    // running render loop from a canvas that was created once and abandoned.
-    window.__codetrialAvatarFrames = () => avatar?.frames() ?? 0;
-    // Through `resumeAvatar`, not straight into the loop. A tab that became
-    // visible while the model was still loading has already started one, and
-    // two loops is two analyser reads and two poses a frame.
-    resumeAvatar();
-  });
-}
-
-function pumpAvatar(at) {
-  if (!avatar) return;
-  // A hidden document stops asking for frames rather than asking and returning
-  // early. Browsers already throttle `requestAnimationFrame` in a background
-  // tab, so what this buys is small and it is not nothing: the analyser read
-  // and the humanoid update stop too, and `resumeAvatar` below is what starts
-  // them again. Written as "stop scheduling" rather than "skip a frame"
-  // because a loop that keeps scheduling is a loop that is still running.
-  if (document.hidden) {
-    avatarFrame = null;
-    return;
-  }
-  avatarFrame = requestAnimationFrame(pumpAvatar);
-  // Hidden by the CSS breakpoint, which the candidate can cross at any time by
-  // narrowing the window or docking devtools. startAvatar only samples this
-  // once, so without the check the humanoid rig, expressions and constraints
-  // kept running 60 times a second to produce no pixels.
-  //
-  // The preflight overlay is the same argument by a different route: it is
-  // opaque and covers the stage, so a model that finishes loading while the
-  // candidate is still granting a camera would otherwise render behind it,
-  // taking main-thread frames away from the level meter and the face detector.
-  // The width check cannot see this, because an element under an overlay still
-  // has its width. Loading early is the point; drawing early is not.
-  if (!nodes.jimAvatar.clientWidth || !nodes.audioCheck.hidden) return;
-  avatar.setMouth(mouthFromAmplitude(jimAmplitude()));
-  // The rAF timestamp is the frame's target time and is identical across every
-  // callback in that frame; performance.now() drifts by however long the loop
-  // took to reach us.
-  avatar.frame(at ?? performance.now());
-}
-
-/// Starts the render loop again after the tab comes back.
-///
-/// One listener for the life of the page, added beside the loop rather than
-/// inside it: a listener added per frame is sixty listeners a second.
-function resumeAvatar() {
-  // `state()` and not just `avatar`: `createAvatar` returns before the model
-  // has loaded, so a visibility change during the load would otherwise start a
-  // loop that poses nothing sixty times a second.
-  if (!avatar || avatar.state() !== "ready" || document.hidden || avatarFrame !== null) return;
-  pumpAvatar();
-}
-
-document.addEventListener("visibilitychange", resumeAvatar);
-
-/// Jim's own track, never the candidate's. `createMediaElementSource` would be
-/// the obvious call and is the wrong one: it returns silence for a
-/// MediaStream-backed element, so the mouth would never open.
-function attachAvatarAnalyser(track, participant) {
-  // Jim only. playRemoteAudio fires for every remote audio track, and this used
-  // to take whichever arrived first: a second participant, or a stray hosted
-  // agent of the kind scripts/browser-check.cjs already has to isolate, would
-  // have driven the mouth. Never the candidate, who is never subscribed here.
-  if (!isAgent(participant)) return;
-  if (!track?.mediaStreamTrack || track === jimAnalyserTrack) return;
-  // A new publication replaces the old analyser rather than being ignored.
-  // Bailing out on `jimAnalyser` alone left the analyser bound to the track
-  // that had just been replaced, and LiveKit does not promise the unsubscribe
-  // for the old publication arrives before the subscribe for the new one: when
-  // it arrived after, `dropRemoteAudio` tore down the only analyser there was
-  // and nothing rebuilt it, so lip sync died for the rest of the session.
-  if (jimAnalyser) releaseAvatarAnalyser();
-  try {
-    jimAnalyserContext ||= new (window.AudioContext || window.webkitAudioContext)();
-    // TrackSubscribed is not a user gesture, so a context first built here can
-    // arrive suspended and then read silence forever. The mouth would simply
-    // never open, with nothing anywhere saying why.
-    if (jimAnalyserContext.state === "suspended") void jimAnalyserContext.resume().catch(() => {});
-    jimAnalyserSource = jimAnalyserContext.createMediaStreamSource(new MediaStream([track.mediaStreamTrack]));
-    jimAnalyser = jimAnalyserContext.createAnalyser();
-    jimAnalyser.fftSize = ANALYSER_FFT_SIZE;
-    // One buffer for the session. Allocating it per frame produced 512 bytes of
-    // garbage 60 times a second for the whole interview.
-    jimAnalyserSamples = new Uint8Array(jimAnalyser.fftSize);
-    jimAnalyserTrack = track;
-    // Not connected to the destination: the audio element is already playing
-    // this track, and a second path would play Jim twice.
-    jimAnalyserSource.connect(jimAnalyser);
-    resumeAnalyserOnGesture();
-  } catch {
-    // No analyser means no lip-sync. Everything else about the avatar, and all
-    // of the audio, still works.
-    releaseAvatarAnalyser();
-  }
-}
-
-/// LiveKit re-subscribes Jim on every reconnect, so this runs more than once
-/// per session. Without disconnecting the source node, each reconnect left a
-/// live MediaStreamAudioSourceNode attached to the same context.
-function releaseAvatarAnalyser() {
-  jimAnalyserSource?.disconnect();
-  jimAnalyserSource = null;
-  jimAnalyser = null;
-  jimAnalyserSamples = null;
-  jimAnalyserTrack = null;
-  jimAnalyserPeaks.length = 0;
-}
-
-/// Safari refuses `resume()` unless the call is inside a user gesture, and
-/// `TrackSubscribed` is not one, so a context first built there stays suspended
-/// for the rest of the interview. The analyser then reads silence forever: the
-/// avatar's mouth never opens, and the code above already predicted exactly
-/// that without being able to do anything about it. Chrome resumes from
-/// anywhere, which is why this survived.
-///
-/// The listeners are capturing and one-shot. A candidate who never touches the
-/// page again keeps a suspended context, which is the state it was already in.
-let gestureResumePending = false;
-
-function resumeAnalyserOnGesture() {
-  if (!jimAnalyserContext || jimAnalyserContext.state !== "suspended") return;
-  // LiveKit re-subscribes Jim on every reconnect, so this runs more than once.
-  // Without the guard a context that stays suspended across two subscribes
-  // collects two pairs of listeners; they do unregister themselves on the first
-  // gesture, but registering them at all was pointless.
-  if (gestureResumePending) return;
-  gestureResumePending = true;
-  function stop() {
-    gestureResumePending = false;
-    document.removeEventListener("pointerdown", resume, true);
-    document.removeEventListener("keydown", resume, true);
-  }
-  function resume() {
-    if (!jimAnalyserContext || jimAnalyserContext.state !== "suspended") {
-      stop();
-      return;
-    }
-    void jimAnalyserContext.resume().then(stop).catch(() => {});
-  }
-  document.addEventListener("pointerdown", resume, true);
-  document.addEventListener("keydown", resume, true);
-}
-
-function jimAmplitude() {
-  if (!jimAnalyser || !jimAnalyserSamples) return 0;
-  jimAnalyser.getByteTimeDomainData(jimAnalyserSamples);
-  jimAnalyserPeaks.push(peakLevel(jimAnalyserSamples));
-  if (jimAnalyserPeaks.length > ANALYSER_WINDOW) jimAnalyserPeaks.shift();
-  return jimAnalyserPeaks.reduce((total, peak) => total + peak, 0) / jimAnalyserPeaks.length;
-}
-
-function stopAvatar() {
-  if (avatarFrame !== null) cancelAnimationFrame(avatarFrame);
-  avatarFrame = null;
-  avatar?.destroy();
-  avatar = null;
-  releaseAvatarAnalyser();
-  void jimAnalyserContext?.close?.().catch(() => {});
-  jimAnalyserContext = null;
-}
-
-/// Lists output devices so Jim can be routed away from the shared tab's
-/// default. No mixer and no synthetic microphone: Meet captures the tab, and
-/// CodeTrial only decides which speaker plays the tab's own audio.
-async function refreshAudioOutputs() {
-  const mediaDevices = navigator.mediaDevices;
-  if (!mediaDevices?.enumerateDevices || !("setSinkId" in HTMLMediaElement.prototype)) {
-    // Hide the row, not just the control: a label pointing at a hidden select
-    // renders as a heading with nothing under it.
-    nodes.meetOutputRow.hidden = true;
-    showOutputNote(OUTPUT_NOTES.unsupported);
-    return;
-  }
-  let devices = [];
-  try {
-    devices = await mediaDevices.enumerateDevices();
-  } catch {
-    showOutputNote(OUTPUT_NOTES.listFailed);
-    return;
-  }
-  const options = outputOptions(devices, readStored(AUDIO_OUTPUT_KEY));
-  nodes.meetOutputSelect.replaceChildren();
-  for (const option of options) {
-    const element = document.createElement("option");
-    element.value = option.deviceId;
-    element.textContent = option.label;
-    element.selected = option.selected;
-    nodes.meetOutputSelect.append(element);
-  }
-  showOutputNote(options.length ? "" : OUTPUT_NOTES.empty);
-}
-
-async function applyAudioOutput(deviceId) {
-  if (!deviceId) return;
-  const previous = readStored(AUDIO_OUTPUT_KEY);
-  writeStored(AUDIO_OUTPUT_KEY, deviceId);
-  if (!jimAudio || typeof jimAudio.setSinkId !== "function") return;
-  const routed = await jimAudio
-    .setSinkId(deviceId)
-    .then(() => true)
-    .catch(() => false);
-  // Cleared, not left alone, when there is no previous device to restore. The
-  // refused id was written before routing was attempted, so leaving it would
-  // persist a device Jim never played through: the next reload would pre-select
-  // it and retry the same refusal.
-  const stored = outputAfterRouting(previous, deviceId, routed);
-  writeStored(AUDIO_OUTPUT_KEY, stored);
-  nodes.meetOutputSelect.value = stored || "";
-  // An empty list keeps its explanation: routing succeeding says nothing about
-  // whether there was anything to choose from.
-  const note = routed ? "" : OUTPUT_NOTES.refused;
-  if (note || nodes.meetOutputSelect.length) showOutputNote(note);
-}
-
-function showOutputNote(text) {
-  nodes.meetOutputNote.textContent = text;
-  nodes.meetOutputNote.hidden = !text;
-}
-
-function readStored(key, storage = localStorage) {
-  try {
-    return storage.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
-/// An empty value clears the key: "no preference" and "the empty preference"
-/// are the same thing, and a separate clearStored existed only so one call site
-/// could pick between them.
-function writeStored(key, value, storage = localStorage) {
-  try {
-    if (value) storage.setItem(key, value);
-    else storage.removeItem(key);
-  } catch {
-    // Private browsing refuses writes; a preference is not worth failing on.
-  }
-}
-
 async function consumeTranscript(room, reader, participant) {
   const attrs = reader.info?.attributes || {};
   const id = attrs["lk.segment_id"] || reader.info?.id || randomId();
@@ -1519,66 +1024,6 @@ async function consumeTranscript(room, reader, participant) {
     // few words and a turn is a sentence, and the replay is read as sentences.
     recordReplay("transcript", { speaker, text: text.trim() });
   }
-}
-
-// One uninterrupted spoken turn is unbounded, and the caption line sits in the
-// header: rendered whole, a long answer pushes the timer and the controls off
-// the screen. The tail is the part being spoken.
-const CAPTION_MAX_CHARS = 160;
-// Long enough to finish reading a sentence that just landed, short enough that
-// a silent pause clears the editor's corner.
-const CAPTION_IDLE_HIDE_MS = 12000;
-let captionIdleTimer = null;
-let interviewerCaption = { id: null, text: "", shown: 0, timer: null };
-
-function updateCaptions(speaker, text, id = null) {
-  if (!nodes.captionsText) return;
-  if (speaker === "interviewer") {
-    if (interviewerCaption.id !== id) {
-      clearTimeout(interviewerCaption.timer);
-      interviewerCaption = { id, text: "", shown: 0, timer: null };
-    }
-    // The longest, not the latest. Every interim publish carries the whole turn
-    // so far on a stream of its own, so one that lands out of order is a
-    // shorter copy of what is already on screen, and taking it would rewind the
-    // reveal to a few characters and replay the line.
-    if (text.length > interviewerCaption.text.length) interviewerCaption.text = text;
-    if (!interviewerCaption.timer) paceInterviewerCaption();
-    return;
-  }
-  // Stop pacing Jim: the next tick would otherwise repaint his line over the
-  // candidate's. A later chunk of the same segment restarts it through the
-  // `!interviewerCaption.timer` check below.
-  clearTimeout(interviewerCaption.timer);
-  interviewerCaption.timer = null;
-  const clipped = captionWindow(text, CAPTION_MAX_CHARS);
-  nodes.captionsText.textContent = `[${speaker === "you" ? "You" : "Jim"}]: ${clipped}`;
-  showCaptions();
-}
-
-function paceInterviewerCaption() {
-  const caption = interviewerCaption;
-  caption.shown = Math.min(caption.text.length, caption.shown + CAPTION_CHARS_PER_TICK);
-  nodes.captionsText.textContent = `[Jim]: ${captionWindow(caption.text.slice(0, caption.shown), CAPTION_MAX_CHARS)}`;
-  showCaptions();
-  if (caption.shown < caption.text.length) {
-    caption.timer = setTimeout(paceInterviewerCaption, CAPTION_TICK_MS);
-  } else {
-    caption.timer = null;
-  }
-}
-
-/// Captions are a live subtitle, not a log: the transcript tab already keeps
-/// every turn. Leaving the last thing anyone said pinned over the editor for
-/// the rest of the interview is just an obstruction, so the bar retires once
-/// nobody has spoken for a while and comes back on the next word.
-function showCaptions() {
-  if (!nodes.captionsBar) return;
-  nodes.captionsBar.hidden = false;
-  clearTimeout(captionIdleTimer);
-  captionIdleTimer = setTimeout(() => {
-    nodes.captionsBar.hidden = true;
-  }, CAPTION_IDLE_HIDE_MS);
 }
 
 async function toggleMicrophone() {
@@ -1660,132 +1105,13 @@ function setLanguage(language) {
   }, CODE_PUBLISH_DEBOUNCE_MS);
 }
 
-function monitorIntegrityTracks() {
-  // A released camera is simply not in the stream, so this watches nothing and
-  // no CAMERA_STOPPED is invented out of our own teardown.
-  watchIntegrityTrack(state.localUserStream?.getVideoTracks?.()[0], "CAMERA_STOPPED", "camera");
-  watchIntegrityTrack(state.localUserStream?.getAudioTracks?.()[0], "MICROPHONE_STOPPED", "microphone");
-  startIntegrityTrackStateMonitor();
-}
-
-function watchIntegrityTrack(track, stoppedType, source) {
-  if (!track?.addEventListener) return;
-  track.addEventListener("ended", () => {
-    void publishIntegrityEvent({ type: stoppedType, source, severity: "high" });
-  });
-  track.addEventListener("mute", () => {
-    void publishIntegrityEvent({ type: `${source.toUpperCase()}_MUTED`, source, severity: "warning" });
-  });
-  track.addEventListener("unmute", () => {
-    void publishIntegrityEvent({ type: `${source.toUpperCase()}_UNMUTED`, source, severity: "info" });
-  });
-}
-
-function startIntegrityHeartbeat() {
-  clearInterval(state.integrityHeartbeatTimer);
-  state.integrityHeartbeatTimer = setInterval(() => {
-    void publishIntegrityEvent({
-      type: "INTEGRITY_HEARTBEAT",
-      source: "heartbeat",
-      severity: "info",
-      detail: integrityHeartbeatDetail(),
-    });
-  }, INTEGRITY_HEARTBEAT_MS);
-}
-
-function integrityHeartbeatDetail() {
-  const camera = state.localUserStream?.getVideoTracks?.()[0];
-  const mic = state.localUserStream?.getAudioTracks?.()[0];
-  const status = (track) => `${track?.readyState || "missing"}/${track?.enabled === false ? "off" : "on"}/${track?.muted ? "muted" : "unmuted"}`;
-  return `camera=${status(camera)};microphone=${status(mic)};analyzer=${state.integrityAnalysisDetail}`;
-}
-
-function startIntegrityTrackStateMonitor() {
-  clearInterval(state.integrityTrackStateTimer);
-  state.integrityTrackStates.clear();
-  const tracks = () => [
-    ["camera", state.localUserStream?.getVideoTracks?.()[0]],
-    ["microphone", state.localUserStream?.getAudioTracks?.()[0]],
-  ];
-  const poll = () => {
-    for (const [source, track] of tracks()) {
-      if (!track) continue;
-      const current = `${track.readyState || "missing"}/${track.enabled === false ? "off" : "on"}`;
-      const previous = state.integrityTrackStates.get(source);
-      state.integrityTrackStates.set(source, current);
-      if (previous && previous !== current) {
-        void publishIntegrityEvent({
-          type: `${source.toUpperCase()}_STATE_CHANGED`,
-          source,
-          severity: current.includes("ended") || current.includes("/off") ? "warning" : "info",
-          detail: current,
-        });
-      }
-    }
-  };
-  poll();
-  state.integrityTrackStateTimer = setInterval(poll, 1000);
-}
-
-function startIntegrityWorker() {
-  stopIntegrityWorker();
-  if (typeof Worker !== "function") {
-    state.integrityAnalysisDetail = "worker_unavailable";
-    return;
-  }
-  state.integrityAnalysisDetail = "worker_starting";
-  const worker = new Worker("/integrity-worker.js", { type: "module" });
-  state.integrityWorker = worker;
-  worker.onmessage = (event) => {
-    if (event.data?.type === "analysis") state.integrityAnalysisDetail = event.data.detail;
-    if (event.data?.type === "integrity-event") {
-      const eventType = event.data.eventType;
-      updatePresenceBanner(eventType);
-      const published = publishIntegrityEvent({
-        type: eventType,
-        source: event.data.source,
-        severity: event.data.severity,
-        durationMs: event.data.durationMs,
-        detail: event.data.detail,
-      });
-      // The event that caused the termination goes out before the end control
-      // does. The other order lets the agent start generating the report on the
-      // control message while the reason for it is still queued, and the report
-      // then omits why it exists.
-      if (PRESENCE_EVENTS[eventType]?.endsInterview) {
-        void published.then(() => endInterview("face_missing_severe"));
-      }
-    }
-  };
-
-  worker.onerror = () => {
-    state.integrityAnalysisDetail = "worker_error";
-  };
-  state.integrityFrameSamplers = [
-    startIntegrityFrameSampler("camera", state.localUserStream?.getVideoTracks?.()[0], nodes.cameraIntegrityVideo, TRACKING_INTERVAL_MS),
-  ].filter(Boolean);
-}
-
-// One row per presence event, so a new one is a row rather than another branch
-// on the same value in the worker message handler. `clears` empties the banner;
-// `endsInterview` is the only event allowed to close the session by itself.
-const PRESENCE_EVENTS = {
-  FACE_DETECTED: { clears: true },
-  FACE_MISSING: { banner: "Stay in front of the camera: no interviewee detected." },
-  MULTIPLE_FACES: { banner: "Take the interview alone: more than one face detected." },
-  FACE_DETECTOR_UNAVAILABLE: { banner: "Face detection is not running in this browser." },
-  FACE_MISSING_SEVERE: {
-    banner: "Interview ended automatically: away from the camera too long.",
-    endsInterview: true,
-  },
-};
-
 /// One banner element, several owners, ranked. Each owner keeps its own slot,
 /// so a warning raised while a higher-ranked one is showing is deferred rather
 /// than thrown away, and every owner is a row here instead of another flag and
 /// another branch. The two-owner version this replaces needed a boolean lock, a
 /// deferred-text field that only one of the two owners got, and a lock-breaking
 /// special case for session-ending events.
+
 const BANNER_RANK = { session: 4, connection: 3, interviewer: 2, face: 1 };
 const banners = { session: "", connection: "", interviewer: "", face: "" };
 
@@ -1807,90 +1133,6 @@ function updatePresenceBanner(eventType) {
   setBanner(entry.endsInterview ? "session" : "face", entry.clears ? "" : entry.banner || "");
 }
 
-function stopIntegrityWorker() {
-  for (const stop of state.integrityFrameSamplers) stop();
-  state.integrityFrameSamplers = [];
-  state.integrityWorker?.terminate();
-  state.integrityWorker = null;
-  state.integrityAnalysisDetail = "not_configured";
-}
-
-function startIntegrityFrameSampler(source, track, video, intervalMs) {
-  if (!track || !video || !state.integrityWorker) return null;
-  const ownsVideo = !video.srcObject;
-  if (ownsVideo) {
-    video.muted = true;
-    video.playsInline = true;
-    video.srcObject = new MediaStream([track]);
-    void video.play?.().catch(() => {});
-  }
-  const timer = setInterval(() => {
-    void postIntegrityFrame(source, track, video);
-  }, intervalMs);
-  void postIntegrityFrame(source, track, video);
-  return () => {
-    clearInterval(timer);
-    if (ownsVideo) video.srcObject = null;
-  };
-}
-
-async function postIntegrityFrame(source, track, video) {
-  // `muted` as well as `readyState`. An ended track stops the sampler already,
-  // but a track another application has taken stays `live` and simply delivers
-  // nothing: the element keeps handing over its last frame, or a black one, and
-  // the detector charges every one of them as an absent candidate until the
-  // 15s severe threshold ends the interview. Opening the camera in Google Meet
-  // does exactly that. A camera that was taken away is a gap in sampling, and
-  // face-presence.js is explicit that a gap is not an observation. The `mute`
-  // listener still publishes CAMERA_MUTED, so the evidence survives for human
-  // review; it just no longer masquerades as the candidate walking off.
-  //
-  // The analyzer detail has to say so. The heartbeat publishes it every five
-  // seconds, and left at its last successful value it would keep reporting
-  // camera analyses while nothing has been sampled for minutes -- an integrity
-  // record claiming an observation that never happened.
-  if (track.muted) state.integrityAnalysisDetail = `${source}_muted`;
-  if (track.readyState !== "live" || track.muted || !state.integrityWorker) return;
-  const worker = state.integrityWorker;
-  const message = {
-    type: "frame",
-    source,
-    // Monotonic, not wall clock. A lid close, an OS suspend or an NTP step
-    // moves `Date.now()` forward by minutes between two frames, and the face
-    // tracker reads the difference as "absent for minutes" and ends the
-    // interview on the first frame after resume.
-    at: performance.now(),
-    width: video.videoWidth || 0,
-    height: video.videoHeight || 0,
-    transport: "metadata",
-  };
-  if (video.readyState < 2) {
-    worker.postMessage(message);
-    return;
-  }
-  // `ImageBitmap`, not the cheaper `VideoFrame` handle. The only consumer of
-  // these pixels is MediaPipe, which reads `image.width`: a `VideoFrame` carries
-  // `codedWidth`/`displayWidth` and no `width`, so it reached the detector as an
-  // undefined size and threw, and every interview reported face detection as
-  // unavailable. A transport the consumer cannot read is not an optimisation.
-  // `createImageBitmap` decodes off the main thread, so this costs the editor
-  // nothing.
-  let frame = null;
-  try {
-    if (typeof createImageBitmap === "function") {
-      frame = await createImageBitmap(video);
-      message.frame = frame;
-      message.transport = "ImageBitmap";
-      worker.postMessage(message, [frame]);
-      return;
-    }
-  } catch {
-    frame?.close?.();
-    delete message.frame;
-    message.transport = "metadata";
-  }
-  worker.postMessage(message);
-}
 
 /// A repaint, not a clock. `state.remaining` used to be decremented once per
 /// firing, so a hidden or minimised tab, which browsers throttle to roughly one
@@ -1905,10 +1147,7 @@ function tickTimer() {
   state.remaining = tick.remaining;
   nodes.timer.textContent = formatTime(tick.remaining);
   nodes.timer.classList.toggle("urgent", tick.urgent);
-  if (Date.now() - replayStageAt >= REPLAY_STAGE_MS) {
-    replayStageAt = Date.now();
-    recordReplay("stage", { remainingSeconds: tick.remaining });
-  }
+  recordStageTick(tick.remaining);
   if (tick.warn) publish(topics.control, timeWarningPayload(tick.remaining));
   if (tick.expired) endInterview("time_up");
 }
@@ -2199,19 +1438,16 @@ function updateAgentState() {
   // The same three states the pill shows. `questioning`, `encouraging`, and
   // `challenging` wait for src/agent.rs to publish lk.avatar.state; inventing
   // them here would be the avatar guessing at the interviewer's intent.
-  avatar?.setExpression(value);
+  setAvatarExpression(value);
   // On the change, not on the tick. This runs for every participant event, and
   // an interviewer who stays in one state for a minute is one event, not sixty.
-  if (value !== replayAvatarState) {
-    replayAvatarState = value;
-    recordReplay("avatar", { state: value });
-  }
+  recordAvatarState(value);
   // Only an agent that actually publishes its state may close the jaw. Muting
   // on the "listening" fallback is the same bug as muting on a missing agent
   // participant: an interviewer whose attribute never arrives, or arrives
   // stale, would talk through the whole interview with his mouth shut. Audio is
   // the signal that cannot lie, and silence closes the mouth on its own.
-  if (published) avatar?.setSpeaking(published === "speaking");
+  if (published) setAvatarSpeaking(published === "speaking");
 }
 
 function isCurrentAgent(participant) {

--- a/web/meet-audio.js
+++ b/web/meet-audio.js
@@ -44,5 +44,12 @@ export function outputOptions(devices, savedId) {
 /// A refusal therefore has to roll the stored value back, or the select and the
 /// real sink disagree until the next reload.
 export function outputAfterRouting(previous, requested, routed) {
-  return routed ? requested : previous;
+  if (routed) return requested;
+  // A refusal falls back to the device that was working before, except when
+  // that is the same device: reapplying a stored preference on reload passes
+  // the same id as both, so returning `previous` would write the refused id
+  // straight back and retry it on every reload for the life of the browser
+  // profile. There is no earlier device to fall back to, so the preference
+  // clears and the next load uses the system default.
+  return previous === requested ? "" : previous;
 }

--- a/web/recording-state.js
+++ b/web/recording-state.js
@@ -82,10 +82,17 @@ export async function pollRecordingState() {
     // for the rest of the page's life.
     if ([401, 403, 404].includes(response.status)) {
       stopRecordingPoll();
-      if (response.status === 401) {
-        nodes.recordingState.hidden = false;
-        nodes.recordingState.textContent = "Sign in again to see the recording status.";
-      }
+      nodes.recordingState.hidden = false;
+      // Every one of these is terminal, so every one of them replaces the
+      // label. Stopping the poll and leaving "Checking whether the recording
+      // started." on screen is the worst reading available: the candidate
+      // agreed to be recorded and is left believing the answer is still
+      // coming, forever, when the server has already said there is nothing.
+      nodes.recordingState.textContent =
+        response.status === 401
+          ? "Sign in again to see the recording status."
+          : "The recording did not start. The interview is not being recorded.";
+      nodes.recordingState.dataset.settled = "1";
     }
   } catch (error) {
     // The interview is the thing that matters; a status that cannot be read is

--- a/web/recording-state.js
+++ b/web/recording-state.js
@@ -1,0 +1,184 @@
+/// Starting a recording, saying whether it is running, and stopping it when the
+/// candidate withdraws.
+///
+/// Split out of `interview.js` because the candidate agreed to be recorded and
+/// is owed the answer to "is it". That answer is a request, a poll, a label and
+/// a withdrawal button that must never claim more than it did, and keeping them
+/// together is what stops the label and the truth from drifting apart.
+///
+/// `addTranscript` and `setBanner` arrive as functions rather than being
+/// imported: they write into the page's transcript view and banner state, which
+/// `interview.js` owns, and importing them back would make the two files
+/// circular.
+
+import { closeReplay } from "./replay-feed.js";
+
+let state = null;
+let nodes = null;
+let recordingEnabled = false;
+let addTranscript = () => {};
+let setBanner = () => {};
+
+export function initRecording(deps) {
+  ({ state, nodes, recordingEnabled, addTranscript, setBanner } = deps);
+}
+
+let recordingPoll = null;
+
+/// Slower than the timer on purpose: the states a recording moves through are
+/// minutes apart, and a poll per second would be a request per second for a
+/// word that does not change.
+const RECORDING_POLL_MS = 15000;
+
+/// Whether the recording notice has been agreed to, or does not apply.
+export function consentGiven() {
+  return !recordingEnabled || nodes.recordingConsent.checked;
+}
+
+/// Asks the server to start recording, and then to keep saying whether it is.
+///
+/// The candidate agreed to be recorded and is owed the answer to "is it". A
+/// silent failure here is the worst outcome available: they believe the
+/// interview is being kept and it is not.
+export async function startRecording() {
+  try {
+    const response = await fetch(`/api/interviews/${encodeURIComponent(state.interviewId)}/recording`, {
+      method: "POST",
+    });
+    if (!response.ok) throw new Error((await response.json())?.error || "The recording could not be started.");
+    showRecordingState(await response.json());
+  } catch (error) {
+    // Still polls. A refused start and a start that succeeded and could not be
+    // read back look the same from here, and the status route is the thing that
+    // can tell them apart: it answers 404 when there is nothing, and polling
+    // stops on that.
+    // Neutral, not a verdict. This call cannot tell a refused start from one
+    // that worked and could not be read back, and the status route can.
+    console.warn("codetrial recording_start_failed", error);
+    nodes.recordingState.hidden = false;
+    nodes.recordingState.textContent = "Checking whether the recording started.";
+  }
+  // One timer, cleared first. `connect` runs again on a reconnect, and an
+  // interval per attempt is a request per attempt per period forever. Armed
+  // only when the first answer was not already terminal, because
+  // `showRecordingState` clears it and an interval created afterwards would
+  // survive one pointless request.
+  clearInterval(recordingPoll);
+  if (!nodes.recordingState.dataset.settled) {
+    recordingPoll = setInterval(pollRecordingState, RECORDING_POLL_MS);
+  }
+}
+
+export async function pollRecordingState() {
+  if (!state.interviewId) return;
+  try {
+    const response = await fetch(`/api/interviews/${encodeURIComponent(state.interviewId)}/recording`);
+    if (response.ok) {
+      showRecordingState(await response.json());
+      return;
+    }
+    // Gone, not ours, or signed out. None of these change by asking again, and
+    // a session that expired would otherwise be a request every fifteen seconds
+    // for the rest of the page's life.
+    if ([401, 403, 404].includes(response.status)) {
+      stopRecordingPoll();
+      if (response.status === 401) {
+        nodes.recordingState.hidden = false;
+        nodes.recordingState.textContent = "Sign in again to see the recording status.";
+      }
+    }
+  } catch (error) {
+    // The interview is the thing that matters; a status that cannot be read is
+    // left showing whatever it last said rather than blanked.
+    console.warn("codetrial recording_status_failed", error);
+  }
+}
+
+/// The state in words a candidate can act on. "failed" is not an instruction,
+/// so the recovery the server returns is what picks the sentence.
+export function showRecordingState(status) {
+  const words = {
+    starting: "Recording is starting.",
+    recording: "Recording.",
+    finalizing: "Recording is finishing.",
+    transferring: "Recording is being saved.",
+    ready: "Recording saved. The link goes to your verified GitHub email.",
+    deleted: "Recording deleted.",
+  };
+  const recovery = {
+    start_again: "Recording stopped and was not kept.",
+    retry_delivery: "Recording was kept and has not been delivered yet.",
+    none: "Recording stopped at your request.",
+    wait_for_operator: "Recording is turned off on this server.",
+    // Neither of these means the recording is gone, and saying it was not kept
+    // would be the opposite of true: the media may still exist.
+    delete_by_hand: "Recording deletion needs an operator. It has not been deleted yet.",
+    clear_the_row_by_hand: "Recording was deleted. Its record needs an operator.",
+  };
+  nodes.recordingState.hidden = false;
+  // The recovery wins where there is one. A recording that is `transferring`
+  // with `drive_failed` is being saved and is also not delivered, and the
+  // second half is the half worth saying.
+  nodes.recordingState.textContent =
+    recovery[status?.recovery] || words[status?.state] || "Recording stopped and was not kept.";
+
+  // Nothing changes after a terminal state, so nothing keeps asking. Ending the
+  // interview is not the end of the recording: `transferring` and `ready` both
+  // happen afterwards, which is exactly when a candidate wants to know.
+  // A `failed` recording whose recovery is another delivery attempt is not
+  // finished: the transfer queue can still deliver it, and the candidate is the
+  // person who wants to know when it does.
+  const settled = ["ready", "deleted", "cleanup_failed"].includes(status?.state)
+    || (status?.state === "failed" && status?.recovery !== "retry_delivery");
+  // Recorded on the element rather than in a variable, because `startRecording`
+  // reads it after this runs and the two are not in the same call.
+  if (settled) {
+    nodes.recordingState.dataset.settled = "1";
+    stopRecordingPoll();
+  } else {
+    delete nodes.recordingState.dataset.settled;
+  }
+}
+
+/// Takes consent back, mid-interview.
+///
+/// No confirmation step. Stopping a recording is the safe direction of a
+/// misclick, because the other one cannot be undone, and a candidate reaching
+/// for this button is not in a mood to be asked twice.
+///
+/// The button does not come back. Consent that was withdrawn stays withdrawn:
+/// re-agreeing would be a new interview, and this page is already in one.
+export async function withdrawRecordingConsent() {
+  if (!state.interviewId) return;
+  nodes.withdrawConsent.disabled = true;
+  try {
+    const response = await fetch(`/api/interviews/${encodeURIComponent(state.interviewId)}/consent`, {
+      method: "DELETE",
+    });
+    if (!response.ok) throw new Error("The server did not accept the request.");
+    // The replay stops here, not at the next refusal. The server will refuse
+    // it, so this changes nothing it can see; what it changes is that a
+    // candidate who has just said stop does not keep sending their editor and
+    // their words for another second while the answer comes back.
+    closeReplay();
+    // "Requested", not "stopped". This route records the withdrawal; stopping
+    // the provider and scheduling the deletion is the recording lifecycle's
+    // work, and a button that reports a completed action it did not perform is
+    // the worst possible place to be optimistic.
+    nodes.withdrawConsent.textContent = "Recording stop requested";
+    addTranscript("interviewer", "Your withdrawal is recorded. Recording will stop and the file is scheduled for deletion. Copies anyone already downloaded cannot be recalled.", true);
+  } catch (error) {
+    console.warn("codetrial withdraw_consent_failed", error);
+    nodes.withdrawConsent.disabled = false;
+    setBanner("connection", "Could not stop the recording. Try again, or end the interview.");
+  }
+}
+
+/// Stops asking about a recording once the interview is over.
+///
+/// The interval outlives the room otherwise: an inert timer at best, and a
+/// request every fifteen seconds for a word that will not change at worst.
+export function stopRecordingPoll() {
+  clearInterval(recordingPoll);
+  recordingPoll = null;
+}

--- a/web/replay-feed.js
+++ b/web/replay-feed.js
@@ -72,9 +72,24 @@ export function closeReplay() {
 /// interview that is still happening, and a queue that grew through an outage
 /// would deliver a burst of stale state after it, on top of the newer state
 /// that had already arrived.
-export async function flushReplay() {
+/// One flush at a time, in the order they were asked for.
+///
+/// `recordReplay` starts one whenever the queue fills, and the interview's last
+/// act awaits one. Left unserialized, a batch posted while another was still
+/// awaiting `fetch` could commit first, and the replay would be ordered by
+/// whichever request the server happened to finish rather than by what the
+/// candidate did. Chained rather than skipped, because a caller that is told
+/// "already flushing" and returns has silently dropped its own batch.
+let flushChain = Promise.resolve();
+
+export function flushReplay() {
   clearTimeout(replayTimer);
   replayTimer = null;
+  flushChain = flushChain.then(sendQueuedBatch);
+  return flushChain;
+}
+
+async function sendQueuedBatch() {
   if (!replayQueue.length || replayClosed) return;
   const batch = replayQueue.splice(0, REPLAY_MAX_BATCH);
   try {
@@ -83,10 +98,27 @@ export async function flushReplay() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ events: batch }),
     });
-    // Over quota, or an interview whose consent has been withdrawn. Both mean
-    // the server will refuse everything after this, and a producer that kept
-    // posting would spend the rest of the interview being told so.
-    if (response.status === 413 || response.status === 404) closeReplay();
+    // 404 is an interview whose consent has been withdrawn, and quota is an
+    // interview that has recorded all it may. Both mean the server will refuse
+    // everything after this, and a producer that kept posting would spend the
+    // rest of the interview being told so.
+    //
+    // The other 413 is `replay_batch_too_large`, which is about this batch and
+    // not about the interview: one oversized editor payload used to close the
+    // feed for good, so a candidate who pasted a large file lost the rest of
+    // their replay. That batch is already gone from the queue, and the smaller
+    // events behind it are still worth sending.
+    if (response.status === 404) {
+      closeReplay();
+      return;
+    }
+    if (response.status === 413) {
+      const code = await response
+        .json()
+        .then((body) => body?.code)
+        .catch(() => null);
+      if (code === "replay_quota_exceeded") closeReplay();
+    }
   } catch {
     // Offline. The interview is what matters and it is still running.
   }
@@ -94,8 +126,18 @@ export async function flushReplay() {
 }
 
 /// The problem heading, as the recording shows it.
+///
+/// Every stage event carries it, not just the first. `Stage` is a snapshot kind
+/// on the server, so the newest one supersedes every earlier one when a replay
+/// is assembled: a clock tick carrying only the seconds would replace the
+/// heading with nothing, and a reader who joined late would find the problem
+/// title blank.
+function stagePayload(extra) {
+  return { title: problem.title, meta: nodes.meta.textContent, ...extra };
+}
+
 export function recordStage() {
-  recordReplay("stage", { title: problem.title, meta: nodes.meta.textContent });
+  recordReplay("stage", stagePayload());
 }
 
 /// Writes down what the candidate agreed to, and returns the interview id the
@@ -130,7 +172,7 @@ export async function recordConsent() {
 export function recordStageTick(remainingSeconds) {
   if (Date.now() - replayStageAt < REPLAY_STAGE_MS) return;
   replayStageAt = Date.now();
-  recordReplay("stage", { remainingSeconds });
+  recordReplay("stage", stagePayload({ remainingSeconds }));
 }
 
 /// On the change, not on the tick. `updateAgentState` runs for every

--- a/web/replay-feed.js
+++ b/web/replay-feed.js
@@ -1,0 +1,143 @@
+/// The replay feed: what the recording shows beside the video.
+///
+/// Split out of `interview.js` because it is one queue with one lifetime. Every
+/// producer in the page goes through `recordReplay`, so there is one answer to
+/// "is this server recording", one place the envelope is written, and one place
+/// the feed stops when the server says it has heard enough. Scattered across
+/// the caller that happened to need it, that invariant was one edit from being
+/// three answers.
+///
+/// The page's own bindings arrive once through `initReplay` and keep their
+/// names, so the queue reads the same state object the rest of the interview
+/// does rather than a copy that drifts from it.
+
+let state = null;
+let nodes = null;
+let problem = null;
+let recordingEnabled = false;
+let consentVersion = "";
+let replayVersion = 1;
+
+export function initReplay(deps) {
+  ({ state, nodes, problem, recordingEnabled, consentVersion, replayVersion } = deps);
+}
+
+const REPLAY_FLUSH_MS = 1000;
+const REPLAY_MAX_BATCH = 32;
+
+/// How often the clock and the problem heading are restated.
+///
+/// Every second would be twenty-seven hundred events in a forty-five minute
+/// interview, most of the per-interview budget spent on a number the viewer
+/// can read off the video anyway. Fifteen seconds is a clock that is never
+/// more than fifteen seconds stale in a replay nobody scrubs to the second.
+const REPLAY_STAGE_MS = 15000;
+
+let replayQueue = [];
+let replayTimer = null;
+let replayClosed = false;
+let replayStageAt = 0;
+let replayAvatarState = "";
+
+/// One event onto the queue.
+///
+/// Every producer goes through here, so there is one answer to "is this server
+/// recording", one place the envelope is written, and one place the replay
+/// stops when the server says it has heard enough.
+export function recordReplay(kind, payload) {
+  if (!recordingEnabled || !state.interviewId || replayClosed) return;
+  replayQueue.push({ v: replayVersion, kind, at: Date.now(), payload });
+  if (replayQueue.length >= REPLAY_MAX_BATCH) {
+    void flushReplay();
+    return;
+  }
+  replayTimer ||= setTimeout(() => void flushReplay(), REPLAY_FLUSH_MS);
+}
+
+/// Stop producing, and forget what has not gone yet.
+///
+/// Called when the candidate withdraws consent and when the server says it has
+/// heard enough. The queue is dropped rather than flushed: these are events
+/// from before a decision that says they should not be stored.
+export function closeReplay() {
+  replayClosed = true;
+  replayQueue = [];
+  clearTimeout(replayTimer);
+  replayTimer = null;
+}
+
+/// Send what is queued.
+///
+/// Dropped rather than retried on a failure. The events are a description of an
+/// interview that is still happening, and a queue that grew through an outage
+/// would deliver a burst of stale state after it, on top of the newer state
+/// that had already arrived.
+export async function flushReplay() {
+  clearTimeout(replayTimer);
+  replayTimer = null;
+  if (!replayQueue.length || replayClosed) return;
+  const batch = replayQueue.splice(0, REPLAY_MAX_BATCH);
+  try {
+    const response = await fetch(`/api/interviews/${encodeURIComponent(state.interviewId)}/events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ events: batch }),
+    });
+    // Over quota, or an interview whose consent has been withdrawn. Both mean
+    // the server will refuse everything after this, and a producer that kept
+    // posting would spend the rest of the interview being told so.
+    if (response.status === 413 || response.status === 404) closeReplay();
+  } catch {
+    // Offline. The interview is what matters and it is still running.
+  }
+  if (replayQueue.length) replayTimer ||= setTimeout(() => void flushReplay(), REPLAY_FLUSH_MS);
+}
+
+/// The problem heading, as the recording shows it.
+export function recordStage() {
+  recordReplay("stage", { title: problem.title, meta: nodes.meta.textContent });
+}
+
+/// Writes down what the candidate agreed to, and returns the interview id the
+/// token request then has to carry.
+///
+/// `null` where the server records nothing: there is no consent to take, and
+/// the token endpoint ignores the field.
+///
+/// A failure throws into `connect`'s catch, which is the right place: an
+/// interview that cannot record consent must not start, and the candidate gets
+/// the server's own sentence plus the offline practice editor rather than a
+/// recording nobody agreed to.
+export async function recordConsent() {
+  if (!recordingEnabled) return null;
+  const response = await fetch("/api/interviews", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ consentVersion }),
+  });
+  if (!response.ok) {
+    throw new Error((await response.json())?.error || "Could not record your recording consent.");
+  }
+  return (await response.json()).interviewId;
+}
+
+
+/// The clock and the problem heading, restated on a throttle.
+///
+/// The guard lives with the queue rather than in `tickTimer`, so the one place
+/// that decides how often the stage repeats is the one place that owns
+/// `REPLAY_STAGE_MS`.
+export function recordStageTick(remainingSeconds) {
+  if (Date.now() - replayStageAt < REPLAY_STAGE_MS) return;
+  replayStageAt = Date.now();
+  recordReplay("stage", { remainingSeconds });
+}
+
+/// On the change, not on the tick. `updateAgentState` runs for every
+/// participant event, and an interviewer who stays in one state for a minute is
+/// one event, not sixty.
+export function recordAvatarState(value) {
+  if (value === replayAvatarState) return;
+  replayAvatarState = value;
+  recordReplay("avatar", { state: value });
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Requires a primary config file for the binary and splits the interview page script into six modules. Releases now ship compressed, and the concurrent interview cap is configurable.

**Migration**
- One config file is found at `./config/` then the current directory, or named with `--config`; a missing file refuses to start and names the path.
- `run_web` refuses to boot without LiveKit credentials; `CODETRIAL_SKIP_CONFIG` and the Makefile guard are removed.
- Scripts and CI pass `--config` explicitly; `--help` is answered before parsing even when a flag is missing its value.

**Refactors**
- `web/interview.js` fell from 2235 to 1474 lines: avatar stage, captions, audio output, integrity, replay feed, and recording state are now separate modules with no circular imports.
- Moved code is byte-identical; the avatar renderer, replay throttles, and recording poll each have one owner, fixing two pre-existing teardown bugs.
- Source-text tests read the modules as one path, and the module list is derived from the source so it cannot drift.

Also included: releases ship as `.tar.gz` for Linux and `.zip` for macOS/Windows, `CODETRIAL_MAX_CONCURRENT_INTERVIEWS` replaces the hard-coded cap, and `chacha20` was updated off a yanked version.

<sup>Written for commit bcdca8962cd213aa56aeb83e616c834829837508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/codetrial/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

