### PR TITLE
Cap the interview length at the recording limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,34 @@ tab with tab audio enabled. Meet owns the shared tab after that point, and
 face-presence analysis is disabled for the session. See the
 [manual check](docs/meet-tab-audio-manual-check.md) for the supported flow.
 
+### Interview length
+
+The lobby offers 30, 45, and 60 minutes, and the candidate picks one before
+starting. `CODETRIAL_DURATION_MIN` is only the length preselected for a
+candidate who does not choose; the endpoint accepts 10 to 90 either way, so a
+deployment that lowers the default has not lowered the ceiling.
+
+Recording lowers it. `CODETRIAL_RECORDING_MAX_MINUTES` bounds a single
+recording, and the sweeper fails one still running five minutes past it, so an
+interview longer than the cap loses exactly the stretch past it and the artifact
+is failed rather than delivered. Where recording is on, the longest interview
+this deployment will start is that cap, clamped into the 10–90 the endpoint
+offers; where it is off, the ceiling is 90.
+
+The lobby is told the ceiling rather than left to discover it. `/api/session`
+reports `maxDurationMin`, and the duration row disables the lengths above it
+with the reason beside them — a length this deployment cannot record is never
+offered and then quietly shortened. `/api/token` clamps to the same ceiling, so
+a request that skips the lobby is bounded too, and both endpoints read it from
+one function so the length that is offered and the length that is enforced
+cannot drift apart.
+
+Startup refuses a cap below `CODETRIAL_DURATION_MIN`, so the length this
+deployment preselects is always one it can record; the pairing is a
+configuration error rather than a quietly shortened interview. Should a cap ever
+sit below every length the row offers, the lobby leaves the row alone rather
+than rendering a page with nothing to press.
+
 ## Development
 
 ```bash
@@ -262,7 +290,7 @@ the environment instead. The common ones are:
 | Variable | Default | Purpose |
 |---|---|---|
 | `CODETRIAL_WEB_ADDR` | `127.0.0.1:3000` | Listen address |
-| `CODETRIAL_DURATION_MIN` | `45` | Default interview length (10–90) |
+| `CODETRIAL_DURATION_MIN` | `45` | Interview length preselected in the lobby (10–90); see [Interview length](#interview-length) |
 | `GEMINI_LIVE_MODEL` | `gemini-3.1-flash-live-preview` | Realtime interviewer model |
 | `GEMINI_REPORT_MODEL` | `gemini-3.1-flash-lite` | Report model |
 | `CODETRIAL_GEMINI_CANDIDATE_VIDEO_ENABLED` | `false` | Forward candidate video to Gemini |
@@ -293,8 +321,11 @@ Serving more than one LiveKit project from one deployment is in
 
 Recording is off by default. Enabling it requires a separate LiveKit project,
 private GCS staging bucket, Shared Drive, service account, GitHub OAuth, and
-candidate consent. The full configuration, lifecycle, retention policy, and
-credentialed acceptance check are in [docs/recording-contract.md](docs/recording-contract.md).
+candidate consent. It also caps how long an interview can run:
+`CODETRIAL_RECORDING_MAX_MINUTES` (45 by default) becomes the longest length the
+lobby offers, described under [Interview length](#interview-length). The full
+configuration, lifecycle, retention policy, and credentialed acceptance check
+are in [docs/recording-contract.md](docs/recording-contract.md).
 
 ## Further documentation
 

--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -287,12 +287,18 @@ pub(crate) async fn session_handler(
     // record a login at all, and telling the page to demand one anyway leaves
     // the candidate typing a username into an endpoint that answers 404.
     let login_required = state.accounts_required;
+    // The lobby offers lengths this deployment may not be able to record, and
+    // only the server knows the recording cap. Answered on both branches
+    // because the duration row is live before anyone signs in.
+    let max_duration_min =
+        super::token::duration_ceiling(state.config.recording.as_ref().map(|it| it.max_minutes));
     match current_user(state.accounts.as_ref(), request.headers()).await {
         Ok(Some(user)) => json_response(
             StatusCode::OK,
             json!({
                 "signedIn": true,
                 "loginRequired": login_required,
+                "maxDurationMin": max_duration_min,
                 "user": {
                     "login": user.login,
                     "avatarUrl": user.avatar_url
@@ -301,7 +307,11 @@ pub(crate) async fn session_handler(
         ),
         Ok(None) => json_response(
             StatusCode::OK,
-            json!({ "signedIn": false, "loginRequired": login_required }),
+            json!({
+                "signedIn": false,
+                "loginRequired": login_required,
+                "maxDurationMin": max_duration_min,
+            }),
         ),
         Err(_) => json_response(
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/web/token.rs
+++ b/src/web/token.rs
@@ -35,6 +35,11 @@ pub struct TokenConfig<'a> {
     pub api_key: &'a str,
     pub api_secret: &'a str,
     pub server_url: &'a str,
+    /// The deployment's recording cap, and `None` wherever recording is off.
+    /// An interview may not outlast the recording made of it: `stale_after` in
+    /// recording/sweeper.rs reaps one still running past this many minutes, so
+    /// a longer interview loses exactly the stretch it was recorded for.
+    pub recording_max_min: Option<u32>,
 }
 
 /// Same reason, and the sharpest case of it: `token` is a minted LiveKit
@@ -148,7 +153,7 @@ pub fn token_response(
         .get("problemId")
         .and_then(Value::as_str)
         .unwrap_or(crate::agent::DEFAULT_PROBLEM_ID);
-    let duration_min = token_duration_min(request.get("durationMin"));
+    let duration_min = token_duration_min(request.get("durationMin"), config.recording_max_min);
     let metadata = json!({
         "problemId": problem_id,
         "durationMin": duration_min,
@@ -180,14 +185,26 @@ pub(crate) fn generated_candidate_identity() -> String {
 
 pub(crate) const CANDIDATE_SUFFIX_LEN: usize = 6;
 
-pub(crate) fn token_duration_min(value: Option<&Value>) -> Value {
+pub(crate) fn token_duration_min(value: Option<&Value>, recording_max_min: Option<u32>) -> Value {
+    // The ceiling a recorded interview gets is its own recording's, because the
+    // sweeper reaps the recording on that bound and not on this one. Clamped
+    // into the range rather than taken as given: a cap above `MAX_DURATION_MIN`
+    // does not buy a longer interview than the endpoint has ever offered, and
+    // one below `MIN_DURATION_MIN` would cross the floor, which is a panic in
+    // `f64::clamp` rather than a short interview.
+    let ceiling = recording_max_min.map_or(MAX_DURATION_MIN, |cap| {
+        cap.clamp(MIN_DURATION_MIN, MAX_DURATION_MIN)
+    });
     let duration = value.and_then(crate::agent::json_number).unwrap_or(0.0);
     if duration == 0.0 || duration.is_nan() {
-        json!(DEFAULT_DURATION_MIN)
+        // The default is a request like any other where the cap is shorter than
+        // it. Handing back a length this server cannot record, for a caller who
+        // named no length at all, is the same lost stretch of interview.
+        json!(DEFAULT_DURATION_MIN.min(ceiling))
     } else {
         // Fractional minutes stay fractional: the metadata is echoed back to
         // the frontend, which renders whatever the lobby asked for.
-        number_json(duration.clamp(MIN_DURATION_MIN.into(), MAX_DURATION_MIN.into()))
+        number_json(duration.clamp(MIN_DURATION_MIN.into(), ceiling.into()))
     }
 }
 
@@ -295,6 +312,7 @@ pub(crate) async fn token_handler(
             api_key: &provider.api_key,
             api_secret: &provider.api_secret,
             server_url: &provider.url,
+            recording_max_min: state.config.recording.as_ref().map(|it| it.max_minutes),
         },
         body.as_ref(),
         &room_name,

--- a/src/web/token.rs
+++ b/src/web/token.rs
@@ -185,16 +185,26 @@ pub(crate) fn generated_candidate_identity() -> String {
 
 pub(crate) const CANDIDATE_SUFFIX_LEN: usize = 6;
 
-pub(crate) fn token_duration_min(value: Option<&Value>, recording_max_min: Option<u32>) -> Value {
-    // The ceiling a recorded interview gets is its own recording's, because the
-    // sweeper reaps the recording on that bound and not on this one. Clamped
-    // into the range rather than taken as given: a cap above `MAX_DURATION_MIN`
-    // does not buy a longer interview than the endpoint has ever offered, and
-    // one below `MIN_DURATION_MIN` would cross the floor, which is a panic in
-    // `f64::clamp` rather than a short interview.
-    let ceiling = recording_max_min.map_or(MAX_DURATION_MIN, |cap| {
+/// The longest interview this deployment will start, which is its recording's
+/// bound wherever it records: the sweeper reaps a recording that outlives
+/// `max_minutes`, so a longer interview loses the stretch past it.
+///
+/// One function because two callers need the same answer and must not drift.
+/// `/api/token` enforces it, and `/api/session` hands it to the lobby so the
+/// browser stops offering what this server would silently shorten.
+///
+/// Clamped into the range rather than taken as given: a cap above
+/// `MAX_DURATION_MIN` does not buy a longer interview than the endpoint has
+/// ever offered, and one below `MIN_DURATION_MIN` would cross the floor, which
+/// is a panic in `f64::clamp` rather than a short interview.
+pub(crate) fn duration_ceiling(recording_max_min: Option<u32>) -> u32 {
+    recording_max_min.map_or(MAX_DURATION_MIN, |cap| {
         cap.clamp(MIN_DURATION_MIN, MAX_DURATION_MIN)
-    });
+    })
+}
+
+pub(crate) fn token_duration_min(value: Option<&Value>, recording_max_min: Option<u32>) -> Value {
+    let ceiling = duration_ceiling(recording_max_min);
     let duration = value.and_then(crate::agent::json_number).unwrap_or(0.0);
     if duration == 0.0 || duration.is_nan() {
         // The default is a request like any other where the cap is shorter than

--- a/tests/browser/lobby.test.js
+++ b/tests/browser/lobby.test.js
@@ -130,6 +130,10 @@ const snapshot = (page) =>
       card: one(".problem-card.selected")?.dataset.problem ?? null,
       pressed: one('.problem-card[aria-pressed="true"]')?.dataset.problem ?? null,
       duration: one(".duration-button.selected")?.dataset.duration ?? null,
+      durationsOff: [...document.querySelectorAll(".duration-button")]
+        .filter((button) => button.disabled)
+        .map((button) => button.dataset.duration),
+      durationNote: one("#duration-note").hidden ? "" : one("#duration-note").textContent,
       levels: [...document.querySelectorAll('[name="difficulty"]:checked')].map((i) => i.value),
       visibleCards: [...document.querySelectorAll(".problem-card")].filter((c) => !c.hidden).length,
       startDisabled: one("#start").disabled,
@@ -789,4 +793,52 @@ lobbyTest("a start already on its way out is not undone by a later choice", asyn
     "start shipped something other than the problem that was on screen when it was pressed",
   );
   release();
+});
+
+lobbyTest("a length this deployment cannot record is disabled, and says why", async (page) => {
+  // The cap the server reports, which is `DEFAULT_RECORDING_MAX_MINUTES` on a
+  // default deployment. Sixty is the length the row offers past it, and
+  // `stale_after` reaps that recording ten minutes before the interview ends.
+  session = { signedIn: true, user: { login: "candidate" }, maxDurationMin: 45 };
+
+  const state = await lobby(page);
+
+  assert.deepEqual(state.durationsOff, ["60"], "a length past the recording cap was still on offer");
+  assert.match(state.durationNote, /at most 45 minutes/, "the disabled button gave no reason");
+  assert.equal(state.duration, "45", "the cap moved a length that was already under it");
+});
+
+lobbyTest("the recording cap outranks the length the markup preselected", async (page) => {
+  // Nothing else here overrules a length that is already set. This does,
+  // because it is not a second opinion about what suits the candidate: it is
+  // what this server is able to record.
+  session = { signedIn: true, user: { login: "candidate" }, maxDurationMin: 30 };
+
+  const state = await lobby(page);
+
+  assert.equal(state.duration, "30", "the lobby kept a length longer than the recording");
+  assert.deepEqual(state.durationsOff, ["45", "60"]);
+});
+
+lobbyTest("a server that can record every length on offer disables nothing", async (page) => {
+  session = { signedIn: true, user: { login: "candidate" }, maxDurationMin: 90 };
+
+  const state = await lobby(page);
+
+  assert.deepEqual(state.durationsOff, []);
+  assert.equal(state.durationNote, "", "a lobby with nothing capped explained a cap anyway");
+  assert.equal(state.duration, markupDuration());
+});
+
+lobbyTest("a cap under every length on offer leaves the row alone", async (page) => {
+  // A deployment that records less than the shortest interview it offers is
+  // misconfigured, and `recording_config` refuses that pairing at startup. If
+  // one reaches the browser anyway, a row with every button dead is a lobby
+  // nobody can start; the server's own floor decides instead.
+  session = { signedIn: true, user: { login: "candidate" }, maxDurationMin: 15 };
+
+  const state = await lobby(page);
+
+  assert.deepEqual(state.durationsOff, []);
+  assert.equal(state.durationNote, "");
 });

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -132,6 +132,7 @@ fn token_response_matches_frontend_contract() {
             api_key: "devkey",
             api_secret: "devsecret",
             server_url: "wss://example.livekit.cloud",
+            recording_max_min: None,
         },
         br#"{"problemId":"merge-intervals","durationMin":120}"#,
         "interview-fixed",
@@ -159,6 +160,7 @@ fn token_response_mints_the_candidate_identity() {
             api_key: "devkey",
             api_secret: "devsecret",
             server_url: "wss://example.livekit.cloud",
+            recording_max_min: None,
         },
         br#"{"candidateIdentity":"candidate-a1b2c3"}"#,
         "interview-fixed",
@@ -182,6 +184,7 @@ fn token_response_ignores_a_supplied_candidate_identity() {
             api_key: "devkey",
             api_secret: "devsecret",
             server_url: "wss://example.livekit.cloud",
+            recording_max_min: None,
         },
         br#"{"candidateIdentity":"candidate-a1b2c3"}"#,
         "interview-fixed",
@@ -211,6 +214,7 @@ fn token_duration_matches_current_frontend_clamp() {
                 api_key: "devkey",
                 api_secret: "devsecret",
                 server_url: "wss://example.livekit.cloud",
+                recording_max_min: None,
             },
             &body,
             "interview-fixed",
@@ -234,6 +238,7 @@ fn token_duration_preserves_fractional_frontend_metadata() {
             api_key: "devkey",
             api_secret: "devsecret",
             server_url: "wss://example.livekit.cloud",
+            recording_max_min: None,
         },
         br#"{"durationMin":42.8}"#,
         "interview-fixed",
@@ -246,6 +251,95 @@ fn token_duration_preserves_fractional_frontend_metadata() {
     assert_eq!(
         serde_json::from_str::<Value>(claims["metadata"].as_str().unwrap()).unwrap()["durationMin"],
         json!(42.8)
+    );
+}
+
+#[test]
+fn token_duration_stops_at_the_recording_cap() {
+    for (recording_max_min, requested, expected) in [
+        // The lobby offers sixty. A deployment recording at the default cap
+        // has `stale_after` reap the recording at fifty, so the last ten
+        // minutes are interview no artifact survives to cover.
+        (Some(45), json!(60), json!(45)),
+        // Under the cap is nobody's problem and stays untouched.
+        (Some(45), json!(30), json!(30)),
+        // A cap above the range the endpoint offers does not widen it.
+        (Some(120), json!(100), json!(90)),
+        // Nothing to outlive when this server does not record.
+        (None, json!(60), json!(60)),
+    ] {
+        let body = serde_json::to_vec(&json!({"durationMin": requested})).unwrap();
+        let response = token_response(
+            &TokenConfig {
+                api_key: "devkey",
+                api_secret: "devsecret",
+                server_url: "wss://example.livekit.cloud",
+                recording_max_min,
+            },
+            &body,
+            "interview-fixed",
+            "candidate-fixed",
+            2000,
+        )
+        .unwrap();
+        let claims = claims(&response.token);
+
+        assert_eq!(
+            serde_json::from_str::<Value>(claims["metadata"].as_str().unwrap()).unwrap()["durationMin"],
+            expected,
+            "asked for {requested} under a cap of {recording_max_min:?}"
+        );
+    }
+}
+
+#[test]
+fn token_duration_default_stops_at_the_recording_cap() {
+    // A caller who names no length gets the default, and the default is a
+    // length like any other. Handing back forty-five to a deployment that can
+    // only record thirty loses the same stretch, for the want of a request.
+    let response = token_response(
+        &TokenConfig {
+            api_key: "devkey",
+            api_secret: "devsecret",
+            server_url: "wss://example.livekit.cloud",
+            recording_max_min: Some(30),
+        },
+        b"{}",
+        "interview-fixed",
+        "candidate-fixed",
+        2000,
+    )
+    .unwrap();
+    let claims = claims(&response.token);
+
+    assert_eq!(
+        serde_json::from_str::<Value>(claims["metadata"].as_str().unwrap()).unwrap()["durationMin"],
+        30
+    );
+}
+
+#[test]
+fn token_duration_survives_a_recording_cap_under_the_floor() {
+    // `f64::clamp` panics when its bounds cross, so a cap below the shortest
+    // interview on offer has to land on the floor rather than in the handler.
+    let response = token_response(
+        &TokenConfig {
+            api_key: "devkey",
+            api_secret: "devsecret",
+            server_url: "wss://example.livekit.cloud",
+            recording_max_min: Some(1),
+        },
+        br#"{"durationMin":45}"#,
+        "interview-fixed",
+        "candidate-fixed",
+        2000,
+    )
+    .unwrap();
+    let claims = claims(&response.token);
+
+    assert_eq!(
+        serde_json::from_str::<Value>(claims["metadata"].as_str().unwrap()).unwrap()["durationMin"],
+        10
     );
 }
 

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -2359,7 +2359,7 @@ async fn account_routes_record_interviewee_github_login() {
 
     assert_eq!(
         session.json::<Value>().await.unwrap(),
-        json!({"signedIn": false, "loginRequired": true})
+        json!({"signedIn": false, "loginRequired": true, "maxDurationMin": MAX_DURATION_MIN})
     );
 
     let signed_in = client
@@ -2474,7 +2474,7 @@ async fn an_unmigratable_account_database_refuses_rather_than_disabling_login() 
         .unwrap();
     assert_eq!(
         session,
-        json!({"signedIn": false, "loginRequired": true}),
+        json!({"signedIn": false, "loginRequired": true, "maxDurationMin": MAX_DURATION_MIN}),
         "a database this binary cannot migrate still requires a login"
     );
 
@@ -2514,7 +2514,7 @@ async fn an_unopenable_account_database_refuses_rather_than_disabling_login() {
         .unwrap();
     assert_eq!(
         session,
-        json!({"signedIn": false, "loginRequired": true}),
+        json!({"signedIn": false, "loginRequired": true, "maxDurationMin": MAX_DURATION_MIN}),
         "a broken database still requires a login; it cannot serve one"
     );
 
@@ -3009,7 +3009,7 @@ async fn account_reports_are_scoped_to_the_signed_in_user() {
         .unwrap();
     assert_eq!(
         signed_out,
-        json!({"signedIn": false, "loginRequired": true}),
+        json!({"signedIn": false, "loginRequired": true, "maxDurationMin": MAX_DURATION_MIN}),
         "accounts exist here, so the browser has to know to demand a sign-in"
     );
 
@@ -3990,6 +3990,44 @@ async fn start_interview(client: &reqwest::Client, base: &str, cookie: &str) -> 
 }
 
 /// A recording block for tests that only care that recording is on.
+/// The lobby offers lengths this deployment may not be able to record, and only
+/// the server knows the cap. Without it in the payload the browser goes on
+/// offering sixty minutes and `/api/token` shortens the interview after the
+/// candidate has already asked for it, which is the substitution #16 is about.
+#[tokio::test]
+async fn the_session_reports_how_long_a_recorded_interview_may_run() {
+    let mut config = web_config();
+    config.recording = Some(recording_config());
+    let (base, server) = spawn_web_server(config).await;
+
+    let session = reqwest::get(format!("{base}/api/session"))
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap();
+
+    assert_eq!(session["maxDurationMin"], recording_config().max_minutes);
+    server.abort();
+}
+
+/// The same endpoint on a server that records nothing, so the cap is the range
+/// the endpoint has always offered rather than a number the lobby invents.
+#[tokio::test]
+async fn a_server_that_does_not_record_caps_nothing_beyond_the_range() {
+    let (base, server) = spawn_web_server(web_config()).await;
+
+    let session = reqwest::get(format!("{base}/api/session"))
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap();
+
+    assert_eq!(session["maxDurationMin"], MAX_DURATION_MIN);
+    server.abort();
+}
+
 fn recording_config() -> codetrial::config::RecordingConfig {
     codetrial::config::RecordingConfig {
         livekit: None,

--- a/web/app.js
+++ b/web/app.js
@@ -8,6 +8,17 @@ let manualProblem = false;
 let manualDuration = false;
 let manualDifficulty = false;
 let historyReady = false;
+/// The longest interview this deployment can record, which only the server
+/// knows. `Infinity` until `/api/session` answers: the duration row is live
+/// before that lands, and `/api/token` clamps anything that gets out in the
+/// meantime, so the gap costs a shortened interview rather than a lost
+/// recording.
+///
+/// Declared with the other module state rather than beside the functions that
+/// read it. The setup below calls `setDuration` while a `let` further down the
+/// file is still in its temporal dead zone, and reading one there throws
+/// before the lobby has rendered anything at all.
+let durationCeiling = Infinity;
 
 // The roll a recommendation is drawn with. It changes when the candidate asks
 // for something different and at no other time, so recommending twice for one
@@ -23,6 +34,7 @@ const nodes = {
   logout: document.querySelector("#logout"),
   history: document.querySelector("#history"),
   recommendation: document.querySelector("#recommendation"),
+  durationNote: document.querySelector("#duration-note"),
 };
 
 // Every card carries the pressed state from the start, not only the one that
@@ -77,7 +89,8 @@ for (const input of levels) {
   });
 }
 
-for (const button of document.querySelectorAll("[data-duration]")) {
+const durations = [...document.querySelectorAll("[data-duration]")];
+for (const button of durations) {
   button.addEventListener("click", () => setDuration(Number(button.dataset.duration), true));
 }
 
@@ -197,6 +210,7 @@ function settle() {
 async function loadAccount() {
   try {
     const session = await fetchJson("/api/session");
+    applyDurationCeiling(session.maxDurationMin);
     if (session.signedIn) {
       nodes.accountStatus.textContent = `Signed in as ${session.user.login}`;
       nodes.githubLogin.hidden = true;
@@ -376,11 +390,51 @@ function suggestedDuration(difficulties) {
 /// they have, nothing suggests over it again. The latch never releases: someone
 /// who asks for sixty minutes keeps it even if their history later moves them
 /// down to Easy.
+///
+/// The ceiling is applied here rather than at each caller, so a length can no
+/// more get past it by being suggested than by being clicked.
 function setDuration(minutes, chosen = false) {
   if (manualDuration && !chosen) return;
   manualDuration ||= chosen;
-  duration = minutes;
-  select("[data-duration]", document.querySelector(`[data-duration="${minutes}"]`));
+  duration = underCeiling(minutes);
+  select("[data-duration]", document.querySelector(`[data-duration="${duration}"]`));
+}
+
+/// Snapped to a length the row actually offers, not to the cap itself: a cap
+/// of forty would otherwise leave `duration` at forty with no button to show
+/// for it, and the candidate reading a row where nothing is selected.
+function underCeiling(minutes) {
+  if (minutes <= durationCeiling) return minutes;
+  const offered = durations
+    .map((button) => Number(button.dataset.duration))
+    .filter((value) => value <= durationCeiling);
+  return offered.length ? Math.max(...offered) : minutes;
+}
+
+/// What the server said it can record, turned into a row that says so. The
+/// button is disabled rather than removed: a length that quietly stops being
+/// on offer is the same silence as one that quietly gets shortened, and this
+/// one has a reason worth reading.
+function applyDurationCeiling(minutes) {
+  if (!Number.isFinite(minutes)) return;
+  durationCeiling = minutes;
+  const over = durations.filter((button) => Number(button.dataset.duration) > minutes);
+  // A cap under every length on offer is a misconfigured deployment, not a
+  // lobby with nothing to press. Leave the row alone and let the server's own
+  // floor decide, rather than handing back a page that cannot start anything.
+  const capped = over.length < durations.length ? over : [];
+  for (const button of durations) button.disabled = capped.includes(button);
+  nodes.durationNote.textContent = capped.length
+    ? `Interviews here are recorded for at most ${minutes} minutes, so longer ones are not offered.`
+    : "";
+  nodes.durationNote.hidden = !capped.length;
+  // The cap outranks a length the candidate chose out loud, which nothing else
+  // here does: it is not a second opinion about what suits them, it is what
+  // this server can record.
+  if (duration > durationCeiling) {
+    duration = underCeiling(duration);
+    select("[data-duration]", document.querySelector(`[data-duration="${duration}"]`));
+  }
 }
 
 function title(card) {

--- a/web/index.html
+++ b/web/index.html
@@ -651,6 +651,11 @@
         <button class="duration-button" type="button" data-duration="60">60 min</button>
       </section>
 
+      <!-- Written by app.js from the cap `/api/session` reports, so a length
+           this deployment cannot record is disabled with the reason beside it
+           rather than silently shortened after the candidate presses start. -->
+      <p id="duration-note" class="duration-note" aria-live="polite" hidden></p>
+
       <section class="start-row">
         <!-- Enabled by app.js once a problem is chosen, so the button cannot
              start an interview on a problem the page has not picked yet. -->

--- a/web/styles.css
+++ b/web/styles.css
@@ -160,6 +160,14 @@ p {
   cursor: pointer;
 }
 
+/* `--sub` for the same reason the fieldset legend uses it: this explains a
+   control rather than decorating it, and `--muted` measures under the 4.5 that
+   normal text needs. */
+.duration-note {
+  margin-top: 0.5rem;
+  color: var(--sub);
+}
+
 .recommendation {
   color: var(--ink);
   font-weight: 700;


### PR DESCRIPTION
The lobby offers sixty minutes and the recording of that interview is reaped at fifty. Reported in #16.

`token_duration_min` clamped the requested length to `MIN_DURATION_MIN..MAX_DURATION_MIN` and never consulted the recording cap, which is a separate deployment-wide number. `stale_after` in recording/sweeper.rs bounds a running recording at `max_minutes * 60 + 300`, fifty minutes on the default forty-five, so the last ten minutes of a sixty-minute interview are recorded by nothing and the artifact is failed as `LostWebhook`. The config check that looks like it covers this compares `max_minutes` against `CODETRIAL_DURATION_MIN`, the configured default, not against the length the caller actually asked for.

**Enforcing it.** The ceiling now comes from the recording cap wherever this server records and from the range alone where it does not. The cap is clamped into the range before use: one above it does not widen what the endpoint has ever offered, and one below the floor would cross the bounds of `f64::clamp`, which panics rather than shortening the interview. The default branch is capped too, because a caller who names no length is asking for forty-five and forty-five is the same lost stretch on a server that can only record thirty. `/api/token` is the one site worth clamping at: the metadata the agent reads is minted into the LiveKit token here, so a hand-crafted request is covered along with the lobby.

**Saying so.** Enforcing alone shortens the interview after the candidate has already asked for sixty, which is the substitution `setDuration` refuses everywhere else. `duration_ceiling` is now one function with two callers: `/api/token` enforces it and `/api/session` reports it, so the endpoint that answers and the endpoint that enforces cannot disagree about what this server can record. The row disables what it cannot record rather than hiding it, with the reason beside it — a length that quietly stops being on offer is the same silence as one that quietly gets shortened. The ceiling applies inside `setDuration`, so a length can no more get past it by being suggested than by being clicked, and it snaps to a length the row actually offers rather than to the cap itself: a cap of forty would otherwise leave `duration` at forty with no button to show for it. It is the only thing here that overrules a length the candidate chose out loud, because it is not a second opinion about what suits them. A cap under every length on offer leaves the row alone: `recording_config` refuses that pairing at startup, and a row with every button dead is a lobby nobody can start.

Tests: three in tests/web.rs for the token clamp (the cap biting, the cap idle, a cap above the range and no cap at all; the default branch under a shorter cap; a cap below the floor landing on the floor rather than in the handler), two for the session payload with and without recording, and four in tests/browser/lobby.test.js for the row.

One note on the second commit, since it is the kind of thing worth pointing at rather than burying. `durationCeiling` first went in beside the functions that read it, near the bottom of app.js. The setup at the bottom of that file calls `setDuration` while a `let` further down is still in its temporal dead zone, so reading it threw during module init and the lobby rendered nothing at all — every test in lobby.test.js timed out waiting for a recommendation that could not arrive. `node --check` passes on it and the Rust suite is blind to it; only running the page catches it. It is declared with the other module state now, with a comment saying why it cannot move back.