### PR TITLE
Delete the serve mode and give releases a tag

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -30,6 +30,19 @@
 # from. It appears whenever a single line inside that hundred-line constructor
 # changes.
 #
+# `run_livekit` is the `run-livekit` mode: it resolves the provider for a room
+# name and then hands the whole interview to `run_room`. Replacing its body with
+# `Ok(())` survives for the reason `run_room`'s mutants do, because reaching a
+# single line of it needs a LiveKit server that `cargo test` never starts. It
+# entered the diff when `select_provider` lost its `strict` argument, which is
+# how a function nothing can test came to be scored.
+#
 # Keep this list short and each entry justified. An entry that is really "we
 # never got around to testing this" belongs in a test, not here.
-exclude_re = ["run_room", "open_session", "run_gemini_check", "replace web_router"]
+exclude_re = [
+    "run_room",
+    "open_session",
+    "run_gemini_check",
+    "run_livekit",
+    "replace web_router",
+]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -606,7 +606,9 @@ jobs:
           name: codetrial-${{ matrix.target }}
           path: codetrial-${{ matrix.target }}.${{ matrix.archive }}
 
-  # A rolling prerelease keeps the current main build one direct download away.
+  # One immutable prerelease per main commit, tagged `<prefix><sha>`. No moving
+  # pointer: a tag that gets force-pushed is a tag nobody can trust, and every
+  # download link it ever handed out silently changes what it serves.
   release:
     needs: [check, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -614,21 +616,26 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
-    # `true`, unlike the workflow-level setting on main. That one keeps every
-    # run's verdict because the verdict is the record. This job's output is a
-    # single mutable pointer, so a publish that a newer commit has already
-    # superseded is work whose result must be thrown away regardless.
+    # Keyed on the commit, not on a shared name. The workflow-level group
+    # already queues one push behind another, so what is left for this to hold
+    # is a re-run of one job against a run still in flight: two jobs drafting
+    # and uploading to the same tag. Not cancelling, because with a tag per
+    # commit the older job is publishing its own release rather than racing for
+    # a pointer, and its build is worth having.
     concurrency:
-      group: release-latest
-      cancel-in-progress: true
+      group: release-${{ github.sha }}
+      cancel-in-progress: false
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
+      # The tag scheme and the retention, named once and read by both the
+      # publish and the prune. Spelled twice they were free to drift, and the
+      # drift is silent in the direction that matters: a prune whose filter
+      # matches nothing is indistinguishable from a prune with nothing to do,
+      # so releases and tags would accumulate with no failure anywhere.
+      TAG_PREFIX: main-
+      KEEP_PRERELEASES: 5
     steps:
-      # Shallow, and only for the tag push below: `gh release edit` cannot move
-      # a tag that already exists, and the GitHub API ignores `target_commitish`
-      # on a published release.
-      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
           pattern: codetrial-*
@@ -646,79 +653,108 @@ jobs:
             [ -f "$asset" ] || { echo "missing release asset: $asset" >&2; exit 1; }
           done
 
-          # Build duration varies by runner and by cache hit, so two pushes in
-          # flight can reach this step out of commit order and leave `latest`
-          # pointing at the older binaries. Cancellation covers the queued case;
-          # this covers the one already running when the newer push lands.
-          git fetch --depth 1 origin main
-          if [ "$(git rev-parse FETCH_HEAD)" != "$GITHUB_SHA" ]; then
-            echo "superseded by a newer main; leaving latest alone"
-            exit 0
-          fi
+          # The commit, in the tag. `gh release create --target` cuts the tag
+          # itself, so nothing here needs a checkout, a `git tag -f` or a force
+          # push to a ref other people have already fetched.
+          tag="${TAG_PREFIX}${GITHUB_SHA}"
 
-          # Never `gh release delete` first. That destroys the only download
-          # for the length of the publish, and a create that fails afterwards
-          # leaves nothing at all.
+          # Drafted while the three assets upload. `gh release upload` writes
+          # one at a time, so a published release would serve a Linux binary
+          # from this commit beside nothing at all for Windows, and nothing on
+          # the page would say so. A draft serves no downloads, so the
+          # half-written state is unreachable rather than merely unlikely.
           #
-          # Drafted for the length of the replacement instead. `gh release
-          # upload` writes one asset at a time and three platforms are three
-          # chances to stop halfway, which on a published release means serving
-          # a Linux binary from this commit beside a Windows one from the last.
-          # Nothing tells a person downloading a pair that they do not match. A
-          # draft serves no downloads at all, so the half-written state is
-          # unreachable rather than merely unlikely, and the tag and the notes
-          # move only once the bytes are known to be there.
+          # Resume only an interrupted draft. A published release is immutable:
+          # reruns may produce different bytes, so never overwrite its assets.
           #
-          # The failure this leaves is a `latest` that 404s with a red build
-          # next to it. That is the trade: loudly absent beats quietly mixed,
-          # and the next push to main republishes it.
-          notes="Automated build of ${GITHUB_SHA:0:7}."
-          if gh release view latest >/dev/null 2>&1; then
-            gh release edit latest --draft
+          # Written as a branch rather than `create || edit`, because a create
+          # that failed on credentials or on the network would read as "already
+          # exists" and the job would go on to publish a release it never made.
+          #
+          # The state lands in a variable rather than inside the `[`, because a
+          # command substitution that failed there is not the test's status:
+          # `set -e` would not see it, the empty string would not equal `false`,
+          # and a network blip would send the job on to `--clobber` the assets
+          # of a published release. Assigned, the failure stops the job, and
+          # anything other than a literal `true` is read as published.
+          if gh release view "$tag" >/dev/null 2>&1; then
+            draft=$(gh release view "$tag" --json isDraft --jq .isDraft)
+            if [ "$draft" != true ]; then
+              echo "$tag is already published; leaving it unchanged"
+              exit 0
+            fi
           else
-            # Only `--target` and `--draft` are create-specific. Title,
-            # prerelease and notes are set by the edit at the bottom, which
-            # runs on both branches, so the notes string has one home.
-            gh release create latest --draft --target "$GITHUB_SHA" --notes ""
+            gh release create "$tag" --draft --target "$GITHUB_SHA" \
+              --prerelease --title "$tag" \
+              --notes "Automated build of ${GITHUB_SHA:0:7}."
           fi
 
-          gh release upload latest "${assets[@]}" --clobber
+          gh release upload "$tag" "${assets[@]}" --clobber
 
           # Sizes, not just presence: an upload cut off partway still leaves a
           # named asset behind, and a truncated binary is the one outcome this
-          # whole dance exists to keep off the download page.
+          # whole dance exists to keep off the download page. One query for the
+          # whole set, because three assets asking the same endpoint the same
+          # question is three round trips for one answer.
+          sizes=$(gh release view "$tag" --json assets --jq '.assets[] | "\(.name) \(.size)"')
           for asset in "${assets[@]}"; do
             name=$(basename "$asset")
             want=$(stat -c%s "$asset")
-            got=$(gh release view latest --json assets \
-              --jq ".assets[] | select(.name == \"$name\") | .size")
+            got=$(printf '%s\n' "$sizes" | awk -v n="$name" '$1 == n { print $2 }')
             [ "$want" = "$got" ] || {
               echo "$name uploaded as ${got:-nothing}, expected $want bytes" >&2
-              echo "latest stays drafted rather than serving a mixed set" >&2
+              echo "$tag stays drafted rather than serving a mixed set" >&2
               exit 1
             }
           done
 
-          # Anything on `latest` that this build did not just upload came from
-          # an older naming scheme, and `--clobber` cannot touch it: it only
-          # overwrites names that match. The raw `codetrial-<target>` binaries
-          # these archives replaced are exactly that, and left alone they sit on
-          # the download page beside the current set with nothing saying which
-          # commit they are from. Removed inside the draft, where the page
-          # serves nobody, and before the tag moves.
-          wanted=$(for asset in "${assets[@]}"; do basename "$asset"; done)
-          gh release view latest --json assets --jq '.assets[].name' \
-            | while read -r name; do
-                printf '%s\n' "$wanted" | grep -qxF "$name" && continue
-                echo "removing stale release asset: $name"
-                gh release delete-asset latest "$name" --yes
-              done
-
           # Only now does anything point at this build.
-          git tag -f latest "$GITHUB_SHA"
-          git push -f origin refs/tags/latest
-          gh release edit latest \
-            --draft=false \
-            --prerelease \
-            --title latest \
-            --notes "$notes"
+          gh release edit "$tag" --draft=false
+
+      # Its own step, because retention is a property of the release namespace
+      # rather than of this build, and a step named for publishing should not
+      # delete things. `!cancelled()` is what makes the split mean anything: a
+      # plain step inherits `success()`, so welded onto the publish or merely
+      # placed after it, a failed upload would silently skip a commit's worth of
+      # pruning. A failed publish is exactly when there is a stray draft to
+      # collect.
+      - name: Prune superseded prereleases
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          # Matched on the shape this job produces, not merely on the prefix: a
+          # prerelease a person tagged `main-rc1` by hand is not something CI
+          # gets to delete. Forty hex characters because the publish step tags
+          # the whole `GITHUB_SHA`; if that ever shortens, this has to shorten
+          # with it, since a filter that stops matching fails open and a prune
+          # that found nothing to do looks exactly like one with nothing to do.
+          #
+          # Already on: `shell: bash` three lines up runs `bash -eo pipefail`,
+          # unlike the mutation plan step, which declares no shell and so gets
+          # the bare `bash -e` its own comment describes. Written down anyway
+          # because this step's correctness rests on it. The status of the
+          # pipeline is the `while` loop's, so a `gh` that failed on rate
+          # limiting or a `jq` that errored would otherwise end the step green
+          # having pruned nothing, which is the exact failure the filter above
+          # is shaped to avoid.
+          set -o pipefail
+          gh api --paginate --slurp 'repos/{owner}/{repo}/releases?per_page=100' \
+            | jq -r --arg prefix "$TAG_PREFIX" --argjson keep "$KEEP_PRERELEASES" \
+              '[.[][] | select(.prerelease
+                               and (.tag_name | startswith($prefix))
+                               and (.tag_name[($prefix | length):] | test("^[0-9a-f]{40}$")))]
+               | sort_by(.created_at) | reverse | .[$keep:]
+               | .[] | "\(.draft) \(.tag_name)"' \
+            | while read -r draft old; do
+                echo "removing superseded prerelease: $old"
+                # `--cleanup-tag` only where there is a tag. A draft holds a tag
+                # name but no ref: publishing is what cuts it, so a stray draft
+                # from a failed publish has none, and asking the API to delete
+                # that ref is a 422 that reddens this step and keeps reddening
+                # it until somebody deletes the draft by hand.
+                if [ "$draft" = true ]; then
+                  gh release delete "$old" --yes
+                else
+                  gh release delete "$old" --yes --cleanup-tag
+                fi
+              done

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -729,6 +729,32 @@ jobs:
           # with it, since a filter that stops matching fails open and a prune
           # that found nothing to do looks exactly like one with nothing to do.
           #
+          # Newest by publish time, not by `created_at`. A release's
+          # `created_at` is the date of the commit it was cut from, not the
+          # moment the release appeared: on this repository the `latest`
+          # release and the commit it pointed at both read 06:15:44Z while it
+          # actually published at 06:37:15Z. Sorting on it ranks a rerun of an
+          # older commit, or anything rebased, below releases that were
+          # published long before it, which is the wrong end of the list to
+          # delete from. Drafts have no `published_at`, so they fall back.
+          #
+          # This commit's own release is counted but never deleted. Excluding
+          # it from the set instead would keep it plus a further
+          # KEEP_PRERELEASES, one more than the number says; dropping it at the
+          # end keeps the arithmetic honest and still means a rerun that
+          # republishes a historical build cannot delete what it just uploaded.
+          #
+          # One case holds KEEP_PRERELEASES + 1, knowingly. A rerun of an old
+          # commit whose release is still published exits the publish step
+          # early, so its `published_at` stays old and it can rank outside the
+          # window; the exemption then spares it. That is the trade against
+          # deleting the release of the very commit being built, and the next
+          # push, where it is no longer `$current`, collects it.
+          #
+          # `// ""` on both reads of tag_name: a draft created by hand in the
+          # web UI can carry no tag at all, and `null | startswith` is a jq
+          # error, which `pipefail` turns into a red step rather than a prune.
+          #
           # Already on: `shell: bash` three lines up runs `bash -eo pipefail`,
           # unlike the mutation plan step, which declares no shell and so gets
           # the bare `bash -e` its own comment describes. Written down anyway
@@ -740,11 +766,13 @@ jobs:
           set -o pipefail
           gh api --paginate --slurp 'repos/{owner}/{repo}/releases?per_page=100' \
             | jq -r --arg prefix "$TAG_PREFIX" --argjson keep "$KEEP_PRERELEASES" \
+                    --arg current "${TAG_PREFIX}${GITHUB_SHA}" \
               '[.[][] | select(.prerelease
-                               and (.tag_name | startswith($prefix))
-                               and (.tag_name[($prefix | length):] | test("^[0-9a-f]{40}$")))]
-               | sort_by(.created_at) | reverse | .[$keep:]
-               | .[] | "\(.draft) \(.tag_name)"' \
+                               and ((.tag_name // "") | startswith($prefix))
+                               and ((.tag_name // "")[($prefix | length):]
+                                    | test("^[0-9a-f]{40}$")))]
+               | sort_by(.published_at // .created_at) | reverse | .[$keep:]
+               | .[] | select(.tag_name != $current) | "\(.draft) \(.tag_name)"' \
             | while read -r draft old; do
                 echo "removing superseded prerelease: $old"
                 # `--cleanup-tag` only where there is a tag. A draft holds a tag

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean indent check fetch-vendor verify-vendor serve web
+.PHONY: all build clean indent check fetch-vendor verify-vendor web
 
 all: build
 
@@ -62,9 +62,6 @@ fetch-vendor:
 # lives in one place because two copies had already drifted apart.
 verify-vendor:
 	@./scripts/verify-vendor.sh
-
-serve: fetch-vendor
-	cargo run -- serve
 
 web: fetch-vendor
 	cargo run -- web

--- a/README.md
+++ b/README.md
@@ -263,13 +263,15 @@ the environment instead. The common ones are:
 | `CODETRIAL_COMPILER_EXPLORER_ENABLED` | `true` | Enable remote C, C++, and Java runs |
 | `CODETRIAL_MAX_CONCURRENT_INTERVIEWS` | `16` | Interviews one `web` process hosts agents for |
 
-Two more matter in production. `SESSION_SECRET` signs the session cookie and its
-built-in default is a published string, so the server refuses to start on it
-either with `NODE_ENV=production` or on any listen address that is not loopback:
-a server other machines can reach signs cookies anyone can forge, whether or not
-its operator remembered to say it was production. `CODETRIAL_TRUSTED_PROXY_HOPS`
-defaults to `0`, and `X-Forwarded-For` is read only once you set it to the number
-of proxies in front of the server.
+Two more matter in production. `SESSION_SECRET` signs the session cookie, and
+its built-in default is a string published in this repository, so the server
+refuses to start on it with `NODE_ENV=production`, on any listen address that is
+not loopback, or with `CODETRIAL_TRUSTED_PROXY_HOPS` above zero. A server other
+machines can reach signs cookies anyone can forge, whether or not its operator
+remembered to say it was production, and a loopback socket behind a proxy is
+reachable too. Naming the built-in value explicitly does not satisfy the check.
+`CODETRIAL_TRUSTED_PROXY_HOPS` defaults to `0`, and `X-Forwarded-For` is read
+only once you set it to the number of proxies in front of the server.
 
 Reports are stored in browser storage and, for signed-in users, in local SQLite.
 GitHub handles are self-declared unless OAuth is configured; they are not proof

--- a/README.md
+++ b/README.md
@@ -76,11 +76,16 @@ for pooling.
 
 ## Prebuilt binaries
 
-Every push to `main` republishes the `latest` prerelease at
-<https://github.com/sysprog21/codetrial/releases/latest>. Nothing is required at
-runtime beyond the binary itself: the browser application, its vendored assets,
-and the WASM are compiled in, so there is no Node.js, no `node_modules`, and no
-`web/` directory to unpack alongside it.
+Every push to `main` publishes a prerelease tagged `main-<commit sha>` under
+<https://github.com/sysprog21/codetrial/releases>, newest first. The tag names
+the commit and never moves, and a release that has already published is left
+alone rather than rebuilt over, so a download link keeps serving the bytes it
+served the first time. Only the most recent few are kept: the `release` job in
+`.github/workflows/check.yml` names the retention, and older prereleases are
+deleted with their tags. Nothing is required at runtime beyond the binary
+itself: the browser application, its vendored assets, and the WASM are compiled
+in, so there is no Node.js, no `node_modules`, and no `web/` directory to
+unpack alongside it.
 
 ```bash
 # Linux
@@ -133,7 +138,7 @@ Platform notes:
 Building from a checkout instead:
 
 ```bash
-INTERVIEW_ROOM_NAME=interview-local make serve
+INTERVIEW_ROOM_NAME=interview-local make web
 ```
 
 Open <http://localhost:3000>, choose a problem and duration, then complete the
@@ -145,15 +150,14 @@ URL rather than the interview. See [docs/providers.md](docs/providers.md).
 
 | Command | Use |
 |---|---|
-| `cargo run -- serve` | Local web server and interviewer in one process |
-| `cargo run -- web` | Web server that dispatches an interviewer for each room |
-| `cargo run -- run-livekit ROOM` | Interviewer only |
+| `cargo run -- web` | The server; hosts interviewers too when `GOOGLE_API_KEY` is set |
+| `cargo run -- run-livekit ROOM` | Interviewer only, for one named room |
 | `cargo run -- check-gemini` | Verify Gemini credentials |
 
-`serve` is for local work and refuses `NODE_ENV=production`; use `web` in
-production. A `web` process hosts agents for at most
-`CODETRIAL_MAX_CONCURRENT_INTERVIEWS` interviews at once, 16 by default; past
-that, dispatch is refused and the candidate waits.
+`web` is the only serving mode, local and deployed alike: the difference between
+the two is the configuration, not the command. A `web` process hosts agents for
+at most `CODETRIAL_MAX_CONCURRENT_INTERVIEWS` interviews at once, 16 by default;
+past that, dispatch is refused and the candidate waits.
 
 Set `CODETRIAL_COMPILER_EXPLORER_ENABLED=false` to leave C, C++, and Java
 editors available while disabling their remote test runs.
@@ -174,8 +178,7 @@ face-presence analysis is disabled for the session. See the
 
 ```bash
 make build           # release build
-make serve           # local server and interviewer
-make web             # web server only
+make web             # run the server
 make indent          # format Rust; the gate runs cargo fmt --check
 make clean           # remove build output
 make fetch-vendor    # fetch pinned browser assets
@@ -261,8 +264,10 @@ the environment instead. The common ones are:
 | `CODETRIAL_MAX_CONCURRENT_INTERVIEWS` | `16` | Interviews one `web` process hosts agents for |
 
 Two more matter in production. `SESSION_SECRET` signs the session cookie and its
-built-in default is a published string, so with `NODE_ENV=production` the server
-refuses to start until you set a real one. `CODETRIAL_TRUSTED_PROXY_HOPS`
+built-in default is a published string, so the server refuses to start on it
+either with `NODE_ENV=production` or on any listen address that is not loopback:
+a server other machines can reach signs cookies anyone can forge, whether or not
+its operator remembered to say it was production. `CODETRIAL_TRUSTED_PROXY_HOPS`
 defaults to `0`, and `X-Forwarded-For` is read only once you set it to the number
 of proxies in front of the server.
 

--- a/config/codetrial.env.example
+++ b/config/codetrial.env.example
@@ -48,7 +48,6 @@ CODETRIAL_GEMINI_CANDIDATE_VIDEO_ENABLED=false
 # CODETRIAL_RECORDING_MAX_MINUTES=45
 # CODETRIAL_RECORDING_BITRATE=2000
 # CODETRIAL_RECORDING_KILL_SWITCH=false
-# CODETRIAL_RECORDING_TIMEOUT_SECONDS=900
 #
 # Retention has no knob here on purpose: twenty-four hours is the number the
 # consent notice states, and a deployment that could quietly change it would be

--- a/scripts/browser-check.cjs
+++ b/scripts/browser-check.cjs
@@ -1102,8 +1102,8 @@ WordDictionary.prototype.search = function(word) {
 
     await page.context().grantPermissions(["microphone", "camera"], { origin: process.env.BASE_URL });
     if (credentialed) {
-      const useAgentServe = process.env.BROWSER_CHECK_USE_AGENT_SERVE === "1";
-      if (useAgentServe) {
+      const fixedRoom = process.env.BROWSER_CHECK_FIXED_ROOM === "1";
+      if (fixedRoom) {
         roomName = process.env.INTERVIEW_ROOM_NAME;
         rustAgentIdentity = `interviewer-${roomName}`;
         sawRustMetadataConfig = true;

--- a/scripts/browser-check.sh
+++ b/scripts/browser-check.sh
@@ -23,7 +23,7 @@ fi
 TMP=$(mktemp -d)
 SERVER_LOG="$TMP/web.log"
 BARGE_AUDIO_FILE=${BROWSER_CHECK_BARGE_AUDIO_FILE:-}
-USE_AGENT_SERVE=0
+FIXED_ROOM=0
 DISPATCH_MODE=0
 LOGIN_DB_PATH="$TMP/accounts.db"
 LOGIN_SESSION_SECRET=browser-check-session
@@ -151,10 +151,10 @@ else
     rust)
       INTERVIEW_ROOM_NAME=${INTERVIEW_ROOM_NAME:-interview-browser-$(date +%s)-$$}
       export INTERVIEW_ROOM_NAME
-      USE_AGENT_SERVE=1
+      FIXED_ROOM=1
       SESSION_SECRET="$LOGIN_SESSION_SECRET" \
       CODETRIAL_DB_PATH="$LOGIN_DB_PATH" \
-      cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- serve --config "$CONFIG_PATH" --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
+      cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -- web --config "$CONFIG_PATH" --web-addr "127.0.0.1:$PORT" --web-dir "$ROOT/web" \
         >"$SERVER_LOG" 2>&1 &
       ;;
     *)
@@ -208,7 +208,7 @@ BASE_URL="$BASE_URL" \
   BROWSER_CHECK_BARGE_AUDIO_FILE="$BARGE_AUDIO_FILE" \
   BROWSER_CHECK_COMPILER_EXPLORER_BASE_URL="$COMPILER_EXPLORER_BASE_URL_ARG" \
   BROWSER_CHECK_SESSION_COOKIE="$SESSION_COOKIE" \
-  BROWSER_CHECK_USE_AGENT_SERVE="$USE_AGENT_SERVE" \
+  BROWSER_CHECK_FIXED_ROOM="$FIXED_ROOM" \
   BROWSER_CHECK_CONFIG_PATH="$CONFIG_PATH" \
   INTERVIEW_ROOM_NAME="${INTERVIEW_ROOM_NAME:-}" \
   PLAYWRIGHT_PATH="$PLAYWRIGHT_PATH" \

--- a/scripts/recording-integration.sh
+++ b/scripts/recording-integration.sh
@@ -34,7 +34,6 @@ Environment, all required:
   LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET  the isolated project
 
 Optional:
-  CODETRIAL_RECORDING_TIMEOUT_SECONDS      default 900, the ceiling for one run
   CODETRIAL_RECORDING_ROOM_SECONDS         default 60, how long the room is up
   CODETRIAL_RECORDING_ACCEPTANCE_JSON      default target/recording-acceptance.json
 USAGE
@@ -105,24 +104,12 @@ done
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 
-# Read so that a run declares its ceiling, and exported rather than spent here:
-# the phases that wait on a provider are 7b's, and the server this points at
-# reads the same variable. It is checked now so an operator finds out before an
-# interview, rather than after one, that the value is not a number.
-timeout_seconds=${CODETRIAL_RECORDING_TIMEOUT_SECONDS:-900}
-case "$timeout_seconds" in
-  '' | *[!0-9]*)
-    echo "CODETRIAL_RECORDING_TIMEOUT_SECONDS takes seconds" >&2
-    exit 2
-    ;;
-esac
 case "${CODETRIAL_RECORDING_ROOM_SECONDS:-60}" in
   '' | *[!0-9]*)
     echo "CODETRIAL_RECORDING_ROOM_SECONDS takes seconds" >&2
     exit 2
     ;;
 esac
-export CODETRIAL_RECORDING_TIMEOUT_SECONDS="$timeout_seconds"
 room_seconds=${CODETRIAL_RECORDING_ROOM_SECONDS:-60}
 acceptance=${CODETRIAL_RECORDING_ACCEPTANCE_JSON:-$ROOT/target/recording-acceptance.json}
 template_origin=${CODETRIAL_RECORDING_TEMPLATE_BASE_URL%/}

--- a/src/config.rs
+++ b/src/config.rs
@@ -468,9 +468,6 @@ pub struct AgentConfig {
     pub gemini_start_sensitivity: String,
     pub room_prefix: String,
     pub default_duration_min: u32,
-    pub web_dir: String,
-    pub web_addr: String,
-    pub compiler_explorer_enabled: bool,
     pub gemini_candidate_video_enabled: bool,
     pub pool: ProviderPool,
 }
@@ -559,11 +556,6 @@ pub fn load_from_pairs(
     let livekit_url = optional(&values, "LIVEKIT_URL", "");
     let production = is_production(&values);
 
-    // `CODETRIAL_WEB_ADDR` is deliberately not validated here.
-    // `bind_web_listener` resolves it through `ToSocketAddrs`, which accepts
-    // hostnames, and it is the only place the value is used: a check that only
-    // accepts a literal `SocketAddr` would reject `localhost:3000` and would
-    // fire in the two modes that never bind a listener at all.
     let mut invalid_entries = Vec::new();
     if !livekit_url.is_empty()
         && let Err(message) = validate_livekit_url(&livekit_url, production)
@@ -612,13 +604,6 @@ pub fn load_from_pairs(
         gemini_start_sensitivity: start_sensitivity_or_default(&values),
         room_prefix: optional(&values, "CODETRIAL_ROOM_PREFIX", DEFAULT_ROOM_PREFIX),
         default_duration_min: optional_u32(&values, "CODETRIAL_DURATION_MIN", DEFAULT_DURATION_MIN),
-        web_dir: optional(&values, "CODETRIAL_WEB_DIR", DEFAULT_WEB_DIR),
-        web_addr: optional(&values, "CODETRIAL_WEB_ADDR", DEFAULT_WEB_ADDR),
-        compiler_explorer_enabled: compiler_explorer_enabled(
-            values
-                .get("CODETRIAL_COMPILER_EXPLORER_ENABLED")
-                .map(String::as_str),
-        ),
         gemini_candidate_video_enabled: gemini_candidate_video_enabled(
             values
                 .get("CODETRIAL_GEMINI_CANDIDATE_VIDEO_ENABLED")
@@ -785,8 +770,6 @@ pub struct RecordingConfig {
     pub bitrate: u32,
     pub kill_switch: bool,
     pub template_base_url: String,
-    pub timeout_seconds: u64,
-    pub integration: bool,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -813,8 +796,6 @@ impl fmt::Debug for RecordingConfig {
             .field("bitrate", &self.bitrate)
             .field("kill_switch", &self.kill_switch)
             .field("template_base_url", &self.template_base_url)
-            .field("timeout_seconds", &self.timeout_seconds)
-            .field("integration", &self.integration)
             .finish()
     }
 }
@@ -860,7 +841,6 @@ pub const DEFAULT_RECORDING_BITRATE: u32 = crate::recording::OUTPUT_VIDEO_BITRAT
 pub const MIN_RECORDING_BITRATE: u32 = 200;
 pub const MAX_RECORDING_BITRATE: u32 = 8_000;
 pub const DEFAULT_RECORDING_GCS_PREFIX: &str = "codetrial";
-pub const DEFAULT_RECORDING_TIMEOUT_SECONDS: u64 = 900;
 
 /// The credentials that only make sense together. Naming them as a group is
 /// what makes a half-configured deployment fail at startup instead of at the
@@ -882,10 +862,10 @@ const RECORDING_LIVEKIT_KEYS: [&str; 3] = [
 
 /// Reads the recording block, or reports every reason it cannot be used.
 ///
-/// Separate from [`load_from_pairs`] because the two callers disagree about
-/// what else must be present: `codetrial serve` insists on a Gemini key, and
-/// `codetrial web` deliberately does not. Both need this, and neither should
-/// have to reimplement it.
+/// Separate from [`load_from_pairs`], which insists on a Gemini key that a
+/// web-only deployment has no use for. The recording block is needed either
+/// way, so it is read on its own rather than tied to a config the caller may
+/// not be able to build.
 ///
 /// Errors carry key names and reasons, never values. A validation message is a
 /// log line, and a log line holding a service-account key is the same incident
@@ -919,11 +899,6 @@ pub fn load_recording(
     let kill_switch = recording_flag(
         values,
         "CODETRIAL_RECORDING_KILL_SWITCH",
-        &mut invalid_entries,
-    );
-    let integration = recording_flag(
-        values,
-        "CODETRIAL_RECORDING_INTEGRATION",
         &mut invalid_entries,
     );
 
@@ -986,17 +961,6 @@ pub fn load_recording(
         ));
     }
 
-    let timeout_seconds = recording_number(
-        values,
-        "CODETRIAL_RECORDING_TIMEOUT_SECONDS",
-        DEFAULT_RECORDING_TIMEOUT_SECONDS,
-        &mut invalid_entries,
-    );
-    if timeout_seconds == 0 {
-        invalid_entries
-            .push("CODETRIAL_RECORDING_TIMEOUT_SECONDS must be at least one second".to_string());
-    }
-
     if !missing_keys.is_empty() || !invalid_entries.is_empty() {
         return Err(ConfigError {
             missing_keys,
@@ -1027,8 +991,6 @@ pub fn load_recording(
             .unwrap_or_default()
             .trim_end_matches('/')
             .to_string(),
-        timeout_seconds,
-        integration,
     }))
 }
 
@@ -1102,12 +1064,12 @@ fn recording_livekit(
 /// and wrong here: an operator who wrote `CODETRIAL_RECORDING_BITRATE=2 Mbps`
 /// would get a server that started, recorded, and billed at whatever the
 /// default happened to be.
-fn recording_number<T: std::str::FromStr>(
+fn recording_number(
     values: &BTreeMap<String, String>,
     key: &'static str,
-    default: T,
+    default: u32,
     invalid_entries: &mut Vec<String>,
-) -> T {
+) -> u32 {
     let Some(value) = values
         .get(key)
         .map(|value| value.trim())

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ struct CliOptions {
 /// per question, because a mode that exists in the dispatch but not in the
 /// arity
 /// check is a mode that silently ignores its extra arguments.
-const MODES: [(&str, usize, &str, ModeFn); 4] = [
+const MODES: [(&str, usize, &str, ModeFn); 3] = [
     ("web", 1, "codetrial web [OPTIONS]", |_, options| {
         run_web(options)
     }),
@@ -38,9 +38,6 @@ const MODES: [(&str, usize, &str, ModeFn); 4] = [
             load_agent_config(&options).and_then(|config| run_livekit(config, &positionals[1]))
         },
     ),
-    ("serve", 1, "codetrial serve [OPTIONS]", |_, options| {
-        run_serve(options)
-    }),
     (
         "check-gemini",
         1,
@@ -94,7 +91,18 @@ fn run_agent_command(args: &[String]) -> i32 {
         return 2;
     };
     let Some(&(_, arity, usage, run)) = MODES.iter().find(|(name, ..)| *name == mode) else {
-        eprintln!("unknown agent mode: {mode}");
+        // The names, not just the refusal. A mode that was removed reaches this
+        // line as an ordinary typo, and "unknown agent mode: serve" on its own
+        // leaves the reader to guess what replaced it. `MODES` is the list, so
+        // it cannot go stale the way a sentence naming one of them would.
+        eprintln!(
+            "unknown agent mode: {mode}\nmodes: {}",
+            MODES
+                .iter()
+                .map(|(name, ..)| *name)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
         return 2;
     };
     if positionals.len() != arity {
@@ -306,6 +314,25 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     initialize_accounts(&config)?;
     let listener = bind_web_listener(&value_or(&values, "CODETRIAL_WEB_ADDR", DEFAULT_WEB_ADDR))?;
 
+    // The other half of the `SESSION_SECRET` guard above, and the half that
+    // does not depend on the operator having said anything.
+    //
+    // After the bind rather than before it, because the address may be a
+    // hostname: `CODETRIAL_WEB_ADDR=interviews.example:3000` is resolved by
+    // `ToSocketAddrs` and only the socket knows what it landed on. That puts it
+    // beside `initialize_accounts`, which refuses after binding for the same
+    // reason and with the same consequence: the socket exists and its backlog
+    // fills, nothing accepts from it, and the process exits non-zero.
+    //
+    // Silent when the socket cannot name itself, which a just-bound listener
+    // does not do. Refusing on an address nothing could read would turn an
+    // impossible kernel answer into a server that will not start.
+    if let Ok(bound) = listener.local_addr()
+        && let Some(refusal) = published_secret_refusal(&values, bound)
+    {
+        return Err(refusal);
+    }
+
     // Whether this process also hosts interviewers. A full agent config, which
     // is a Gemini key on top of what the web side needs, means yes; without it
     // this is the web half of a split deployment and agents arrive from
@@ -344,117 +371,8 @@ fn run_web(options: CliOptions) -> Result<(), String> {
         .map_err(|error| format!("web server failed: {error}"))
 }
 
-fn run_serve(options: CliOptions) -> Result<(), String> {
-    let values = load_values(&options)?;
-
-    // `serve` runs one agent in one room, and `/api/token` only hands out that
-    // room while `production` is false. Refusing here beats booting a server
-    // that mints rooms nobody is listening in.
-    if is_production(&values) {
-        return Err(
-            "serve is a local mode and cannot run with NODE_ENV=production; \
-                    run `codetrial web`, which serves the same way and is the \
-                    mode meant to be deployed"
-                .to_string(),
-        );
-    }
-
-    let fixed_room_name = nonempty(&values, "INTERVIEW_ROOM_NAME");
-    let github_client_id = nonempty(&values, "GITHUB_CLIENT_ID");
-    let github_client_secret = nonempty(&values, "GITHUB_CLIENT_SECRET");
-
-    // `serve` refused to run in production above, so the built-in default is
-    // always allowed here.
-    let session_secret = Some(value_or(&values, "SESSION_SECRET", DEFAULT_SESSION_SECRET));
-    let db_path = Some(account_db_path(&values));
-    let trusted_proxy_hops = trusted_proxy_hops(&values);
-    let recording_values = values.clone();
-
-    // `serve` hosts one room, so this can only ever refuse a second. It is read
-    // anyway so the two modes cannot disagree about what the operator asked
-    // for.
-    let max_concurrent = read_max_concurrent(&values);
-    let provider_order = value_or(&values, codetrial::config::PROVIDER_ORDER_KEY, "");
-    let mut config =
-        codetrial::config::load_from_pairs(values).map_err(|error| error.to_string())?;
-    // `serve` refused to run in production above.
-    extend_pool(
-        &mut config.pool,
-        false,
-        &provider_dir(&options),
-        &provider_order,
-    );
-
-    // No `select_provider`. This process hosts an interviewer per room rather
-    // than one for a room named up front, so there is no single project to
-    // narrow the credentials to: the dispatcher is handed the provider the
-    // token was minted from, with the room.
-    //
-    // A recording URL naming a project outside the pool is refused here for the
-    // same reason it is refused in `run_web`.
-    let recording = codetrial::config::load_recording(
-        &recording_values,
-        &config.pool,
-        config.default_duration_min,
-        false,
-    )
-    .map_err(|error| error.to_string())?;
-    recording_needs_verified_identity(
-        recording.is_some(),
-        github_client_id.is_some() && github_client_secret.is_some(),
-    )?;
-    recording_can_deliver(recording.as_ref())?;
-    let web_config = WebServerConfig {
-        web_dir: PathBuf::from(config.web_dir.clone()),
-        github_client_id,
-        github_client_secret,
-        session_secret,
-        db_path,
-        github_oauth_base_url: None,
-        github_api_base_url: None,
-        room_prefix: config.room_prefix.clone(),
-
-        // Only when the operator names one. `serve` used to invent
-        // `<prefix>-local` and pin every interview to it, which meant the
-        // rotation was built on every start and consulted on none of them.
-        fixed_room_name,
-        production: false,
-        trusted_proxy_hops,
-        compiler_explorer_enabled: config.compiler_explorer_enabled,
-        recording,
-        pool: config.pool.clone(),
-        probe_provider_quota: true,
-    };
-
-    initialize_accounts(&web_config)?;
-    let listener =
-        bind_web_listener(&config.web_addr).map_err(|error| format!("web side {error}"))?;
-    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
-    runtime
-        .block_on(async {
-            let listener = tokio::net::TcpListener::from_std(listener)?;
-
-            // Built before the spawn for the same reason `run_web` does it:
-            // constructing the service opens the database, migrates it and
-            // sweeps it, all blocking, and doing that inside the serving task
-            // parks a worker while the bound listener backs up.
-            let dispatcher = Arc::new(codetrial::dispatch::LocalDispatcher {
-                config,
-                runtime: tokio::runtime::Handle::current(),
-                live: Arc::default(),
-                max_concurrent,
-            }) as Arc<dyn RoomDispatcher>;
-            axum::serve(
-                listener,
-                codetrial::web::web_service_with_dispatcher(web_config, Some(dispatcher)),
-            )
-            .await
-        })
-        .map_err(|error| format!("web server failed: {error}"))
-}
-
 fn run_livekit(config: AgentConfig, room_name: &str) -> Result<(), String> {
-    let config = select_provider(config, room_name, true)?;
+    let config = select_provider(config, room_name)?;
     let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
     runtime
         .block_on(codetrial::livekit::run_room(
@@ -473,7 +391,7 @@ fn run_livekit(config: AgentConfig, room_name: &str) -> Result<(), String> {
 /// `CODETRIAL_DURATION_MIN`, so a second path for it would only be a second
 /// place to disagree.
 fn run_gemini_check(config: AgentConfig, room_name: &str) -> Result<(), String> {
-    let config = select_provider(config, room_name, true)?;
+    let config = select_provider(config, room_name)?;
     let duration_min = config.default_duration_min;
     let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
     let result = runtime.block_on(async {
@@ -506,18 +424,8 @@ fn run_gemini_check(config: AgentConfig, room_name: &str) -> Result<(), String> 
 /// wrong: an agent that cannot see the config directory has a pool of one and
 /// an
 /// unresolvable id, which is exactly the case that has to fail loudly.
-///
-/// `strict` is off only for `serve`, where the room name is the operator's own
-/// `INTERVIEW_ROOM_NAME` and the web half of the same process resolves it from
-/// the same pool. Both sides fall back to the primary together there, so a
-/// hand-written name that happens to contain a dash cannot split them.
-fn select_provider(
-    mut config: AgentConfig,
-    room_name: &str,
-    strict: bool,
-) -> Result<AgentConfig, String> {
-    if strict
-        && let Some(id) = codetrial::config::provider_id_from_room(room_name, &config.room_prefix)
+fn select_provider(mut config: AgentConfig, room_name: &str) -> Result<AgentConfig, String> {
+    if let Some(id) = codetrial::config::provider_id_from_room(room_name, &config.room_prefix)
         && config.pool.get(id).is_none()
     {
         return Err(format!(
@@ -779,9 +687,6 @@ fn trusted_proxy_hops(values: &BTreeMap<String, String>) -> u32 {
 /// `config::is_production` matches the exact string, so a `NODE_ENV=Production`
 /// typo lands here too, which is the other way a deployment ends up local
 /// without meaning to.
-///
-/// `run_serve` does not call this. That mode refuses `NODE_ENV=production`
-/// outright, so it is local by definition and has nothing to warn about.
 fn relaxed_for_local_use(values: &BTreeMap<String, String>) -> Vec<String> {
     if is_production(values) {
         return Vec::new();
@@ -800,6 +705,40 @@ fn relaxed_for_local_use(values: &BTreeMap<String, String>) -> Vec<String> {
         ));
     }
     warnings
+}
+
+/// Why the built-in `SESSION_SECRET` may not sign cookies on `bound`, or `None`
+/// where it may.
+///
+/// Split out for the reason `relaxed_for_local_use` is: the caller can only
+/// return the string, and a refusal reachable solely by starting a process that
+/// otherwise never exits is a branch no test can assert on without hanging.
+///
+/// `NODE_ENV` is a claim; the address this process bound is a fact. A server
+/// other machines can reach is not the local run the published default exists
+/// for, whether or not anyone remembered to say so, which is the mistake the
+/// warning in `relaxed_for_local_use` can name but not prevent.
+///
+/// Unspecified addresses (`0.0.0.0`, `::`) are not loopback and must not be
+/// treated as such: binding every interface is how a container serves the
+/// world.
+///
+/// `to_canonical` before the test, because `Ipv6Addr::is_loopback` is true of
+/// `::1` and of nothing else: a dual-stack socket that landed on
+/// `::ffff:127.0.0.1`, which is a name for the same interface, would otherwise
+/// be refused an address only this machine can reach.
+fn published_secret_refusal(
+    values: &BTreeMap<String, String>,
+    bound: std::net::SocketAddr,
+) -> Option<String> {
+    if nonempty(values, "SESSION_SECRET").is_some() || bound.ip().to_canonical().is_loopback() {
+        return None;
+    }
+    Some(format!(
+        "SESSION_SECRET must be set to bind {bound}: the built-in default is a published \
+         value, so every session cookie this server signs would be forgeable by anyone who \
+         can reach it. Loopback is the only address it is allowed on"
+    ))
 }
 
 fn compiler_explorer_enabled(values: &BTreeMap<String, String>) -> bool {
@@ -839,6 +778,69 @@ mod tests {
             .iter()
             .map(|(key, value)| (key.to_string(), value.to_string()))
             .collect()
+    }
+
+    /// A hostname, not a literal socket address. `bind_web_listener` hands the
+    /// string to `ToSocketAddrs`, which resolves it, and `CODETRIAL_WEB_ADDR`
+    /// has always accepted one. This used to be guarded in `config`, where the
+    /// value was parsed into a field only `serve` read; with the field gone,
+    /// the guard belongs on the one function that still takes the string.
+    #[test]
+    fn a_hostname_web_address_binds() {
+        let listener =
+            super::bind_web_listener("localhost:0").expect("a hostname address should bind");
+        assert!(
+            listener
+                .local_addr()
+                .expect("a bound listener has an address")
+                .ip()
+                .is_loopback()
+        );
+    }
+
+    fn addr(text: &str) -> std::net::SocketAddr {
+        text.parse().expect("test address should parse")
+    }
+
+    /// The published default is tolerated on loopback and nowhere else, and the
+    /// two unspecified addresses are the ones a container binds: neither is
+    /// loopback, and reading them as local is how the guard would miss the
+    /// deployment it exists for.
+    #[test]
+    fn the_published_session_secret_is_confined_to_loopback() {
+        for local in [
+            "127.0.0.1:3000",
+            "127.0.0.53:3000",
+            "[::1]:3000",
+            // A dual-stack socket's spelling of the first one.
+            "[::ffff:127.0.0.1]:3000",
+        ] {
+            assert_eq!(
+                super::published_secret_refusal(&values(&[]), addr(local)),
+                None,
+                "{local} is loopback and needs no secret"
+            );
+        }
+
+        for public in ["0.0.0.0:3000", "[::]:3000", "192.168.1.10:3000"] {
+            let refusal = super::published_secret_refusal(&values(&[]), addr(public))
+                .unwrap_or_else(|| panic!("{public} must be refused"));
+            assert!(refusal.contains(public), "{refusal}");
+            assert!(refusal.contains("SESSION_SECRET must be set"), "{refusal}");
+        }
+    }
+
+    /// A secret of the operator's own is the whole point: setting it must lift
+    /// the restriction rather than merely change the message.
+    #[test]
+    fn a_real_session_secret_is_allowed_on_any_address() {
+        assert_eq!(
+            super::published_secret_refusal(
+                &values(&[("SESSION_SECRET", "a-real-secret")]),
+                addr("0.0.0.0:3000")
+            ),
+            None
+        );
     }
 
     /// The deployment this whole warning exists for: every credential set, and
@@ -948,17 +950,15 @@ mod tests {
             ],
         };
 
-        let config =
-            super::select_provider(agent_config(pool.clone()), "interview-eu-a1b2c3d4", true)
-                .expect("a configured provider should resolve");
+        let config = super::select_provider(agent_config(pool.clone()), "interview-eu-a1b2c3d4")
+            .expect("a configured provider should resolve");
         assert_eq!(config.livekit_url, "wss://eu.example");
         assert_eq!(config.livekit_api_secret, "eu-secret");
         assert_eq!(config.google_api_key, "eu-google");
 
         // No segment: what a single-provider deployment mints, and what a
         // hand-written INTERVIEW_ROOM_NAME usually looks like.
-        let config =
-            super::select_provider(agent_config(pool), "interview-a1b2c3d4", true).unwrap();
+        let config = super::select_provider(agent_config(pool), "interview-a1b2c3d4").unwrap();
         assert_eq!(config.livekit_url, "wss://primary.example");
     }
 
@@ -978,17 +978,11 @@ mod tests {
             let pool = codetrial::config::ProviderPool { providers };
             // Not `expect_err`: `AgentConfig` deliberately has no `Debug`.
             let Err(error) =
-                super::select_provider(agent_config(pool.clone()), "interview-eu-a1b2c3d4", true)
+                super::select_provider(agent_config(pool.clone()), "interview-eu-a1b2c3d4")
             else {
                 panic!("an unknown provider id should refuse");
             };
             assert!(error.contains("eu"), "{error}");
-
-            // `serve` runs both halves from one pool, so they fall back
-            // together and a dash in a fixed room name is not an error.
-            let config =
-                super::select_provider(agent_config(pool), "interview-eu-a1b2c3d4", false).unwrap();
-            assert_eq!(config.livekit_url, "wss://primary.example");
         }
     }
 
@@ -1023,8 +1017,6 @@ bm90IGEga2V5
             bitrate: 2000,
             kill_switch: false,
             template_base_url: "https://recording.example".to_string(),
-            timeout_seconds: 900,
-            integration: false,
         };
         let error = super::recording_can_deliver(Some(&recording)).unwrap_err();
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,7 +219,9 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     // The built-in default is a published string, so in production it is not a
     // weak signing key, it is a known one. Refuse rather than mint forgeable
     // session cookies.
-    if is_production(&values) && nonempty(&values, "SESSION_SECRET").is_none() {
+    if is_production(&values)
+        && value_or(&values, "SESSION_SECRET", DEFAULT_SESSION_SECRET) == DEFAULT_SESSION_SECRET
+    {
         return Err(
             "SESSION_SECRET must be set when NODE_ENV=production; the built-in \
                     default is a published value that would let anyone forge a session cookie"
@@ -324,12 +326,14 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     // reason and with the same consequence: the socket exists and its backlog
     // fills, nothing accepts from it, and the process exits non-zero.
     //
-    // Silent when the socket cannot name itself, which a just-bound listener
-    // does not do. Refusing on an address nothing could read would turn an
-    // impossible kernel answer into a server that will not start.
-    if let Ok(bound) = listener.local_addr()
-        && let Some(refusal) = published_secret_refusal(&values, bound)
-    {
+    // Fails closed when the socket cannot name itself, which a just-bound
+    // listener does not do. Skipping the check on an unreadable address would
+    // make an impossible kernel answer the one way past a security guard, and
+    // refusing to start is the cheaper half of that trade.
+    let bound = listener
+        .local_addr()
+        .map_err(|error| format!("bound listener has no address to check: {error}"))?;
+    if let Some(refusal) = published_secret_refusal(&values, bound) {
         return Err(refusal);
     }
 
@@ -731,13 +735,31 @@ fn published_secret_refusal(
     values: &BTreeMap<String, String>,
     bound: std::net::SocketAddr,
 ) -> Option<String> {
-    if nonempty(values, "SESSION_SECRET").is_some() || bound.ip().to_canonical().is_loopback() {
+    // What the cookie signer will actually use, not whether the key was
+    // mentioned. `value_or` trims, so `SESSION_SECRET=" codetrial-local-session "`
+    // is the published key spelled with whitespace rather than a secret of the
+    // operator's own, and a guard that only asked whether the variable was set
+    // would wave it through.
+    if value_or(values, "SESSION_SECRET", DEFAULT_SESSION_SECRET) != DEFAULT_SESSION_SECRET {
         return None;
     }
+
+    // Two ways to be reachable, and the second is the one a bind address cannot
+    // see: a server on loopback behind nginx or a tunnel is as public as one on
+    // `0.0.0.0`. `CODETRIAL_TRUSTED_PROXY_HOPS` is the operator saying requests
+    // arrive through something in front, which is the same admission.
+    let reason = if !bound.ip().to_canonical().is_loopback() {
+        format!("bind {bound}")
+    } else if trusted_proxy_hops(values) > 0 {
+        "serve from behind a declared proxy".to_string()
+    } else {
+        return None;
+    };
+
     Some(format!(
-        "SESSION_SECRET must be set to bind {bound}: the built-in default is a published \
-         value, so every session cookie this server signs would be forgeable by anyone who \
-         can reach it. Loopback is the only address it is allowed on"
+        "SESSION_SECRET must be set to {reason}: {DEFAULT_SESSION_SECRET:?} is published in \
+         this repository, so every session cookie this server signs would be forgeable by \
+         anyone who can reach it"
     ))
 }
 
@@ -840,6 +862,46 @@ mod tests {
                 addr("0.0.0.0:3000")
             ),
             None
+        );
+    }
+
+    /// Naming the published value is not setting a secret. A guard that asked
+    /// only whether `SESSION_SECRET` was present would take the string this
+    /// repository publishes as proof that it is not being used, and whitespace
+    /// around it changes nothing, because the signer trims before it signs.
+    #[test]
+    fn spelling_out_the_published_default_does_not_count_as_setting_one() {
+        for spelling in [super::DEFAULT_SESSION_SECRET, "  codetrial-local-session  "] {
+            assert!(
+                super::published_secret_refusal(
+                    &values(&[("SESSION_SECRET", spelling)]),
+                    addr("0.0.0.0:3000")
+                )
+                .is_some(),
+                "{spelling:?} is the published key, not a secret"
+            );
+        }
+    }
+
+    /// A bind address cannot see a reverse proxy. Declaring hops is the
+    /// operator saying requests reach this process from somewhere else, which
+    /// makes a loopback socket as public as the proxy in front of it.
+    #[test]
+    fn a_declared_proxy_makes_loopback_public_too() {
+        let refusal = super::published_secret_refusal(
+            &values(&[("CODETRIAL_TRUSTED_PROXY_HOPS", "1")]),
+            addr("127.0.0.1:3000"),
+        )
+        .expect("loopback behind a declared proxy must be refused");
+        assert!(refusal.contains("behind a declared proxy"), "{refusal}");
+
+        assert_eq!(
+            super::published_secret_refusal(
+                &values(&[("CODETRIAL_TRUSTED_PROXY_HOPS", "0")]),
+                addr("127.0.0.1:3000")
+            ),
+            None,
+            "no declared proxy is the local run the default exists for"
         );
     }
 

--- a/src/recording/deletion.rs
+++ b/src/recording/deletion.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::accounts::{Accounts, blocking};
 
-use super::store::{clear_handle, delivery_handles};
+use super::store::{Handle, clear_handle, delivery_handles};
 use super::*;
 
 /// Revokes, deletes, and tombstones, in that order.
@@ -21,12 +21,11 @@ use super::*;
 /// before it boxes anything. Deleting the file before the revoke landed is not
 /// a failure worth resting on that.
 struct Release<'a> {
-    // `'static`, not `'a`: the column name crosses into the blocking pool,
-    // which takes only what it can own, and these are literals from this file
-    // rather than anything a caller passed.
+    // `'static` and `Copy`: both cross into the blocking pool, which takes only
+    // what it can own, and neither is anything a caller passed.
     step: &'static str,
     clear_step: &'static str,
-    column: &'static str,
+    handle: Handle,
     call: Call<'a>,
 }
 
@@ -70,7 +69,7 @@ pub async fn delete_recording(
         releases.push(Release {
             step: "revoke",
             clear_step: "clear_permission",
-            column: "drive_permission_id",
+            handle: Handle::DrivePermission,
             call: Call::Revoke {
                 drive_file_id: file_id,
                 permission_id,
@@ -81,7 +80,7 @@ pub async fn delete_recording(
         releases.push(Release {
             step: "delete_file",
             clear_step: "clear_file",
-            column: "drive_file_id",
+            handle: Handle::DriveFile,
             call: Call::DeleteFile(file_id),
         });
     }
@@ -89,7 +88,7 @@ pub async fn delete_recording(
         releases.push(Release {
             step: "delete_object",
             clear_step: "clear_object",
-            column: "gcs_object",
+            handle: Handle::GcsObject,
             call: Call::DeleteObject(object),
         });
     }
@@ -98,7 +97,7 @@ pub async fn delete_recording(
     for Release {
         step,
         clear_step,
-        column,
+        handle,
         call,
     } in releases
     {
@@ -116,7 +115,7 @@ pub async fn delete_recording(
         }
         let accounts = accounts.clone();
         let id = recording.id.clone();
-        if let Err(error) = blocking(move || clear_handle(&accounts, &id, column)).await {
+        if let Err(error) = blocking(move || clear_handle(&accounts, &id, handle)).await {
             // The handle is gone from the provider and the row still names it.
             // Reported rather than swallowed: the next pass repeats a call that
             // will `404`, which is harmless, and an operator reading

--- a/src/recording/store.rs
+++ b/src/recording/store.rs
@@ -467,25 +467,45 @@ pub(super) fn delivery_handles(
     })
 }
 
-/// Give up one handle, now that what it named is gone.
+/// Which of the three handles a row can hold, and the one statement that
+/// clears it.
 ///
-/// The column name arrives as a literal from `deletion`, which holds all three
-/// call sites, rather than as a value from anywhere else. The `unreachable!`
-/// is what keeps that true: a caller cannot name a column this function was not
-/// written for without failing loudly.
+/// An enum rather than the column name as a `&str`, because the set is closed
+/// and `deletion` holds every call site. Spelled as a string this needed a
+/// fourth match arm for a column nobody passes, so a typo compiled and aborted
+/// the deletion pass at runtime; spelled this way the fourth case cannot be
+/// written down. `Copy`, so it crosses into the blocking pool the way the
+/// literal did.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum Handle {
+    DrivePermission,
+    DriveFile,
+    GcsObject,
+}
+
+impl Handle {
+    /// Every column name in this file is a literal that reaches SQL only from
+    /// here, which is what keeps the statement a constant rather than something
+    /// assembled around a value.
+    fn clear_statement(self) -> &'static str {
+        match self {
+            Self::DrivePermission => {
+                "UPDATE recordings SET drive_permission_id = NULL WHERE id = ?1"
+            }
+            Self::DriveFile => "UPDATE recordings SET drive_file_id = NULL WHERE id = ?1",
+            Self::GcsObject => "UPDATE recordings SET gcs_object = NULL WHERE id = ?1",
+        }
+    }
+}
+
+/// Give up one handle, now that what it named is gone.
 pub(super) fn clear_handle(
     accounts: &Accounts,
     recording_id: &str,
-    column: &str,
+    handle: Handle,
 ) -> rusqlite::Result<()> {
-    let statement = match column {
-        "drive_permission_id" => "UPDATE recordings SET drive_permission_id = NULL WHERE id = ?1",
-        "drive_file_id" => "UPDATE recordings SET drive_file_id = NULL WHERE id = ?1",
-        "gcs_object" => "UPDATE recordings SET gcs_object = NULL WHERE id = ?1",
-        other => unreachable!("no handle called {other}"),
-    };
     accounts.with(|connection| {
-        connection.execute(statement, [recording_id])?;
+        connection.execute(handle.clear_statement(), [recording_id])?;
         Ok(())
     })
 }

--- a/src/web/assets.rs
+++ b/src/web/assets.rs
@@ -33,9 +33,9 @@ struct EmbeddedWeb;
 /// Says out loud at startup which vendored assets were never downloaded.
 ///
 /// The megabytes under `web/vendor` are pinned but not committed:
-/// `scripts/fetch-vendor.sh` downloads them, and `make build`, `make serve` and
-/// `make web` all run it first. `cargo run -- serve` does not, and neither does
-/// a deployment that copies the tree without running the fetch. The failure
+/// `scripts/fetch-vendor.sh` downloads them, and `make build` and `make web`
+/// run it first. `cargo run -- web` does not, and neither does a deployment
+/// that copies the tree without running the fetch. The failure
 /// then lands on a candidate as a Python runtime that will not start or a face
 /// detector that never loads, which is a long way from the cause.
 ///

--- a/src/web/recordings.rs
+++ b/src/web/recordings.rs
@@ -72,15 +72,15 @@ pub(crate) const DELIVERY_INTERVAL: Duration = Duration::from_secs(10);
 ///
 /// A deployment whose credentials do not build a delivery client gets a warning
 /// and no worker rather than a panic in a router constructor. The binary does
-/// not reach that case: `codetrial web` and `codetrial serve` parse the key
-/// before they listen and refuse to start without one. It is reachable from
+/// not reach that case: `codetrial web` parses the key before it listens and
+/// refuses to start without one. It is reachable from
 /// this function, which is public and is what the tests build, and there the
 /// warning is the right answer.
 /// The delivery client, or a warning and none.
 ///
 /// A `None` here is a deployment that records and never hands anything over,
-/// which the binary refuses to start in: `codetrial web` and `codetrial serve`
-/// parse the key before they listen. It is reachable from the public router
+/// which the binary refuses to start in: `codetrial web` parses the key before
+/// it listens. It is reachable from the public router
 /// constructors, which is what the tests build, and there a warning is the
 /// right answer rather than a panic inside a constructor.
 pub(crate) fn delivery_provider(

--- a/tests/browser/render.test.js
+++ b/tests/browser/render.test.js
@@ -13,6 +13,7 @@ import {
   feedbackMarkup,
   finalRunnerStatus,
   chainSentence,
+  problemMarkup,
   reportMarkdown,
   reportMarkup,
   resultsMarkup,
@@ -351,6 +352,39 @@ test("report markup marks a no-hire and an empty editor", () => {
 
   assert.match(body, /class="critical">NO HIRE</);
   assert.match(body, /\(editor was empty\)/);
+});
+
+test("problem markup escapes every field a problem carries", () => {
+  // Not all problem text is written in this repository: `leetcode-import.js`
+  // brings statements, examples and constraints in from outside, and all three
+  // land in the same panel.
+  const body = problemMarkup({
+    statement: ["<script>s</script>"],
+    examples: [
+      {
+        input: "<script>i</script>",
+        output: "<script>o</script>",
+        explanation: "<script>x</script>",
+      },
+    ],
+    constraints: ["<script>c</script>"],
+  });
+
+  assert.doesNotMatch(body, /<script>/, "no problem field may become live markup");
+  for (const marker of ["s", "i", "o", "x", "c"]) {
+    assert.match(body, new RegExp(`&lt;script&gt;${marker}&lt;/script&gt;`));
+  }
+});
+
+test("problem markup omits the explanation line rather than printing undefined", () => {
+  const body = problemMarkup({
+    statement: ["one"],
+    examples: [{ input: "a", output: "b" }],
+    constraints: ["c"],
+  });
+
+  assert.doesNotMatch(body, /Explanation/);
+  assert.doesNotMatch(body, /undefined/);
 });
 
 test("feedback markup escapes list items", () => {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,7 +3,7 @@ use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 fn run_cli_args(args: &[&str]) -> (i32, String, String) {
     run_cli_args_with_env(args, &[])
@@ -12,9 +12,91 @@ fn run_cli_args(args: &[&str]) -> (i32, String, String) {
 fn run_cli_args_with_env(args: &[&str], envs: &[(&str, &str)]) -> (i32, String, String) {
     let cwd = temp_path("empty-cwd");
     std::fs::create_dir_all(&cwd).expect("empty cwd should create");
-    let output = Command::new(env!("CARGO_BIN_EXE_codetrial"))
+    let output = cli_command(args, envs, &cwd)
+        .output()
+        .expect("codetrial should exit");
+    let _ = std::fs::remove_dir_all(cwd);
+
+    (
+        output.status.code().unwrap_or_default(),
+        String::from_utf8(output.stdout).expect("stdout should be UTF-8"),
+        String::from_utf8(output.stderr).expect("stderr should be UTF-8"),
+    )
+}
+
+/// The same invocation, but the process is required to stop by itself.
+///
+/// `run_cli_args` waits forever, which is right for a mode that always exits.
+/// A refusal test is not that: what it asserts is that the binary *stops*, so a
+/// regression letting it serve instead hangs the suite rather than failing it,
+/// and `cargo mutants` scores that as a timeout instead of a caught mutant.
+/// That is not hypothetical; it is how `replace == with != in run_web` reached
+/// CI as a 33-second timeout. Bounded, so a guard that stopped guarding is a
+/// red test.
+fn run_cli_until_exit(args: &[&str]) -> (i32, String, String) {
+    // Generous for a loaded runner, and well inside the timeout `cargo mutants`
+    // derives from the baseline (33s when this was written). A bound above that
+    // would score a caught mutant as a timeout again, which is the failure this
+    // whole helper exists to remove.
+    const LIMIT: Duration = Duration::from_secs(10);
+
+    let cwd = temp_path("empty-cwd");
+    std::fs::create_dir_all(&cwd).expect("empty cwd should create");
+    let mut child = cli_command(args, &[], &cwd)
+        .spawn()
+        .expect("codetrial should start");
+
+    // Drained while the child runs, not after it exits. A pipe holds about
+    // 64KB; a child that filled one would block in `write` and never reach the
+    // exit this loop is watching for, so the helper would report a refusal that
+    // did not happen as a timeout that did not either. These paths print a few
+    // lines, but the trap belongs to whoever reuses this next.
+    let mut out = child.stdout.take().expect("stdout is piped");
+    let mut err = child.stderr.take().expect("stderr is piped");
+    let out = thread::spawn(move || {
+        let mut text = String::new();
+        out.read_to_string(&mut text)
+            .expect("stdout should be UTF-8");
+        text
+    });
+    let err = thread::spawn(move || {
+        let mut text = String::new();
+        err.read_to_string(&mut text)
+            .expect("stderr should be UTF-8");
+        text
+    });
+
+    let deadline = Instant::now() + LIMIT;
+    let status = loop {
+        match child.try_wait().expect("child status should be readable") {
+            Some(status) => break status,
+            None if Instant::now() >= deadline => {
+                // Kills and reaps, which also closes the pipes and lets the two
+                // readers finish rather than parking this thread on `join`.
+                stop_child(&mut child);
+                let _ = std::fs::remove_dir_all(&cwd);
+                panic!("codetrial {args:?} was still running after {LIMIT:?}; it had to refuse");
+            }
+            None => thread::sleep(Duration::from_millis(25)),
+        }
+    };
+
+    let stdout = out.join().expect("stdout reader should finish");
+    let stderr = err.join().expect("stderr reader should finish");
+    let _ = std::fs::remove_dir_all(&cwd);
+
+    (status.code().unwrap_or_default(), stdout, stderr)
+}
+
+/// One place builds the invocation, so the two runners cannot drift about which
+/// environment the child inherits. The removals matter: a developer with
+/// `NODE_ENV` or `SESSION_SECRET` exported would otherwise change what these
+/// tests are testing.
+fn cli_command(args: &[&str], envs: &[(&str, &str)], cwd: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_codetrial"));
+    command
         .args(args)
-        .current_dir(&cwd)
+        .current_dir(cwd)
         .env_remove("LIVEKIT_URL")
         .env_remove("LIVEKIT_API_KEY")
         .env_remove("LIVEKIT_API_SECRET")
@@ -27,16 +109,8 @@ fn run_cli_args_with_env(args: &[&str], envs: &[(&str, &str)]) -> (i32, String, 
         .env_remove("SESSION_SECRET")
         .envs(envs.iter().copied())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("codetrial should exit");
-    let _ = std::fs::remove_dir_all(cwd);
-
-    (
-        output.status.code().unwrap_or_default(),
-        String::from_utf8(output.stdout).expect("stdout should be UTF-8"),
-        String::from_utf8(output.stderr).expect("stderr should be UTF-8"),
-    )
+        .stderr(Stdio::piped());
+    command
 }
 
 /// Binding then dropping is inherently racy: the child re-binds the port a
@@ -413,7 +487,7 @@ fn binary_web_refuses_a_public_listener_without_a_session_secret() {
 
     let (code, stdout, stderr) = with_free_addr(|addr| {
         let port = addr.rsplit_once(':').unwrap().1;
-        let result = run_cli_args(&[
+        let result = run_cli_until_exit(&[
             "web",
             "--web-addr",
             &format!("0.0.0.0:{port}"),
@@ -452,7 +526,7 @@ fn binary_web_refuses_production_without_a_session_secret() {
 
     // No free-port dance: the refusal comes before the bind, so no listener is
     // ever created and there is no port to race for.
-    let (code, stdout, stderr) = run_cli_args(&[
+    let (code, stdout, stderr) = run_cli_until_exit(&[
         "web",
         "--web-addr",
         "127.0.0.1:0",

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -432,6 +432,76 @@ fn binary_web_refuses_a_public_listener_without_a_session_secret() {
     );
 }
 
+/// The built-in `SESSION_SECRET` is not a weak key, it is a published one, so a
+/// production start on it has to refuse rather than mint forgeable cookies.
+///
+/// `serve` carried the only integration test that ever set
+/// `NODE_ENV=production`, and deleting that mode took the coverage with it:
+/// this guard sits in `run_web` and is reachable only by starting the binary.
+/// The address guard below is a different path and does not stand in for it.
+#[test]
+fn binary_web_refuses_production_without_a_session_secret() {
+    let dir = temp_path("web-production-secret");
+    std::fs::create_dir_all(&dir).unwrap();
+    let config = dir.join("production.env");
+    std::fs::write(
+        &config,
+        "LIVEKIT_URL=wss://example\nLIVEKIT_API_KEY=key\nLIVEKIT_API_SECRET=secret\nGOOGLE_API_KEY=google\nNODE_ENV=production\n",
+    )
+    .unwrap();
+
+    // No free-port dance: the refusal comes before the bind, so no listener is
+    // ever created and there is no port to race for.
+    let (code, stdout, stderr) = run_cli_args(&[
+        "web",
+        "--web-addr",
+        "127.0.0.1:0",
+        "--config",
+        config.to_str().unwrap(),
+    ]);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(code, 1);
+    assert!(stdout.is_empty());
+    assert!(
+        stderr.contains("SESSION_SECRET must be set when NODE_ENV=production"),
+        "{stderr}"
+    );
+}
+
+/// And the other direction, so the guard cannot be inverted without a test
+/// noticing: production with a secret of the operator's own is the supported
+/// deployment and has to serve.
+#[test]
+fn binary_web_serves_in_production_with_a_session_secret() {
+    let dir = temp_path("web-production-serves");
+    std::fs::create_dir_all(&dir).unwrap();
+    let config = dir.join("production.env");
+    std::fs::write(
+        &config,
+        format!(
+            "LIVEKIT_URL=wss://example\nLIVEKIT_API_KEY=key\nLIVEKIT_API_SECRET=secret\nGOOGLE_API_KEY=google\nNODE_ENV=production\nSESSION_SECRET=a-real-secret\nCODETRIAL_DB_PATH={}/accounts.db\n",
+            dir.display()
+        ),
+    )
+    .unwrap();
+
+    let (addr, _server) = spawn_server(|addr| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_codetrial"));
+        command
+            .args(["web", "--web-addr", addr, "--config"])
+            .arg(config.to_str().unwrap());
+        command
+    });
+    let response = http_request(
+        &addr,
+        "GET /api/session HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+}
+
 /// `serve` used to read the proxy-hop count straight from the process
 /// environment, so a value set in the config file was silently a no-op and the
 /// rate limiter keyed on the proxy instead of the client. Asserted against the

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -23,6 +23,8 @@ fn run_cli_args_with_env(args: &[&str], envs: &[(&str, &str)]) -> (i32, String, 
         .env_remove("CODETRIAL_DURATION_MIN")
         .env_remove("CODETRIAL_WEB_DIR")
         .env_remove("CODETRIAL_WEB_ADDR")
+        .env_remove("NODE_ENV")
+        .env_remove("SESSION_SECRET")
         .envs(envs.iter().copied())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -387,9 +389,9 @@ fn binary_modes_that_read_configuration_require_a_primary_config_file() {
 }
 
 #[test]
-fn binary_serve_requires_a_primary_config_file() {
+fn binary_web_requires_a_primary_config_file() {
     let (code, stdout, stderr) = with_free_addr(|addr| {
-        let result = run_cli_args(&["serve", "--web-addr", addr]);
+        let result = run_cli_args(&["web", "--web-addr", addr]);
         (!result.2.contains("failed to bind")).then_some(result)
     });
 
@@ -398,25 +400,23 @@ fn binary_serve_requires_a_primary_config_file() {
     assert!(stderr.contains("required configuration file is missing"));
 }
 
-/// `serve` runs one agent in one room, and `/api/token` only hands that room
-/// out while `production` is false. Booting anyway would mint rooms with nobody
-/// listening in them, so the refusal has to come before the bind succeeds.
 #[test]
-fn binary_serve_refuses_production() {
-    let config_dir = temp_path("serve-production");
+fn binary_web_refuses_a_public_listener_without_a_session_secret() {
+    let config_dir = temp_path("serve-public-default-secret");
     std::fs::create_dir_all(&config_dir).unwrap();
-    let config = config_dir.join("production.env");
+    let config = config_dir.join("public.env");
     std::fs::write(
         &config,
-        "LIVEKIT_URL=wss://example\nLIVEKIT_API_KEY=key\nLIVEKIT_API_SECRET=secret\nGOOGLE_API_KEY=google\nNODE_ENV=production\n",
+        "LIVEKIT_URL=wss://example\nLIVEKIT_API_KEY=key\nLIVEKIT_API_SECRET=secret\nGOOGLE_API_KEY=google\n",
     )
     .unwrap();
 
     let (code, stdout, stderr) = with_free_addr(|addr| {
+        let port = addr.rsplit_once(':').unwrap().1;
         let result = run_cli_args(&[
-            "serve",
+            "web",
             "--web-addr",
-            addr,
+            &format!("0.0.0.0:{port}"),
             "--config",
             config.to_str().unwrap(),
         ]);
@@ -427,7 +427,7 @@ fn binary_serve_refuses_production() {
     assert_eq!(code, 1);
     assert!(stdout.is_empty());
     assert!(
-        stderr.contains("cannot run with NODE_ENV=production"),
+        stderr.contains("SESSION_SECRET must be set to bind 0.0.0.0"),
         "{stderr}"
     );
 }
@@ -436,20 +436,21 @@ fn binary_serve_refuses_production() {
 /// environment, so a value set in the config file was silently a no-op and the
 /// rate limiter keyed on the proxy instead of the client. Asserted against the
 /// source because reaching it behaviorally needs a running proxy;
-/// `binary_serve_refuses_production` covers the `NODE_ENV` half for real.
+/// `binary_web_refuses_a_public_listener_without_a_session_secret` covers a
+/// startup refusal read from the same values, for real.
 #[test]
-fn binary_serve_reads_deployment_keys_from_the_config_file() {
+fn binary_web_reads_deployment_keys_from_the_config_file() {
     let source = std::fs::read_to_string("src/main.rs").unwrap();
 
     // Ends at the closing brace in column zero rather than at whatever item
     // happens to follow. Keying on the next `async fn` meant deleting the
     // function that used to sit there silently emptied this test's haystack.
     let serve = source
-        .split_once("fn run_serve(")
-        .expect("run_serve should exist")
+        .split_once("fn run_web(")
+        .expect("run_web should exist")
         .1
         .split_once("\n}\n")
-        .expect("run_serve should end")
+        .expect("run_web should end")
         .0;
 
     assert!(serve.contains("trusted_proxy_hops(&values)"), "{serve}");
@@ -509,7 +510,7 @@ fn binary_web_does_not_require_github_oauth_config() {
 }
 
 #[test]
-fn binary_serve_reports_web_bind_failure_after_config_validation() {
+fn binary_web_reports_bind_failure_after_config_validation() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("occupied port should bind");
     let addr = listener.local_addr().unwrap().to_string();
     let dir = temp_path("occupied-port");
@@ -517,7 +518,7 @@ fn binary_serve_reports_web_bind_failure_after_config_validation() {
     let config = dir.join("codetrial.env.local");
     write_config(&config, &dir, "127.0.0.1:1");
     let (code, stdout, stderr) = run_cli_args(&[
-        "serve",
+        "web",
         "--web-addr",
         &addr,
         "--config",
@@ -527,7 +528,7 @@ fn binary_serve_reports_web_bind_failure_after_config_validation() {
 
     assert_eq!(code, 1);
     assert!(stdout.is_empty());
-    assert!(stderr.contains("web side failed to bind"));
+    assert!(stderr.contains("failed to bind"), "{stderr}");
 }
 
 #[test]
@@ -540,7 +541,6 @@ fn binary_agent_modes_reject_usage_errors_with_exit_two() {
         &["web", "--duration-min", "nope"],
         &["web", "--duration-min", "0"],
         &["run-livekit", "room", "extra"],
-        &["serve", "extra"],
         &["check-gemini", "extra"],
     ] {
         let (code, stdout, stderr) = run_cli_args(args);

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -2,8 +2,8 @@ use codetrial::config::{
     DEFAULT_COMPILER_EXPLORER_ENABLED, DEFAULT_DURATION_MIN,
     DEFAULT_GEMINI_CANDIDATE_VIDEO_ENABLED, DEFAULT_GEMINI_LIVE_MODEL, DEFAULT_GEMINI_REPORT_MODEL,
     DEFAULT_GEMINI_SILENCE_MS, DEFAULT_GEMINI_START_SENSITIVITY, DEFAULT_GEMINI_VOICE,
-    DEFAULT_MAX_CONCURRENT_INTERVIEWS, DEFAULT_ROOM_PREFIX, DEFAULT_WEB_ADDR, DEFAULT_WEB_DIR,
-    MAX_GEMINI_SILENCE_MS, load_from_pairs, max_concurrent_interviews,
+    DEFAULT_MAX_CONCURRENT_INTERVIEWS, DEFAULT_ROOM_PREFIX, MAX_GEMINI_SILENCE_MS, load_from_pairs,
+    max_concurrent_interviews,
 };
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -37,9 +37,6 @@ fn config_accepts_current_env_names() {
     assert_eq!(config.gemini_silence_ms, DEFAULT_GEMINI_SILENCE_MS);
     assert_eq!(config.room_prefix, "room");
     assert_eq!(config.default_duration_min, 30);
-    assert_eq!(config.web_dir, "public");
-    assert_eq!(config.web_addr, "0.0.0.0:8080");
-    assert!(!config.compiler_explorer_enabled);
     assert!(config.gemini_candidate_video_enabled);
 }
 
@@ -83,12 +80,6 @@ fn config_defaults_optional_names_and_web_runtime_fields() {
     assert_eq!(config.gemini_start_sensitivity, "START_SENSITIVITY_LOW");
     assert_eq!(config.room_prefix, DEFAULT_ROOM_PREFIX);
     assert_eq!(config.default_duration_min, DEFAULT_DURATION_MIN);
-    assert_eq!(config.web_dir, DEFAULT_WEB_DIR);
-    assert_eq!(config.web_addr, DEFAULT_WEB_ADDR);
-    assert_eq!(
-        config.compiler_explorer_enabled,
-        DEFAULT_COMPILER_EXPLORER_ENABLED
-    );
     assert_eq!(
         config.gemini_candidate_video_enabled,
         DEFAULT_GEMINI_CANDIDATE_VIDEO_ENABLED
@@ -119,30 +110,40 @@ fn config_uses_defaults_for_blank_optional_web_runtime_fields() {
 
     assert_eq!(config.room_prefix, DEFAULT_ROOM_PREFIX);
     assert_eq!(config.default_duration_min, DEFAULT_DURATION_MIN);
-    assert_eq!(config.web_dir, DEFAULT_WEB_DIR);
-    assert_eq!(config.web_addr, DEFAULT_WEB_ADDR);
-    assert_eq!(
-        config.compiler_explorer_enabled,
-        DEFAULT_COMPILER_EXPLORER_ENABLED
-    );
     assert_eq!(
         config.gemini_candidate_video_enabled,
         DEFAULT_GEMINI_CANDIDATE_VIDEO_ENABLED
     );
 }
 
+/// Asserted on the parser rather than through a config struct, because the
+/// struct field it used to be read through was only ever consumed by `serve`.
+///
+/// The distinction worth pinning is blank against unreadable. This switch sends
+/// candidate code to a third party, so a value nobody can read has to mean off,
+/// while a blank one is an operator who said nothing and gets the default. A
+/// parser that collapsed the two would either turn the feature off for an empty
+/// line in a config file or leave it on for a typo.
 #[test]
 fn config_fails_closed_for_invalid_compiler_explorer_switch() {
-    let config = load_from_pairs([
-        ("LIVEKIT_URL", "wss://example.livekit.cloud"),
-        ("LIVEKIT_API_KEY", "key"),
-        ("LIVEKIT_API_SECRET", "secret"),
-        ("GOOGLE_API_KEY", "google"),
-        ("CODETRIAL_COMPILER_EXPLORER_ENABLED", "flase"),
-    ])
-    .expect("invalid privacy switch should still load");
+    let enabled = codetrial::config::compiler_explorer_enabled;
 
-    assert!(!config.compiler_explorer_enabled);
+    for unreadable in ["flase", "maybe", "2"] {
+        assert!(!enabled(Some(unreadable)), "{unreadable} should mean off");
+    }
+    for said_nothing in [Some(""), Some("   "), None] {
+        assert_eq!(
+            enabled(said_nothing),
+            DEFAULT_COMPILER_EXPLORER_ENABLED,
+            "{said_nothing:?} should mean the default"
+        );
+    }
+    for on in ["true", "TRUE", "1", "yes", "on"] {
+        assert!(enabled(Some(on)), "{on} should mean on");
+    }
+    for off in ["false", "0", "no", "off"] {
+        assert!(!enabled(Some(off)), "{off} should mean off");
+    }
 }
 
 #[test]
@@ -815,23 +816,6 @@ fn loading_config_does_not_depend_on_the_current_directory() {
     assert_eq!(config.pool.providers[0].google_api_key, "google");
 }
 
-#[test]
-fn a_hostname_web_address_still_loads() {
-    // `ToSocketAddrs` resolves this and `bind_web_listener` accepts it, so a
-    // config-time check that only takes a literal socket address would refuse a
-    // setting that has always worked.
-    let config = load_from_pairs([
-        ("LIVEKIT_URL", "wss://example.livekit.cloud"),
-        ("LIVEKIT_API_KEY", "key"),
-        ("LIVEKIT_API_SECRET", "secret"),
-        ("GOOGLE_API_KEY", "google"),
-        ("CODETRIAL_WEB_ADDR", "localhost:3000"),
-    ])
-    .expect("a hostname web address should load");
-
-    assert_eq!(config.web_addr, "localhost:3000");
-}
-
 /// The recording block, which is off in every deployment until an operator
 /// provisions the resources in `docs/recording-contract.md`. These read the
 /// parser directly rather than through `load_from_pairs`, because
@@ -841,8 +825,7 @@ mod recording {
 
     use codetrial::config::{
         DEFAULT_RECORDING_BITRATE, DEFAULT_RECORDING_GCS_PREFIX, DEFAULT_RECORDING_MAX_MINUTES,
-        DEFAULT_RECORDING_TIMEOUT_SECONDS, PRIMARY_PROVIDER_ID, Provider, ProviderPool,
-        load_recording,
+        PRIMARY_PROVIDER_ID, Provider, ProviderPool, load_recording,
     };
 
     const SERVICE_ACCOUNT: &str = r#"{"type":"service_account","client_email":"codetrial@example.iam.gserviceaccount.com","private_key":"KEYMATERIAL-4bd2"}"#;
@@ -907,9 +890,7 @@ mod recording {
         assert_eq!(config.gcs_prefix, DEFAULT_RECORDING_GCS_PREFIX);
         assert_eq!(config.max_minutes, DEFAULT_RECORDING_MAX_MINUTES);
         assert_eq!(config.bitrate, DEFAULT_RECORDING_BITRATE);
-        assert_eq!(config.timeout_seconds, DEFAULT_RECORDING_TIMEOUT_SECONDS);
         assert!(!config.kill_switch);
-        assert!(!config.integration);
         assert!(
             config.livekit.is_none(),
             "with no override, recording follows the project that owns the room"
@@ -1040,7 +1021,6 @@ mod recording {
         for (key, value) in [
             ("CODETRIAL_RECORDING_BITRATE", "2 Mbps"),
             ("CODETRIAL_RECORDING_MAX_MINUTES", "forty-five"),
-            ("CODETRIAL_RECORDING_TIMEOUT_SECONDS", "15m"),
         ] {
             let error = load_recording(&values([(key, value)]), &pool(), 45, false)
                 .unwrap_err()
@@ -1054,7 +1034,6 @@ mod recording {
         for key in [
             "CODETRIAL_RECORDING_ENABLED",
             "CODETRIAL_RECORDING_KILL_SWITCH",
-            "CODETRIAL_RECORDING_INTEGRATION",
         ] {
             let error = load_recording(&values([(key, "ture")]), &pool(), 45, false)
                 .unwrap_err()

--- a/tests/recording.rs
+++ b/tests/recording.rs
@@ -612,8 +612,6 @@ pub(crate) mod lifecycle {
             bitrate: 2000,
             kill_switch: false,
             template_base_url: "https://recording.codetrial.example".to_string(),
-            timeout_seconds: 900,
-            integration: false,
         }
     }
 

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -3861,8 +3861,6 @@ fn recording_config() -> codetrial::config::RecordingConfig {
         bitrate: 2000,
         kill_switch: false,
         template_base_url: "https://recording.codetrial.example".to_string(),
-        timeout_seconds: 900,
-        integration: false,
     }
 }
 

--- a/web/interview.js
+++ b/web/interview.js
@@ -14,6 +14,7 @@ import { createFaceCheck } from "./face-check.js";
 import {
   createTranscriptView,
   finalRunnerStatus,
+  problemMarkup,
   reportMarkdown,
   reportMarkup,
   resultsMarkup,
@@ -25,7 +26,6 @@ import {
   codeUpdatePayload,
   countdown,
   endInterviewPayload,
-  escapeHtml,
   formatTime,
   integrityEventPayload,
   isAgent,
@@ -1053,24 +1053,7 @@ function renderProblem() {
   // happens in the lobby, before there is an interview to attach it to, which
   // is why `connect` sends it again once there is one.
   recordStage();
-  nodes.problemPanel.innerHTML = `
-    <div class="problem-detail">
-      ${problem.statement.map((text) => `<p>${escapeHtml(text)}</p>`).join("")}
-      <div class="examples">
-        ${problem.examples.map((example, index) => `
-          <section>
-            <h2>Example ${index + 1}</h2>
-            <pre><span>Input: </span>${escapeHtml(example.input)}
-<span>Output: </span>${escapeHtml(example.output)}${example.explanation ? `
-<span>Explanation: </span>${escapeHtml(example.explanation)}` : ""}</pre>
-          </section>
-        `).join("")}
-      </div>
-      <h2>Constraints</h2>
-      <ul>${problem.constraints.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>
-      <div class="hint-box"><strong>Think out loud.</strong> Jim is listening to your voice and reading your editor in real time - narrate your approach like you would with a human interviewer, and say "can I get a hint?" if you need one.</div>
-    </div>
-  `;
+  nodes.problemPanel.innerHTML = problemMarkup(problem);
 }
 
 function selectTab(tab) {

--- a/web/render.js
+++ b/web/render.js
@@ -85,6 +85,34 @@ function sourceEventMarkup(event) {
   return `<ul>${event.sourceEventIds.map((id) => `<li>source event ${escapeHtml(id)}</li>`).join("")}</ul>`;
 }
 
+// The problem panel, here rather than inline in `interview.js` for the reason
+// every other builder in this file is here: a markup string assembled beside a
+// DOM lookup cannot be handed to `node --test`, so the one guarantee that
+// matters about it, that nothing a problem carries becomes live markup, had no
+// test while every sibling renderer did. Problem text is not all first-party:
+// `leetcode-import.js` brings statements in from outside.
+export function problemMarkup(problem) {
+  const example = (example, index) => `
+          <section>
+            <h2>Example ${index + 1}</h2>
+            <pre><span>Input: </span>${escapeHtml(example.input)}
+<span>Output: </span>${escapeHtml(example.output)}${example.explanation ? `
+<span>Explanation: </span>${escapeHtml(example.explanation)}` : ""}</pre>
+          </section>
+        `;
+  return `
+    <div class="problem-detail">
+      ${problem.statement.map((text) => `<p>${escapeHtml(text)}</p>`).join("")}
+      <div class="examples">
+        ${problem.examples.map(example).join("")}
+      </div>
+      <h2>Constraints</h2>
+      <ul>${problem.constraints.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>
+      <div class="hint-box"><strong>Think out loud.</strong> Jim is listening to your voice and reading your editor in real time - narrate your approach like you would with a human interviewer, and say "can I get a hint?" if you need one.</div>
+    </div>
+  `;
+}
+
 /// Only the verdict and the scores differ between an evaluated session and one
 /// that produced nothing. Forking the whole card duplicated the header, the
 /// evidence section, the code block and the actions row, including the


### PR DESCRIPTION
`serve` and `web` built the same thing through two copies of the same
assembly: one `WebServerConfig`, one `LocalDispatcher`, one
`web_service_with_dispatcher`. The only difference was that `serve` refused
`NODE_ENV=production` and insisted on a Gemini key, and its own production
error already said to run `web`, "which serves the same way". The README
described a distinction that did not exist, calling `serve` the mode that
hosts an interviewer in-process while another paragraph said `web` does that
too. One serving mode now; local and deployed differ by configuration, not by
command.

Releases stop moving. The job used to force-push a `latest` tag, so every
download link it handed out silently changed what it served. It now publishes
one immutable prerelease per commit, keeps the newest few, and deletes the
rest with their tags. Removing the mutable pointer removed most of the job
with it: the supersede guard, the cancel-in-progress race and the stale-asset
sweep all existed to defend that one pointer.

Also here: two recording env keys that were parsed, validated, stored and
documented but read by nothing; the problem panel moved into the renderer
module so its escaping is testable like every sibling renderer's; a
three-variant enum in place of a column-name string match that ended in the
only `unreachable!` outside tests; and the published built-in `SESSION_SECRET`
refused on any listen address that is not loopback.

## Breaking

- `codetrial serve` is gone. Use `codetrial web`. Unknown modes now print the
  list, so the failure names its own fix.
- `make serve` is gone. Use `make web`.
- A local run no longer hard-fails without `GOOGLE_API_KEY`; `web` warns and
  serves the web side only, which it has always done. `scripts/browser-check.sh`
  still requires the key before it starts anything, so CI coverage is unchanged.
- `SESSION_SECRET` must be set to bind a non-loopback address. Every script in
  the repo binds loopback, so none of them change.
- `CODETRIAL_RECORDING_TIMEOUT_SECONDS` and `CODETRIAL_RECORDING_INTEGRATION`
  are no longer parsed. Both were inert, so setting them changes nothing that
  was not already nothing; the only difference is that an unreadable value no
  longer refuses to start.

## Needs a decision before or after merge

The old `latest` release and tag still exist and the prune filter deliberately
does not match them, so CI will never touch them. Left alone they sit at the
top of the releases page serving frozen bytes that the README no longer
mentions. Removing them breaks any link already in the wild:

```
gh release delete latest -R sysprog21/codetrial --yes --cleanup-tag
```

## Verification

`./scripts/test.sh` green, all 19 gates, 400 Rust tests and 242 browser tests,
`clippy -D warnings` and `actionlint` clean.

The release job cannot be exercised by that gate, so both `run:` blocks were
extracted from the YAML with a parser and executed under GitHub's own shell
flags with `gh` stubbed. Publish covers a fresh tag, a truncated asset, an
existing draft, an already-published release, and a failing `isDraft` query.
Prune covers pagination, a stray draft (deleted without `--cleanup-tag`, since
a draft has no ref behind its tag name), and tag shapes that must not match:
uppercase hex, 39 and 41 characters, hand-tagged `main-rc1`, the legacy
`latest`, and a non-prerelease. `gh api` placeholder resolution was checked
from a non-git directory with only `GH_REPO` set, which is the condition in the
job now that it has no checkout step.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `serve` mode and replaces the moving `latest` release tag with immutable per-commit prereleases.

**Breaking changes**
- `codetrial serve` is gone; use `codetrial web`. Unknown modes now print the list of valid modes.
- `make serve` is gone; use `make web`.
- Local runs no longer hard-fail without `GOOGLE_API_KEY`; `web` warns and serves web-only. `scripts/browser-check.sh` still requires the key.
- `SESSION_SECRET` must be set to bind a non-loopback address. All repo scripts bind loopback, so none change.
- `CODETRIAL_RECORDING_TIMEOUT_SECONDS` and `CODETRIAL_RECORDING_INTEGRATION` are no longer parsed; both were inert.

**Release changes**
- Releases are now published per commit as `main-<sha>` prereleases, keeping the newest five and deleting older ones with their tags.
- The old `latest` release and tag are left untouched and may need manual deletion if links still reference them.
- The problem panel moved into the renderer module so its escaping is tested like every other renderer; the recording handle column match became an enum.

<sup>Written for commit 978f2b7762a4f1f2cfa930bde39e8bb7304c5dc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/codetrial/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

