### PR TITLE
Stop offering C for class-style problems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "rtrb"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
+checksum = "fae8ee26b0371a29a77d2b2d6b3ae13aa81def6f9bf1b1b92a32d279a5e709b7"
 
 [[package]]
 name = "rusqlite"

--- a/scripts/gen-wire-fixtures.mjs
+++ b/scripts/gen-wire-fixtures.mjs
@@ -21,18 +21,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const FIXTURES = join(ROOT, "tests", "fixtures");
 
 const lib = await import(join(ROOT, "web", "lib.js"));
-
-// Read the offered languages out of the producer instead of restating them.
-// The point of these fixtures is to catch the two sides disagreeing, and a
-// hardcoded list here would be a third place to disagree with. A language the
-// tabs offer but src/agent.rs does not recognize reaches no prompt and changes
-// no state, so the candidate's click is silently ignored.
-function offeredLanguages() {
-  const source = readFileSync(join(ROOT, "web", "interview.js"), "utf8");
-  const match = source.match(/^const languages = \[(.*?)\];$/m);
-  if (!match) throw new Error("could not find the language list in web/interview.js");
-  return match[1].split(",").map((part) => part.trim().replace(/^"|"$/g, ""));
-}
+const { ALL_LANGUAGES } = await import(join(ROOT, "web", "compiler-explorer.js"));
 
 const CODE = "def two_sum(nums, target):\n    return []\n";
 const EDITED = "def two_sum(nums, target):\n    seen = {}\n    return []\n";
@@ -218,7 +207,11 @@ async function integrityChain() {
   return events;
 }
 
-const languages = offeredLanguages();
+// Imported rather than restated: a hardcoded list here would be a third place
+// to disagree with. The constant, not `languagesFor`, because which tabs a
+// given judge offers is a UX choice and this is the whole set src/agent.rs has
+// to recognize.
+const languages = ALL_LANGUAGES;
 const files = {
   "code-update.json": { topic: lib.topics.code, cases: codeUpdateCases(languages) },
   "control.json": { topic: lib.topics.control, cases: controlCases() },

--- a/tests/browser/account.test.js
+++ b/tests/browser/account.test.js
@@ -40,14 +40,19 @@ test("interview history routes through the shared persistence helper", () => {
 test("a completed test run keeps pause and round locks", () => {
   const interview = read("interview.js");
 
-  // Both places that hand the runner back have to ask the same question. A
-  // finished test run was the one that got it right; resuming from a pause was
-  // the one that did not, and gave the editor and the runner back during the
-  // behavioral round that had just retired them.
-  assert.match(functionBody(interview, "runTests"), /nodes\.run\.disabled = state\.paused \|\| codingClosed\(\)/);
+  // Both places that hand the runner back use the same guard. A finished test
+  // run was the one that got it right; resuming from a pause was the one that
+  // did not, and gave the editor and the runner back during the behavioral
+  // round that had just retired them.
+  assert.match(functionBody(interview, "runTests"), /updateRunAvailability\(\)/);
   const applyPause = functionBody(interview, "applyPause");
   assert.match(applyPause, /nodes\.editor\.disabled = paused \|\| codingClosed\(\)/);
-  assert.match(applyPause, /nodes\.run\.disabled = paused \|\| codingClosed\(\)/);
+  assert.match(applyPause, /updateRunAvailability\(\)/);
+  // Asserted as two facts rather than one spelling: the guard is `codingClosed`
+  // itself now, not a DOM attribute that happens to track it.
+  const updateRunAvailability = functionBody(interview, "updateRunAvailability");
+  assert.match(updateRunAvailability, /codingClosed\(\)/);
+  assert.match(updateRunAvailability, /!languages\.includes\(state\.language\)/);
   assert.match(
     functionBody(interview, "codingClosed"),
     /frameworkRound === "behavioral" \|\| state\.phase !== "live"/,

--- a/tests/browser/compiler-explorer.test.js
+++ b/tests/browser/compiler-explorer.test.js
@@ -6,8 +6,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  ALL_LANGUAGES,
   compilerType,
   generateHarness,
+  harnessGap,
+  languagesFor,
   mapCompilerResponse,
   nativeLiteral,
   parseCompilerResults,
@@ -515,3 +518,19 @@ function bankFunctionTypes() {
   }
   return [...types].sort();
 }
+
+test("a class-style judge withholds C, and says why", () => {
+  assert.equal(judges["lru-cache"].kind, "class");
+  assert.deepEqual(languagesFor(judges["lru-cache"]), ALL_LANGUAGES.filter((one) => one !== "c"));
+  assert.match(harnessGap("c", judges["lru-cache"]), /only builds function judges/);
+  assert.equal(harnessGap("cpp", judges["lru-cache"]), null);
+});
+
+test("a function-style judge offers every language, and so does an unreadable one", () => {
+  assert.equal(judges["two-sum"].kind, "function");
+  assert.deepEqual(languagesFor(judges["two-sum"]), ALL_LANGUAGES);
+  // A judge that could not be fetched must not cost a candidate a language:
+  // the run path reports the failure itself.
+  assert.deepEqual(languagesFor(null), ALL_LANGUAGES);
+  assert.equal(harnessGap("c", null), null);
+});

--- a/tests/browser/dom-contract.test.js
+++ b/tests/browser/dom-contract.test.js
@@ -251,6 +251,17 @@ test("the interview page keeps the structure the script drives", () => {
   );
 });
 
+test("a late judge response does not replace the active editor buffer", () => {
+  const script = read("interview.js");
+  const applyLanguages = functionBody(script, "applyLanguages");
+  const setLanguage = functionBody(script, "setLanguage");
+  const updateRunAvailability = functionBody(script, "updateRunAvailability");
+  assert.doesNotMatch(applyLanguages, /setLanguage\(/);
+  assert.match(applyLanguages, /updateRunAvailability\(\)/, "the unsupported active tab cannot run");
+  assert.match(setLanguage, /updateRunAvailability\(\)/, "a supported tab restores the runner");
+  assert.match(updateRunAvailability, /!languages\.includes\(state\.language\)/);
+});
+
 test("output confirmation is required but not blocked by tone timing", () => {
   const script = interviewSource();
   const heardHandler = script.slice(

--- a/tests/browser/lib.test.js
+++ b/tests/browser/lib.test.js
@@ -607,6 +607,14 @@ test("framework evidence preserves valid kinds and drops hostile or contradictor
   assert.deepEqual(report.frameworkEvidence.map((item) => item.kind), ["inferred", "observed", "skipped"]);
   assert.equal(report.frameworkEvidence[1].future, "ignored", "unknown fields round-trip but are never rendered");
 
+  const protoField = sanitizeReport(JSON.parse(`{"frameworkEvidence":[{
+    "atMs":1000,"phase":"algorithm","source":"candidate_speech","kind":"observed",
+    "confidence":90,"summary":"Explained invariant","frameworkVersion":1,
+    "__proto__":"newer report field"
+  }]}`)).frameworkEvidence[0];
+  assert.equal(Object.hasOwn(protoField, "__proto__"), true);
+  assert.equal(protoField.__proto__, "newer report field");
+
   // Round-tripping them is for a newer client's fields, not for a payload.
   // The account sync refuses an oversized report outright rather than
   // trimming it, so one unbounded field here costs the whole account copy.

--- a/web/compiler-explorer.js
+++ b/web/compiler-explorer.js
@@ -72,6 +72,35 @@ export function nativeLiteral(value, type, language) {
   throw new Error(`Unsupported literal type: ${type}`);
 }
 
+/// Every language the editor offers, in tab order. The list lives here because
+/// the only thing that ever removes one from it is what the harness below can
+/// generate. Frozen because it is exported: a caller that filtered it in place
+/// would change what every later caller is offered.
+export const ALL_LANGUAGES = Object.freeze(["python", "javascript", "c", "cpp", "java"]);
+
+/// Why this judge cannot be run in this language, in a sentence a candidate can
+/// read, or null when it can. The tab row disables from it and shows it as the
+/// tooltip, so the reason a tab is dead cannot drift from the rule that killed
+/// it; a second withheld pair is a second case here rather than a second place
+/// to remember.
+///
+/// C has no classes, so `generateHarness` refuses a class judge for it and a
+/// candidate would otherwise find that out by writing a whole solution and
+/// pressing run.
+export function harnessGap(language, spec) {
+  if (language === "c" && spec?.kind === "class") {
+    return "This problem asks for a class, and the C harness only builds function judges.";
+  }
+  return null;
+}
+
+/// A missing or unreadable judge offers everything: the run path says why it
+/// failed on its own, and dropping a tab over a dropped request is the worse
+/// guess.
+export function languagesFor(spec) {
+  return ALL_LANGUAGES.filter((language) => !harnessGap(language, spec));
+}
+
 export function generateHarness(language, spec, candidateCode) {
   if (!["c", "cpp", "java"].includes(language)) throw new Error(`Unsupported harness language: ${language}`);
   if (spec.kind === "class" && language === "c") throw new Error("Only function judges are supported for C");

--- a/web/interview.js
+++ b/web/interview.js
@@ -1,4 +1,4 @@
-import { loadProblem } from "./problem-data.js";
+import { loadJudge, loadProblem } from "./problem-data.js";
 import {
   MIC_CONFIRM_FRAMES,
   mediaReadiness,
@@ -85,11 +85,17 @@ import {
 } from "./recording-state.js";
 import { saveReportHistory } from "./history.js";
 import { createFacePresenceDetector, facePresenceVerdict } from "./face-presence.js";
+import { harnessGap, languagesFor } from "./compiler-explorer.js";
 import { runBrowserTests } from "./runners.js";
 import { mountBehavioralReview } from "./behavioral-review.js";
 import { consumeGroundingPacket } from "./document-grounding.js";
 
-const languages = ["python", "javascript", "c", "cpp", "java"];
+/// Which framework the candidate is being read against right now. The rounds
+/// never overlap, so this is a single value rather than a pair. Declared up
+/// here because `codingClosed` reads it and `init` runs before the rest of the
+/// module body does, so a declaration beside its other readers would be in the
+/// temporal dead zone for the first paint.
+let frameworkRound = "coding";
 let editorInitialized = false;
 let codePublishTimer = null;
 // The agent reads the editor once per 2s watch tick, so publishing every
@@ -131,6 +137,13 @@ const problem = await loadProblem(params.get("problem")).catch((error) => {
   if (title) title.textContent = "This interview could not load its problem. Reload the page.";
   throw error;
 });
+// Started here and awaited nowhere: which tabs are real is a property of the
+// judge, but it is not worth holding a page the candidate can already work in.
+// Every tab is offered until the answer arrives, which is what the row did
+// before this and what it keeps doing if the judge never loads; the run path
+// reports that failure itself.
+const judgePromise = loadJudge(problem.id).catch(() => null);
+let languages = languagesFor(null);
 const durationMin = clamp(Number.parseInt(params.get("duration") || "45", 10) || 45, 10, 90);
 const interviewLoop = codingLoop(params.get("loop"));
 const behavioralMinutes = interviewLoop === "coding_behavioral" ? Math.min(8, durationMin) : 0;
@@ -155,6 +168,7 @@ const state = {
   transcript: null, // createTranscriptView, built in init once nodes exist
   latestSummary: null,
   testStatus: "done",
+  runningTests: false,
   report: null,
   room: null,
   connected: false,
@@ -271,6 +285,10 @@ async function init() {
   renderProblem();
   setLanguage("python");
   bindEvents();
+  // After bindEvents, so the callback cannot beat the row it edits: everything
+  // above here is synchronous, and a `then` runs no earlier than the next
+  // microtask.
+  void judgePromise.then(applyLanguages);
   // No enumeration here. Before the preflight grant the browser reports only a
   // blank placeholder, so the list is discarded and repainted a few lines down;
   // the `toggle` handler covers a panel opened while the preflight is still up.
@@ -1109,6 +1127,20 @@ function selectTab(tab) {
   nodes.transcriptTab.classList.toggle("selected", transcript);
 }
 
+/// Both the row and its tooltips come from `harnessGap`, so a tab is never
+/// dead for a reason it does not state. An already-active buffer stays
+/// visible: hiding it would replace the candidate's final submission with a
+/// starter buffer when the judge response arrives late.
+function applyLanguages(spec) {
+  languages = languagesFor(spec);
+  for (const button of document.querySelectorAll("[data-language]")) {
+    const gap = harnessGap(button.dataset.language, spec);
+    button.disabled = gap !== null;
+    button.title = gap ?? "";
+  }
+  updateRunAvailability();
+}
+
 function setLanguage(language) {
   if (!languages.includes(language)) return;
   if (editorInitialized) {
@@ -1121,6 +1153,7 @@ function setLanguage(language) {
   for (const button of document.querySelectorAll("[data-language]")) {
     button.classList.toggle("selected", button.dataset.language === language);
   }
+  updateRunAvailability();
   // Debounced like a keystroke, and for the same reason. Publishing on every
   // click meant a candidate trying three tabs in a row produced three language
   // changes, and the agent speaks a confirmation for each, so Jim talked over
@@ -1201,9 +1234,6 @@ function togglePause() {
   if (!state.room) applyPause(!state.paused);
 }
 
-/// Which framework the candidate is being read against right now. The rounds
-/// never overlap, so this is a single value rather than a pair.
-let frameworkRound = "coding";
 let frameworkPhases = [];
 let frameworkHintTimer = null;
 
@@ -1289,7 +1319,7 @@ function applyPause(paused) {
   // behavioral round disables the editor and the runner on purpose, and a
   // pause taken during it used to give both back on the way out.
   nodes.editor.disabled = paused || codingClosed();
-  nodes.run.disabled = paused || codingClosed();
+  updateRunAvailability();
   recordReplay("lifecycle", { state: paused ? "paused" : "resumed" });
   recordStage();
   tickTimer();
@@ -1298,6 +1328,7 @@ function applyPause(paused) {
 
 async function runTests() {
   flushPendingCodePublish();
+  state.runningTests = true;
   nodes.run.disabled = true;
   nodes.run.textContent = "Running...";
   nodes.resultsBody.hidden = false;
@@ -1316,8 +1347,14 @@ async function runTests() {
     addTranscript("you", "I ran the tests.", true);
     addTranscript("interviewer", summary.setupError ? "I could not run that yet. Check the setup error and keep going." : `${summary.passed}/${summary.total} tests passed. Explain what changed.`, true);
   }
-  nodes.run.disabled = state.paused || codingClosed();
+  state.runningTests = false;
+  updateRunAvailability();
   nodes.run.textContent = "Run tests";
+}
+
+function updateRunAvailability() {
+  nodes.run.disabled = state.runningTests || state.paused || codingClosed()
+    || !languages.includes(state.language);
 }
 
 function firstRunnerStatus(language) {

--- a/web/lib.js
+++ b/web/lib.js
@@ -576,16 +576,20 @@ export function sanitizeReport(raw) {
       // refuses the request rather than trimming it: over that, the candidate
       // keeps the local copy and the account copy simply never arrives. So
       // they are carried while they are a field rather than a payload.
-      // The common row has nothing unknown on it, and this runs over whatever
-      // length arrived from storage or the wire, before the cap below trims
-      // it. Counting the keys is one comparison; building and serializing an
-      // empty object to learn the same thing is five allocations a row.
-      const extras = Object.keys(item).length === knownEvidenceFields.size
-        ? {}
-        : Object.fromEntries(
-          Object.entries(item).filter(([key]) => !knownEvidenceFields.has(key)),
-        );
-      const carried = textEncoder.encode(JSON.stringify(extras)).length <= 512 ? extras : {};
+      // The common row has nothing unknown on it and this runs over whatever
+      // length arrived from storage or the wire, before the cap below trims it,
+      // so that row allocates nothing and is never serialized to be measured.
+      // Null prototype, not `{}`: assigning a key named `__proto__` to a plain
+      // object runs the inherited setter, which ignores a string and drops the
+      // field. A newer client's field is not ours to name, so it cannot be ours
+      // to lose either.
+      let extras = null;
+      for (const key of Object.keys(item)) {
+        if (!knownEvidenceFields.has(key)) (extras ??= Object.create(null))[key] = item[key];
+      }
+      // Spreading null spreads nothing, which is what both the common row and
+      // an over-budget one want.
+      const carried = extras && textEncoder.encode(JSON.stringify(extras)).length <= 512 ? extras : null;
       return {
         ...carried,
         // A year, which no interview approaches: this is a sanity bound on a

--- a/web/styles.css
+++ b/web/styles.css
@@ -302,6 +302,13 @@ p {
   opacity: 0.6;
 }
 
+/* A tab the judge cannot run, dimmed rather than removed: the row stays the
+   same five tabs everywhere, and the title says which one is out and why. */
+.language-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .history {
   margin-top: 1rem;
   padding: 1rem;


### PR DESCRIPTION
Seven of the 150 problems in the bank carry a class-style judge, and
`generateHarness` refuses a class judge in C. Nothing said so: C was one of
five tabs on every problem, fully stocked with C starter code, and the way a
candidate found out was by writing a solution and pressing run.

## What changed

`harnessGap(language, spec)` in `web/compiler-explorer.js` answers why a judge
cannot be run in a language, as a sentence a candidate can read, or null when
it can. `languagesFor` filters the tab list through it, and the interview page
disables from it and shows it as the tooltip, so a dead tab always states its
own reason and a second withheld pair is a second case in one function rather
than a second place to remember.

The judge is fetched without blocking the page. Every tab is offered until the
answer lands, which is what the row did before and what it keeps doing if the
judge never loads; the run path reports that failure itself. A candidate who
reached C in that window keeps their buffer and loses the runner, rather than
having their work replaced by a starter buffer at whatever moment the fetch
happened to land.

`updateRunAvailability` now owns the run button, asking `codingClosed()` rather
than inferring the interview phase from `nodes.editor.disabled`. That also
closes a hole where pausing and resuming handed the runner back on a language
the harness refuses.

`scripts/gen-wire-fixtures.mjs` used to learn the offered languages by
regex-scraping a `const languages = [...]` line out of `web/interview.js`. It
imports `ALL_LANGUAGES` now. The generated fixtures are byte-identical.

## Two independent commits ride along

`Stop the evidence carry from resting on a key count` removes a fast path in
`sanitizeReport` that was correct only because all seven known evidence fields
happen to be required; one optional field later and a row with an unknown key
would have dropped it.

`Take the rtrb fix for RUSTSEC-2026-0274` is a lockfile-only bump that was
failing the `cargo-audit` gate before this branch.

## Checks

`./scripts/test.sh` green end to end: 484 Rust tests passed / 0 failed / 2
ignored, browser 351 passed / 1 skipped / 0 failed, cargo-audit clean, fmt,
clippy at `-D warnings`, eslint and the generator checks all passing.

Verified in a real browser against a local release build, including the race
the non-blocking fetch opens:

| case | C tab | selected | run button |
| --- | --- | --- | --- |
| `lru-cache` (class judge) | disabled, reason in title | python | live |
| `two-sum` (function judge) | live, click selects it | c | live |
| `lru-cache`, judge stalled 2.5s, C grabbed first | live, then disabled | c, buffer kept | live, then dead |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops offering C on the seven problems with class-style judges, so candidates no longer write a whole solution and press run to discover the C harness can't build it. The C tab now disables itself with the reason shown as its tooltip, and the judge is fetched without blocking the page: every tab stays offered until the response lands, and a candidate already in C keeps their buffer but loses the run button.

**Bug Fixes**
- `sanitizeReport` no longer assumes all evidence fields are required, so a future optional field with an unknown key won't be dropped.
- The run button now reads `codingClosed()` directly, closing a hole where pausing and resuming re-enabled the runner on an unsupported language.

**Dependencies**
- Bumps `rtrb` to 0.3.5, the lockfile-only fix for RUSTSEC-2026-0274 that the `cargo-audit` gate was failing on.

<sup>Written for commit 3fe99728d6d9a8b7fb773febda4af301c0e081ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/codetrial/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

