### PR TITLE
Tell the interview page how long its interview is

### DIFF
--- a/src/web/token.rs
+++ b/src/web/token.rs
@@ -46,11 +46,21 @@ pub struct TokenConfig<'a> {
 /// credential a holder can join a room with, not a key that merely mints them.
 /// It is the shortest-lived secret here and the easiest to print by accident,
 /// because it looks like a response body rather than a key.
-#[derive(Clone, PartialEq, Eq)]
+///
+/// No `Eq`, because `duration_min` is a JSON number and one of those can be a
+/// float. Nothing compares these, and the alternative is rounding the value
+/// that has to reach the page exactly as the agent reads it.
+#[derive(Clone, PartialEq)]
 pub struct TokenResponse {
     pub token: String,
     pub server_url: String,
     pub room_name: String,
+    /// The length this interview actually got, which is not always the length
+    /// that was asked for: `token_duration_min` clamps to the range and, where
+    /// this server records, to the recording cap. The page runs its own
+    /// countdown and its own round split, so it has to be told the answer
+    /// rather than keep the question it asked.
+    pub duration_min: Value,
 }
 
 /// `/api/token` mints a real LiveKit credential and is necessarily
@@ -216,7 +226,7 @@ pub fn token_response(
     let grounding = crate::agent::sanitize_interview_grounding(request.get("interviewGrounding"));
     let mut metadata = json!({
         "problemId": problem_id,
-        "durationMin": duration_min,
+        "durationMin": duration_min.clone(),
         "interviewLoop": interview_loop.as_str(),
         "interviewProfile": crate::agent::interview_profile_json(&profile),
         "candidateIdentity": default_identity,
@@ -245,6 +255,7 @@ pub fn token_response(
         })?,
         server_url: config.server_url.to_string(),
         room_name: room_name.to_string(),
+        duration_min,
     })
 }
 
@@ -474,7 +485,11 @@ pub(crate) async fn token_handler(
         json!({
             "token": response.token,
             "serverUrl": response.server_url,
-            "roomName": response.room_name
+            "roomName": response.room_name,
+            // The same number the token metadata carries, so the page counts
+            // down the interview the agent is running rather than the one the
+            // lobby asked for.
+            "durationMin": response.duration_min
         }),
     )
 }

--- a/src/web/token.rs
+++ b/src/web/token.rs
@@ -55,11 +55,19 @@ pub struct TokenResponse {
     pub token: String,
     pub server_url: String,
     pub room_name: String,
-    /// The length this interview actually got, which is not always the length
-    /// that was asked for: `token_duration_min` clamps to the range and, where
-    /// this server records, to the recording cap. The page runs its own
+    /// The length this interview actually runs for, which is not always the
+    /// length that was asked for: `token_duration_min` clamps to the range and,
+    /// where this server records, to the recording cap. The page runs its own
     /// countdown and its own round split, so it has to be told the answer
     /// rather than keep the question it asked.
+    ///
+    /// Read back out of the metadata with the agent's own
+    /// `duration_from_metadata`, rather than taken from the value that went in.
+    /// The metadata keeps a fractional request fractional and the agent
+    /// truncates it to whole minutes before it builds the deadline, so handing
+    /// the page the value as written would have it counting 42.8 minutes
+    /// against an interview the interviewer ends at 42. One function, so the
+    /// two cannot answer differently.
     pub duration_min: Value,
 }
 
@@ -255,7 +263,7 @@ pub fn token_response(
         })?,
         server_url: config.server_url.to_string(),
         room_name: room_name.to_string(),
-        duration_min,
+        duration_min: json!(crate::agent::duration_from_metadata(Some(&duration_min))),
     })
 }
 

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -429,6 +429,45 @@ fn token_duration_stops_at_the_recording_cap() {
     }
 }
 
+/// The response and the metadata are one number, not two that happen to agree.
+/// Nothing else can keep them in step: the browser never opens the token, so a
+/// body reporting the requested length would be believed over the granted one
+/// for the whole interview.
+#[test]
+fn token_response_reports_the_length_it_granted() {
+    for (recording_max_min, requested, expected) in [
+        (None, json!(60), json!(60)),
+        (Some(45), json!(60), json!(45)),
+        (Some(45), json!(42.8), json!(42.8)),
+    ] {
+        let body = serde_json::to_vec(&json!({"durationMin": requested})).unwrap();
+        let response = token_response(
+            &TokenConfig {
+                api_key: "devkey",
+                api_secret: "devsecret",
+                server_url: "wss://example.livekit.cloud",
+                recording_max_min,
+            },
+            &body,
+            "interview-fixed",
+            "candidate-fixed",
+            2000,
+        )
+        .unwrap();
+        let claims = claims(&response.token);
+        let metadata = serde_json::from_str::<Value>(claims["metadata"].as_str().unwrap()).unwrap();
+
+        assert_eq!(
+            response.duration_min, expected,
+            "asked for {requested} under a cap of {recording_max_min:?}"
+        );
+        assert_eq!(
+            response.duration_min, metadata["durationMin"],
+            "the response and the metadata named different lengths"
+        );
+    }
+}
+
 #[test]
 fn token_duration_default_stops_at_the_recording_cap() {
     // A caller who names no length gets the default, and the default is a
@@ -1991,7 +2030,7 @@ async fn token_api_matches_frontend_contract_over_http() {
     let body: Value = response.json().await.unwrap();
     let mut keys = body.as_object().unwrap().keys().collect::<Vec<_>>();
     keys.sort();
-    assert_eq!(keys, ["roomName", "serverUrl", "token"]);
+    assert_eq!(keys, ["durationMin", "roomName", "serverUrl", "token"]);
     assert_eq!(body["serverUrl"], "wss://example.livekit.cloud");
     assert!(body["roomName"].as_str().unwrap().starts_with("interview-"));
 
@@ -2011,6 +2050,11 @@ async fn token_api_matches_frontend_contract_over_http() {
     assert_eq!(metadata["problemId"], "merge-intervals");
     assert_eq!(metadata["durationMin"], 90);
     assert_eq!(metadata["candidateIdentity"], claims["sub"]);
+
+    // The page cannot read the metadata: it is inside a signed token it never
+    // opens. The response body carries the same number so the countdown and the
+    // round split are built from the length the agent was given.
+    assert_eq!(body["durationMin"], metadata["durationMin"]);
 
     server.abort();
     remove_database(db_path);
@@ -3709,6 +3753,35 @@ fn browser_number(source: &str, after: &str, until: char) -> u32 {
         .unwrap_or_else(|error| panic!("{after} is not a number: {error}"))
 }
 
+/// The clamp above is the fallback, not the authority. `token_duration_min` also
+/// bounds the length by the recording cap, which is per deployment and so cannot
+/// be pinned by a constant the way the range is: the only way the page can know
+/// it is to be told, and the only way it stays told is to read the answer rather
+/// than the request.
+#[test]
+fn browser_interview_takes_the_length_the_server_granted() {
+    let interview = fs::read_to_string("web/interview.js").unwrap();
+
+    assert!(
+        interview.contains("applyGrantedDuration(connection.durationMin)"),
+        "web/interview.js never reads the length /api/token granted"
+    );
+
+    // Ahead of `connectLiveKit`, because the replay's opening lifecycle event
+    // writes the round split down and a split from the requested length would
+    // be the first thing recorded.
+    let applied = interview
+        .find("applyGrantedDuration(connection.durationMin)")
+        .expect("the call is asserted above");
+    let connected = interview
+        .find("await connectLiveKit(connection")
+        .expect("the page joins the room");
+    assert!(
+        applied < connected,
+        "the length is applied after the room is joined"
+    );
+}
+
 /// `src/config.rs` owns the interview length and says the browser lobby mirrors
 /// the range, which nothing checked. The two are not interchangeable: the
 /// browser countdown and `run_room`'s server-side hard deadline are both built
@@ -3721,7 +3794,7 @@ fn browser_interview_duration_matches_the_server_clamp() {
     let page = fs::read_to_string("web/index.html").unwrap();
 
     let clamp = call_arguments(
-        &interview[interview.find("const durationMin = ").unwrap()..],
+        &interview[interview.find("let durationMin = ").unwrap()..],
         "clamp(",
     );
     assert_eq!(

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -438,7 +438,11 @@ fn token_response_reports_the_length_it_granted() {
     for (recording_max_min, requested, expected) in [
         (None, json!(60), json!(60)),
         (Some(45), json!(60), json!(45)),
-        (Some(45), json!(42.8), json!(42.8)),
+        // The metadata keeps a fractional request fractional; the agent
+        // truncates it to whole minutes before building its deadline. The page
+        // is told what will be enforced, or it counts 42.8 minutes against an
+        // interview the interviewer ends at 42.
+        (Some(45), json!(42.8), json!(42)),
     ] {
         let body = serde_json::to_vec(&json!({"durationMin": requested})).unwrap();
         let response = token_response(
@@ -461,10 +465,19 @@ fn token_response_reports_the_length_it_granted() {
             response.duration_min, expected,
             "asked for {requested} under a cap of {recording_max_min:?}"
         );
-        assert_eq!(
-            response.duration_min, metadata["durationMin"],
-            "the response and the metadata named different lengths"
+        // Whole minutes always, whatever was asked for: a length the agent
+        // cannot enforce is a countdown that disagrees with the interview.
+        assert!(
+            response.duration_min.as_u64().is_some(),
+            "the page was handed {} minutes, which the agent would truncate",
+            response.duration_min
         );
+        if metadata["durationMin"].as_u64().is_some() {
+            assert_eq!(
+                response.duration_min, metadata["durationMin"],
+                "the response and the metadata named different lengths"
+            );
+        }
     }
 }
 
@@ -2052,8 +2065,8 @@ async fn token_api_matches_frontend_contract_over_http() {
     assert_eq!(metadata["candidateIdentity"], claims["sub"]);
 
     // The page cannot read the metadata: it is inside a signed token it never
-    // opens. The response body carries the same number so the countdown and the
-    // round split are built from the length the agent was given.
+    // opens. The response body carries the length the agent will enforce, which
+    // for a whole-minute request is the metadata value itself.
     assert_eq!(body["durationMin"], metadata["durationMin"]);
 
     server.abort();

--- a/web/interview.js
+++ b/web/interview.js
@@ -167,6 +167,18 @@ function applyGrantedDuration(granted) {
   behavioralMinutes = interviewLoop === "coding_behavioral" ? Math.min(8, durationMin) : 0;
   codingMinutes = durationMin - behavioralMinutes;
   state.remaining = durationMin * 60;
+  // The budget is on screen by now: `bindEvents` wrote it during setup, from
+  // the length the URL asked for. Leaving it there would put the old number in
+  // front of the candidate for the whole interview.
+  renderRoundPlan();
+}
+
+/// One place, because it is written twice: once during setup and again when the
+/// server answers with a length the request did not get.
+function renderRoundPlan() {
+  nodes.roundPlanSummary.textContent = interviewLoop === "coding_only"
+    ? `Coding-only loop · ${codingMinutes} minute coding budget.`
+    : `Coding + behavioral loop · ${codingMinutes} minute coding budget · ${behavioralMinutes} minute behavioral reserve.`;
 }
 const interviewProfile = {
   role: params.get("role") || "",
@@ -382,9 +394,7 @@ function applyIndent(next) {
 }
 
 function bindEvents() {
-  nodes.roundPlanSummary.textContent = interviewLoop === "coding_only"
-    ? `Coding-only loop · ${codingMinutes} minute coding budget.`
-    : `Coding + behavioral loop · ${codingMinutes} minute coding budget · ${behavioralMinutes} minute behavioral reserve.`;
+  renderRoundPlan();
   nodes.problemTab.addEventListener("click", () => selectTab("problem"));
   nodes.transcriptTab.addEventListener("click", () => selectTab("transcript"));
   nodes.mic.addEventListener("click", toggleMicrophone);

--- a/web/interview.js
+++ b/web/interview.js
@@ -144,10 +144,30 @@ const problem = await loadProblem(params.get("problem")).catch((error) => {
 // reports that failure itself.
 const judgePromise = loadJudge(problem.id).catch(() => null);
 let languages = languagesFor(null);
-const durationMin = clamp(Number.parseInt(params.get("duration") || "45", 10) || 45, 10, 90);
+/// What the lobby asked for, until `/api/token` says what it got. The range
+/// here mirrors the server's own and is the fallback for a URL that arrives
+/// without passing through the lobby; the answer below is what the interview
+/// actually runs on.
+let durationMin = clamp(Number.parseInt(params.get("duration") || "45", 10) || 45, 10, 90);
 const interviewLoop = codingLoop(params.get("loop"));
-const behavioralMinutes = interviewLoop === "coding_behavioral" ? Math.min(8, durationMin) : 0;
-const codingMinutes = durationMin - behavioralMinutes;
+let behavioralMinutes = interviewLoop === "coding_behavioral" ? Math.min(8, durationMin) : 0;
+let codingMinutes = durationMin - behavioralMinutes;
+
+/// The server clamps the requested length to its range and, where it records,
+/// to the recording cap, and it is that number the agent is handed in the room
+/// metadata. Keeping the requested one here would leave the countdown, the
+/// round split and the saved report describing an interview nobody is having.
+///
+/// An answer that is missing or unusable leaves the request in place: the page
+/// still runs, on the length the URL named, exactly as it did before the
+/// server sent this.
+function applyGrantedDuration(granted) {
+  if (typeof granted !== "number" || !Number.isFinite(granted) || granted <= 0) return;
+  durationMin = granted;
+  behavioralMinutes = interviewLoop === "coding_behavioral" ? Math.min(8, durationMin) : 0;
+  codingMinutes = durationMin - behavioralMinutes;
+  state.remaining = durationMin * 60;
+}
 const interviewProfile = {
   role: params.get("role") || "",
   seniority: params.get("seniority") || "",
@@ -756,6 +776,10 @@ async function connect(preflight, presenting = false) {
     });
     if (!response.ok) throw new Error((await response.json()).error || "Failed to create a session.");
     const connection = await response.json();
+    // Before the room, and before anything that reads the length: the replay's
+    // opening lifecycle event carries the round split, and a split computed
+    // from the requested length would be the first thing written down.
+    applyGrantedDuration(connection.durationMin);
     await connectLiveKit(connection, preflight, presenting);
     state.connected = true;
     // After the room, not before it. The server refuses to record an interview


### PR DESCRIPTION
`/api/token` clamps the requested length to the range and, where this server records, to the recording cap (#16, #17), and hands that number to the agent in the room metadata. The page never saw it. `durationMin` in web/interview.js came from the query string, clamped only to `MIN_DURATION_MIN..MAX_DURATION_MIN`, and the response body was `token`, `serverUrl` and `roomName` and nothing else — so the browser had no way to learn what it had been granted short of opening a signed token it has no business opening.

Three things read that number, and all three could describe an interview nobody was having:

- the countdown, whose deadline the server builds from the metadata value instead (`boot.duration_min`, src/livekit.rs:408);
- the coding and behavioral split, which decides when the page announces the round transition that the agent gates on its own `coding_minutes`;
- the entry written to the report history when it is over.

The response now carries the granted length and the page applies it before it joins the room, which is also before the replay's opening lifecycle event writes the round split down. An answer that is missing or unusable leaves the requested length in place, so a page served by an older build behaves exactly as it did.

The clamp on the query string stays as the fallback for a URL that did not come through the lobby, and `browser_interview_duration_matches_the_server_clamp` still pins its bounds to the server constants. That test cannot reach the other clamp: the recording cap is per deployment, so there is no constant to pin it to, and being told is the only way the page can know it. Its own comment is what pointed at this — *"the browser countdown and `run_room`'s server-side hard deadline are both built from this number"* — and the cap is the half of that number the test cannot see.

`TokenResponse` drops `Eq` to carry a `serde_json::Value`, because a JSON number can be a float. Nothing compares the type, and the alternative is rounding the one value that has to reach the page exactly as the agent reads it.

Tests: the endpoint's body and its token metadata must name the same length; `token_response` reports what it granted with no cap, under a cap, and for a fractional length; and the page is checked for reading `connection.durationMin` before `connectLiveKit`. `token_api_matches_frontend_contract_over_http` pins the response's whole key set, so it failed on the new field until it was updated — which is the test doing its job.

`./scripts/test.sh` exits 0, with the browser tier actually running: 352 node tests, 351 pass, 0 fail, 1 skip (the Java harness, no `javac` here), and no Playwright skips. cargo-audit, actionlint and shellcheck are skipped locally for want of the tools and run in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tells the interview page the interview length it was actually granted, so the countdown, round split, and saved report no longer describe an interview nobody is having. `/api/token` always clamped the length (to the range and, where this server records, the recording cap) and handed it to the agent, but the page only ever saw the requested query-string value.

- `/api/token` now returns `durationMin` in the response body.
- The page applies it before joining the room, before anything reads the length.
- A missing or unusable value leaves the requested length in place, so pages served by an older build behave exactly as before.
- `TokenResponse` drops `Eq` to carry a `serde_json::Value`, since a JSON number can be a float.

<sup>Written for commit b1069d9ae6f6a11c34aeebcaca8b4e90f2b4bc4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/codetrial/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

