### PR TITLE
Publish one rolling latest release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -606,9 +606,8 @@ jobs:
           name: codetrial-${{ matrix.target }}
           path: codetrial-${{ matrix.target }}.${{ matrix.archive }}
 
-  # One immutable prerelease per main commit, tagged `<prefix><sha>`. No moving
-  # pointer: a tag that gets force-pushed is a tag nobody can trust, and every
-  # download link it ever handed out silently changes what it serves.
+  # One rolling release for the current main build. GitHub releases require a
+  # tag; `latest` avoids exposing an implementation SHA as a release name.
   release:
     needs: [check, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -616,32 +615,19 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
-    # Keyed on the commit, not on a shared name. The workflow-level group
-    # already queues one push behind another, so what is left for this to hold
-    # is a re-run of one job against a run still in flight: two jobs drafting
-    # and uploading to the same tag. Not cancelling, because with a tag per
-    # commit the older job is publishing its own release rather than racing for
-    # a pointer, and its build is worth having.
     concurrency:
-      group: release-${{ github.sha }}
+      group: release-latest
       cancel-in-progress: false
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
-      # The tag scheme and the retention, named once and read by both the
-      # publish and the prune. Spelled twice they were free to drift, and the
-      # drift is silent in the direction that matters: a prune whose filter
-      # matches nothing is indistinguishable from a prune with nothing to do,
-      # so releases and tags would accumulate with no failure anywhere.
-      TAG_PREFIX: main-
-      KEEP_PRERELEASES: 5
     steps:
       - uses: actions/download-artifact@v8
         with:
           pattern: codetrial-*
           path: dist
           merge-multiple: true
-      - name: Verify and publish the prerelease
+      - name: Verify and publish the latest release
         shell: bash
         run: |
           assets=(
@@ -653,136 +639,83 @@ jobs:
             [ -f "$asset" ] || { echo "missing release asset: $asset" >&2; exit 1; }
           done
 
-          # The commit, in the tag. `gh release create --target` cuts the tag
-          # itself, so nothing here needs a checkout, a `git tag -f` or a force
-          # push to a ref other people have already fetched.
-          tag="${TAG_PREFIX}${GITHUB_SHA}"
+          tag=latest
+          # The attempt, not just the run: a re-run reuses GITHUB_RUN_ID, and
+          # `gh release create` fails outright on a leftover draft.
+          staged="staging-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
 
-          # Drafted while the three assets upload. `gh release upload` writes
-          # one at a time, so a published release would serve a Linux binary
-          # from this commit beside nothing at all for Windows, and nothing on
-          # the page would say so. A draft serves no downloads, so the
-          # half-written state is unreachable rather than merely unlikely.
-          #
-          # Resume only an interrupted draft. A published release is immutable:
-          # reruns may produce different bytes, so never overwrite its assets.
-          #
-          # Written as a branch rather than `create || edit`, because a create
-          # that failed on credentials or on the network would read as "already
-          # exists" and the job would go on to publish a release it never made.
-          #
-          # The state lands in a variable rather than inside the `[`, because a
-          # command substitution that failed there is not the test's status:
-          # `set -e` would not see it, the empty string would not equal `false`,
-          # and a network blip would send the job on to `--clobber` the assets
-          # of a published release. Assigned, the failure stops the job, and
-          # anything other than a literal `true` is read as published.
-          if gh release view "$tag" >/dev/null 2>&1; then
-            draft=$(gh release view "$tag" --json isDraft --jq .isDraft)
-            if [ "$draft" != true ]; then
-              echo "$tag is already published; leaving it unchanged"
-              exit 0
-            fi
-          else
-            gh release create "$tag" --draft --target "$GITHUB_SHA" \
-              --prerelease --title "$tag" \
-              --notes "Automated build of ${GITHUB_SHA:0:7}."
-          fi
+          # Upload to a draft first: a failed upload must not take the current
+          # public release down with it. Nothing else here looks for a draft,
+          # so it collects itself on the way out, including on the superseded
+          # path below, which exits green. No `--cleanup-tag`: publishing is
+          # what cuts a tag, so a draft has none and deleting that ref is a 422.
+          published=false
+          trap '[ "$published" = true ] || gh release delete "$staged" --yes >/dev/null 2>&1 || true' EXIT
 
-          gh release upload "$tag" "${assets[@]}" --clobber
+          gh release create "$staged" --draft --target "$GITHUB_SHA" \
+            --title "$tag" --notes "Automated build of ${GITHUB_SHA:0:7}."
+          gh release upload "$staged" "${assets[@]}"
 
           # Sizes, not just presence: an upload cut off partway still leaves a
           # named asset behind, and a truncated binary is the one outcome this
-          # whole dance exists to keep off the download page. One query for the
-          # whole set, because three assets asking the same endpoint the same
-          # question is three round trips for one answer.
-          sizes=$(gh release view "$tag" --json assets --jq '.assets[] | "\(.name) \(.size)"')
+          # whole dance exists to keep off the download page.
+          sizes=$(gh release view "$staged" --json assets --jq '.assets[] | "\(.name) \(.size)"')
           for asset in "${assets[@]}"; do
             name=$(basename "$asset")
             want=$(stat -c%s "$asset")
             got=$(printf '%s\n' "$sizes" | awk -v n="$name" '$1 == n { print $2 }')
             [ "$want" = "$got" ] || {
               echo "$name uploaded as ${got:-nothing}, expected $want bytes" >&2
-              echo "$tag stays drafted rather than serving a mixed set" >&2
               exit 1
             }
           done
 
-          # Only now does anything point at this build.
-          gh release edit "$tag" --draft=false
+          # One moving pointer means order matters, and the concurrency group
+          # serializes these jobs without ordering them: a re-run of an older
+          # commit, or a build overtaken by a newer push, would otherwise walk
+          # `latest` backwards onto stale binaries. The race stays open until
+          # the swap, so this asks as late as it usefully can.
+          tip=$(gh api "repos/$GH_REPO/git/ref/heads/main" --jq .object.sha)
+          if [ "$tip" != "$GITHUB_SHA" ]; then
+            echo "superseded by $tip; leaving $tag as it is"
+            exit 0
+          fi
 
-      # Its own step, because retention is a property of the release namespace
-      # rather than of this build, and a step named for publishing should not
-      # delete things. `!cancelled()` is what makes the split mean anything: a
-      # plain step inherits `success()`, so welded onto the publish or merely
-      # placed after it, a failed upload would silently skip a commit's worth of
-      # pruning. A failed publish is exactly when there is a stray draft to
-      # collect.
-      - name: Prune superseded prereleases
-        if: ${{ !cancelled() }}
-        shell: bash
-        run: |
-          # Matched on the shape this job produces, not merely on the prefix: a
-          # prerelease a person tagged `main-rc1` by hand is not something CI
-          # gets to delete. Forty hex characters because the publish step tags
-          # the whole `GITHUB_SHA`; if that ever shortens, this has to shorten
-          # with it, since a filter that stops matching fails open and a prune
-          # that found nothing to do looks exactly like one with nothing to do.
+          # Existence read out of a listing rather than a status code. `gh`
+          # exits non-zero on a 404 and `shell: bash` runs with `pipefail`, so
+          # pulling the code out of `gh api -i` kills the job at the
+          # assignment; and `view || skip` reads a rate limit or an expired
+          # token as "not there". Both queries below answer with data and a
+          # zero status when the thing is absent, so anything else stops the
+          # job here instead of being mistaken for absence.
           #
-          # Newest by publish time, not by `created_at`. A release's
-          # `created_at` is the date of the commit it was cut from, not the
-          # moment the release appeared: on this repository the `latest`
-          # release and the commit it pointed at both read 06:15:44Z while it
-          # actually published at 06:37:15Z. Sorting on it ranks a rerun of an
-          # older commit, or anything rebased, below releases that were
-          # published long before it, which is the wrong end of the list to
-          # delete from. Drafts have no `published_at`, so they fall back.
+          # GitHub allows one release per tag, so the old release has to go
+          # before the draft can take its name, and `latest` resolves to
+          # nothing until the edit lands.
           #
-          # This commit's own release is counted but never deleted. Excluding
-          # it from the set instead would keep it plus a further
-          # KEEP_PRERELEASES, one more than the number says; dropping it at the
-          # end keeps the arithmetic honest and still means a rerun that
-          # republishes a historical build cannot delete what it just uploaded.
-          #
-          # One case holds KEEP_PRERELEASES + 1, knowingly. A rerun of an old
-          # commit whose release is still published exits the publish step
-          # early, so its `published_at` stays old and it can rank outside the
-          # window; the exemption then spares it. That is the trade against
-          # deleting the release of the very commit being built, and the next
-          # push, where it is no longer `$current`, collects it.
-          #
-          # `// ""` on both reads of tag_name: a draft created by hand in the
-          # web UI can carry no tag at all, and `null | startswith` is a jq
-          # error, which `pipefail` turns into a red step rather than a prune.
-          #
-          # Already on: `shell: bash` three lines up runs `bash -eo pipefail`,
-          # unlike the mutation plan step, which declares no shell and so gets
-          # the bare `bash -e` its own comment describes. Written down anyway
-          # because this step's correctness rests on it. The status of the
-          # pipeline is the `while` loop's, so a `gh` that failed on rate
-          # limiting or a `jq` that errored would otherwise end the step green
-          # having pruned nothing, which is the exact failure the filter above
-          # is shaped to avoid.
-          set -o pipefail
-          gh api --paginate --slurp 'repos/{owner}/{repo}/releases?per_page=100' \
-            | jq -r --arg prefix "$TAG_PREFIX" --argjson keep "$KEEP_PRERELEASES" \
-                    --arg current "${TAG_PREFIX}${GITHUB_SHA}" \
-              '[.[][] | select(.prerelease
-                               and ((.tag_name // "") | startswith($prefix))
-                               and ((.tag_name // "")[($prefix | length):]
-                                    | test("^[0-9a-f]{40}$")))]
-               | sort_by(.published_at // .created_at) | reverse | .[$keep:]
-               | .[] | select(.tag_name != $current) | "\(.draft) \(.tag_name)"' \
-            | while read -r draft old; do
-                echo "removing superseded prerelease: $old"
-                # `--cleanup-tag` only where there is a tag. A draft holds a tag
-                # name but no ref: publishing is what cuts it, so a stray draft
-                # from a failed publish has none, and asking the API to delete
-                # that ref is a 422 that reddens this step and keeps reddening
-                # it until somebody deletes the draft by hand.
-                if [ "$draft" = true ]; then
-                  gh release delete "$old" --yes
-                else
-                  gh release delete "$old" --yes --cleanup-tag
-                fi
-              done
+          # The release and the tag come off in two calls because they go
+          # missing separately: a tag outlives its release when a cleanup was
+          # interrupted or a ref is protected, and a release outlives its tag
+          # when somebody deletes the tag by hand. `--cleanup-tag` would fold
+          # them into one round trip, but on a ref that is already gone it
+          # fails, and it fails having already deleted the release, which ends
+          # the job with `latest` taken down and nothing put back.
+          releases=$(gh release list --limit 100 --json tagName --jq '.[].tagName')
+          if printf '%s\n' "$releases" | grep -qxF "$tag"; then
+            gh release delete "$tag" --yes
+          fi
+
+          # `target_commitish` is documented as unused when the tag already
+          # exists, so a tag left in place here would publish this build's
+          # assets under a name still pointing at an older commit, with nothing
+          # on the page saying so.
+          refs=$(gh api "repos/$GH_REPO/git/matching-refs/tags/$tag" --jq '.[].ref')
+          if printf '%s\n' "$refs" | grep -qxF "refs/tags/$tag"; then
+            gh api -X DELETE "repos/$GH_REPO/git/refs/tags/$tag" --silent
+          fi
+
+          # `--target` is read only when the tag is cut, which is what the two
+          # deletes above are for.
+          gh release edit "$staged" --tag "$tag" --target "$GITHUB_SHA" --draft=false
+          published=true
+

--- a/README.md
+++ b/README.md
@@ -76,19 +76,22 @@ for pooling.
 
 ## Prebuilt binaries
 
-Every push to `main` publishes a prerelease tagged `main-<commit sha>` under
-<https://github.com/sysprog21/codetrial/releases>, newest first. The tag names
-the commit and never moves, and a release that has already published is left
-alone rather than rebuilt over, so a download link keeps serving the bytes it
-served the first time. Only the most recent few are kept: the `release` job in
-`.github/workflows/check.yml` names the retention, and older prereleases are
-deleted with their tags. Nothing is required at runtime beyond the binary
-itself: the browser application, its vendored assets, and the WASM are compiled
-in, so there is no Node.js, no `node_modules`, and no `web/` directory to
-unpack alongside it. The avatar model is not in there either: the browser
-downloads it once from a pinned upstream URL, checks it against a pinned
-SHA-256, and keeps it in its own cache. Without that reachable, the interview
-falls back to Jim's voice-only panel and nothing else changes.
+Every successful build of `main` replaces the `latest` release under
+<https://github.com/sysprog21/codetrial/releases>, unless a newer commit landed
+while it was running. The binaries go to a draft first, and their sizes are
+checked against the files the build produced before that draft takes the name,
+so a truncated upload never reaches the download page. Two things that tag will not
+give you: replacing a release is not atomic, so each publish has a short window
+where `latest` resolves to nothing, and the tag moves, so a link does not keep
+serving the bytes it served last week. Pin a commit and keep your own checksum
+if you need the same binary twice. Nothing is required at runtime beyond the
+binary itself: the browser application, its vendored assets, and the WASM are
+compiled in, so there is no Node.js, no `node_modules`, and no `web/` directory
+to unpack alongside it. The avatar
+model is not in there either: the browser downloads it once from a pinned
+upstream URL, checks it against a pinned SHA-256, and keeps it in its own cache.
+Without that reachable, the interview falls back to Jim's voice-only panel and
+nothing else changes.
 
 ```bash
 # Linux


### PR DESCRIPTION
Downloads point at one name now. The old scheme cut an immutable prerelease per main commit, tagged main-<sha>, and kept the newest five, so the tag named an implementation detail and the release list grew an entry every push. What it bought was permanence: a link kept serving the bytes it served the first time. That is the trade being made here, and the README states it rather than leaving it to be discovered. Anyone who needs the same binary twice pins a commit and keeps a checksum.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches release publishing on `main` from per-commit prereleases (tagged `main-<sha>`, keeping the newest five) to a single rolling `latest` release. Downloads now always point to the newest build, but links are no longer immutable; the README advises pinning a commit and keeping a checksum for stable downloads.

**What changed**

- The workflow now uploads assets to a draft release, verifies uploaded sizes, then replaces the previous `latest` release.
- If a newer commit lands while the build runs, the release is skipped so `latest` never points to an older commit.
- The replace is not atomic: there’s a short window where `latest` resolves to nothing.

<sup>Written for commit 9cf7ffbb874233a5ef91c01eeddf7e2cae3ac09a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/codetrial/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

