### PR TITLE
Make a double-clicked binary able to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,14 @@ Explorer service.
 3. Set `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`, and
    `GOOGLE_API_KEY` in that file.
 
-The binary looks for `codetrial.env.local` in `./config/`, then in the current
-directory, then beside the executable itself. Use `--config PATH` to point at a
-different file. Extra `codetrial.env.*` files in the same directory are optional
+One installation keeps its config file and its account database together in a
+`config/` directory: `config/` in a checkout, and a `config/` beside the
+executable for a downloaded binary. The binary looks in both, and in two older
+places it no longer writes to — `codetrial.env.local` in the current directory
+and beside the executable. Use `--config PATH` to point at a different file. Extra `codetrial.env.*` files in the same directory are optional
 providers used for pooling. If `web` mode finds no config file at all, it serves
 a Setup page instead and prints the URL to open — you can skip steps 2–3 above,
-fill in your keys there, and it writes them to `codetrial.env.local` for you. That page
+fill in your keys there, and it writes them to `config/codetrial.env.local` for you. That page
 serves on a loopback address only; a start that would put it on any other
 address refuses instead, and writing the file yourself is the way to deploy for
 other people. See [Prebuilt binaries](#prebuilt-binaries).
@@ -117,11 +119,12 @@ Loopback is the only place it will serve: `--web-addr 0.0.0.0:3000` or
 credentials over plain HTTP from anyone who can reach it.
 Enter your LiveKit keys there, and your Google key if you want this process to
 host interviewers (see below). Saving writes them **in plain text** to
-`codetrial.env.local` beside the executable — the same file you would
-otherwise write yourself:
+`config/codetrial.env.local` beside the executable, creating that directory —
+the same file you would otherwise write yourself:
 
 ```bash
-cat >codetrial.env.local <<'EOF'
+mkdir -p config
+cat >config/codetrial.env.local <<'EOF'
 LIVEKIT_URL=wss://YOUR-PROJECT.livekit.cloud
 LIVEKIT_API_KEY=...
 LIVEKIT_API_SECRET=...
@@ -129,6 +132,12 @@ GOOGLE_API_KEY=...
 EOF
 ./codetrial web   # http://127.0.0.1:3000
 ```
+
+That `config/` is your data: the keys above and, once the server has run,
+`codetrial.db` with your accounts and reports. To take a newer build, replace
+the executable in place and leave `config/` alone. Unpacking into a fresh
+directory starts over, and deleting the directory removes everything this
+program kept.
 
 `GOOGLE_API_KEY` is the optional one, and it decides which of two things this
 process is. With it, the server hosts interviewers itself. Without it, it serves
@@ -148,10 +157,10 @@ Platform notes:
   source.
 - Windows binaries are unsigned. SmartScreen warns on first run. Put the exe in
   a folder of its own before double-clicking it: with no config file nearby it
-  opens the Setup page above, and everything it writes lands next to the
-  executable — the `codetrial.env.local` that page saves, and, if the start
-  fails, a `codetrial-error.log` that is the only place the reason appears when
-  there is no terminal to read one from.
+  opens the Setup page above, and everything it writes lands in that folder —
+  the `config/` that page fills in, and, if the start fails, a
+  `codetrial-error.log` beside the executable that is the only place the reason
+  appears when there is no terminal to read one from.
 - Only `x86_64` Linux, `arm64` macOS, and `x86_64` Windows are published. Build
   from source for anything else.
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,13 @@ Explorer service.
 3. Set `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`, and
    `GOOGLE_API_KEY` in that file.
 
-The binary requires `codetrial.env.local`, searching `./config/` before the
-current directory. Use `--config PATH` for an alternate primary config file.
-Extra `codetrial.env.*` files in the same directory are optional providers used
-for pooling.
+The binary looks for `codetrial.env.local` in `./config/`, then in the current
+directory, then beside the executable itself. Use `--config PATH` to point at a
+different file. Extra `codetrial.env.*` files in the same directory are optional
+providers used for pooling. If `web` mode finds no config file at all, it opens
+a Setup page in your browser instead — you can skip steps 2–3 above, fill in
+your keys there, and it writes them to `codetrial.env.local` for you. See
+[Prebuilt binaries](#prebuilt-binaries).
 
 ## Prebuilt binaries
 
@@ -104,10 +107,12 @@ xattr -d com.apple.quarantine codetrial-aarch64-apple-darwin
 mv codetrial-aarch64-apple-darwin codetrial
 ```
 
-A config file has to sit beside it. The binary will not run on environment
-variables alone, and it refuses to start without LiveKit credentials rather than
-booting a server that cannot mint a token. There is no `config/codetrial.env.example`
-to copy outside a checkout, so write the three required keys yourself:
+Run `./codetrial` with no config file nearby, and `web` mode opens a Setup
+page in your browser at <http://127.0.0.1:3000> instead of refusing to start.
+Enter your LiveKit keys there, and your Google key if you want this process to
+host interviewers (see below). Saving writes them **in plain text** to
+`codetrial.env.local` beside the executable — the same file you would
+otherwise write yourself:
 
 ```bash
 cat >codetrial.env.local <<'EOF'
@@ -135,7 +140,12 @@ Platform notes:
   project does not have. A downloaded `.zip` carries the quarantine attribute
   and Gatekeeper refuses it, so clear the attribute as above or build from
   source.
-- Windows binaries are unsigned. SmartScreen warns on first run.
+- Windows binaries are unsigned. SmartScreen warns on first run. Put the exe in
+  a folder of its own before double-clicking it: with no config file nearby it
+  opens the Setup page above, and everything it writes lands next to the
+  executable — the `codetrial.env.local` that page saves, and, if the start
+  fails, a `codetrial-error.log` that is the only place the reason appears when
+  there is no terminal to read one from.
 - Only `x86_64` Linux, `arm64` macOS, and `x86_64` Windows are published. Build
   from source for anything else.
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ Explorer service.
 The binary looks for `codetrial.env.local` in `./config/`, then in the current
 directory, then beside the executable itself. Use `--config PATH` to point at a
 different file. Extra `codetrial.env.*` files in the same directory are optional
-providers used for pooling. If `web` mode finds no config file at all, it opens
-a Setup page in your browser instead — you can skip steps 2–3 above, fill in
-your keys there, and it writes them to `codetrial.env.local` for you. See
-[Prebuilt binaries](#prebuilt-binaries).
+providers used for pooling. If `web` mode finds no config file at all, it serves
+a Setup page instead and prints the URL to open — you can skip steps 2–3 above,
+fill in your keys there, and it writes them to `codetrial.env.local` for you. That page
+serves on a loopback address only; a start that would put it on any other
+address refuses instead, and writing the file yourself is the way to deploy for
+other people. See [Prebuilt binaries](#prebuilt-binaries).
 
 ## Prebuilt binaries
 
@@ -107,8 +109,12 @@ xattr -d com.apple.quarantine codetrial-aarch64-apple-darwin
 mv codetrial-aarch64-apple-darwin codetrial
 ```
 
-Run `./codetrial` with no config file nearby, and `web` mode opens a Setup
-page in your browser at <http://127.0.0.1:3000> instead of refusing to start.
+Run `./codetrial` with no config file nearby, and `web` mode serves a Setup
+page at <http://127.0.0.1:3000> instead of refusing to start, printing that
+address for you to open.
+Loopback is the only place it will serve: `--web-addr 0.0.0.0:3000` or
+`CODETRIAL_WEB_ADDR` pointing anywhere else is refused, because the page takes
+credentials over plain HTTP from anyone who can reach it.
 Enter your LiveKit keys there, and your Google key if you want this process to
 host interviewers (see below). Saving writes them **in plain text** to
 `codetrial.env.local` beside the executable — the same file you would

--- a/config/codetrial.env.example
+++ b/config/codetrial.env.example
@@ -29,6 +29,8 @@ CODETRIAL_GEMINI_CANDIDATE_VIDEO_ENABLED=false
 # Its built-in default is a published string, so with NODE_ENV=production the
 # server refuses to start until this is set to a real one.
 # SESSION_SECRET=replace_with_a_long_random_secret
+# CODETRIAL_DB_PATH defaults to codetrial.db in this directory, the one this
+# config file was read from. Set it to move the accounts and reports elsewhere.
 # CODETRIAL_DB_PATH=codetrial.db
 # Production recording is off unless CODETRIAL_RECORDING_ENABLED=true, and a
 # half-configured block fails at startup rather than mid-interview. Provision

--- a/docs/recording-contract.md
+++ b/docs/recording-contract.md
@@ -1172,7 +1172,9 @@ deletion nothing here can perform.
 
 ## The database
 
-One database, the one at `CODETRIAL_DB_PATH`, default `codetrial.db`.
+One database, the one at `CODETRIAL_DB_PATH`. Its default is `codetrial.db` in
+the directory the config file was read from, so it stays with the installation
+rather than with whatever directory the server was started in.
 `interviewlab.db` at the repo root is a pre-rename leftover and is not migrated.
 
 Schema changes are appended to `ACCOUNT_MIGRATIONS` in `src/accounts.rs` and

--- a/scripts/recording-cleanup.sh
+++ b/scripts/recording-cleanup.sh
@@ -29,13 +29,19 @@ usage: recording-cleanup.sh [--db PATH] [--now EPOCH] [--dry-run]
   --expire ID...  bring those recordings' deadlines forward, so the running
                   server's sweeper deletes their media on its next pass and
                   records the deletion as an operator's
-  --db PATH       the account database, default $CODETRIAL_DB_PATH or codetrial.db
+  --db PATH       the account database, default $CODETRIAL_DB_PATH; required,
+                  because the server's own default is the config directory of
+                  the launch that wrote it and this script cannot know which
+                  one that was
   --now EPOCH     the clock to measure deadlines against, default now
 USAGE
     exit 2
 }
 
-db=${CODETRIAL_DB_PATH:-codetrial.db}
+# No fallback filename. sqlite3 creates a database it cannot find, so a guess
+# that misses does not fail: it reports an empty list of due recordings, which
+# reads exactly like a clean sweep.
+db=${CODETRIAL_DB_PATH:-}
 now=$(date +%s)
 expire=
 
@@ -84,6 +90,11 @@ case "$now" in
         exit 2
         ;;
 esac
+
+[ -n "$db" ] || {
+    echo "no database: pass --db PATH or set CODETRIAL_DB_PATH" >&2
+    exit 2
+}
 
 command -v sqlite3 > /dev/null 2>&1 || {
     echo "required command is unavailable: sqlite3" >&2

--- a/src/config.rs
+++ b/src/config.rs
@@ -480,15 +480,31 @@ pub struct AgentConfig {
     pub pool: ProviderPool,
 }
 
-/// Scheme, and whether it encrypts. A LiveKit join token is a bearer
-/// credential, so plaintext is a local-development convenience and nothing
-/// more.
-const LIVEKIT_SCHEMES: [(&str, bool); 4] = [
-    ("wss://", true),
-    ("https://", true),
-    ("ws://", false),
-    ("http://", false),
+/// Scheme, whether it encrypts, and the scheme a RoomService request to the
+/// same deployment is made over. A LiveKit join token is a bearer credential,
+/// so plaintext is a local-development convenience and nothing more.
+///
+/// The third column lives here rather than beside the two functions that
+/// rewrite a URL with it, because all three lists have to agree on what a
+/// scheme is and two of them already disagreed: this one matched `WSS://`
+/// case-insensitively and `livekit_http_base` did not, so an accepted URL was
+/// posted to as `WSS://`, which is not a scheme reqwest will send.
+const LIVEKIT_SCHEMES: [(&str, bool, &str); 4] = [
+    ("wss://", true, "https://"),
+    ("https://", true, "https://"),
+    ("ws://", false, "http://"),
+    ("http://", false, "http://"),
 ];
+
+/// The entry `url` starts with, matched the way a URL scheme compares: without
+/// regard to case. Case is the whole reason this is a function and not an
+/// `iter().find()` at each call site.
+pub(crate) fn livekit_scheme(url: &str) -> Option<&'static (&'static str, bool, &'static str)> {
+    LIVEKIT_SCHEMES.iter().find(|(scheme, _, _)| {
+        url.get(..scheme.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(scheme))
+    })
+}
 
 /// Rejects what `url_origin` in `web.rs` would otherwise have to cope with: a
 /// scheme nothing here knows, or a scheme with no host after it. The URL never
@@ -496,11 +512,7 @@ const LIVEKIT_SCHEMES: [(&str, bool); 4] = [
 /// can carry a query string.
 pub fn validate_livekit_url(url: &str, production: bool) -> Result<(), String> {
     let trimmed = url.trim();
-    let Some((scheme, encrypted)) = LIVEKIT_SCHEMES.iter().find(|(scheme, _)| {
-        trimmed
-            .get(..scheme.len())
-            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(scheme))
-    }) else {
+    let Some((scheme, encrypted, _)) = livekit_scheme(trimmed) else {
         return Err("LIVEKIT_URL must start with wss://, https://, ws:// or http://".to_string());
     };
     if trimmed[scheme.len()..]

--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -112,8 +112,19 @@ impl GeminiLiveSession {
     /// Same teardown as [`Self::close`], for callers that only hold a mutable
     /// borrow and cannot give up ownership.
     pub async fn shutdown(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        self.writer.close().await?;
+        // The reader is aborted whether or not the close lands, and the close
+        // result is reported afterwards. Returning on the close first left the
+        // task running: dropping a `JoinHandle` detaches the task rather than
+        // cancelling it, so it stayed parked on a read holding the socket open.
+        //
+        // The order matters most where the close is expected to fail. A socket
+        // that is gone without having said so answers no read and refuses every
+        // write, which is what the reconnect in `livekit.rs` calls this for, so
+        // the one session that cannot end on its own was the one this left
+        // behind.
+        let closed = self.writer.close().await;
         self.reader.abort();
+        closed?;
         Ok(())
     }
 
@@ -1409,6 +1420,51 @@ mod tests {
         );
         drop(held);
         session.close().await.unwrap();
+    }
+
+    /// Ending the session has to end the reader task. Dropping the handle only
+    /// detaches it, and a detached reader parked on a socket holds that socket
+    /// for the rest of the process.
+    ///
+    /// The server answers the handshake and then holds the connection without
+    /// replying to the close, so a reader that was merely dropped would still
+    /// be waiting here rather than finishing on its own.
+    ///
+    /// The close succeeds here, so what this pins is that the reader is ended
+    /// at all, not the order the two happen in. A close that fails while the
+    /// reader is still parked is the case that was wrong, and it has no test:
+    /// every way of making a write fail locally breaks the read as well, and
+    /// then the reader ends on its own and proves nothing.
+    #[tokio::test]
+    async fn shutdown_ends_the_reader_task() {
+        let config = live_config(&[]);
+        let boot = bootstrap(&config, "interview-fixed", Some("two-sum"), 45);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(socket).await.unwrap();
+            let _ = socket.next().await;
+            socket
+                .send(Message::Text(r#"{"setupComplete":{}}"#.into()))
+                .await
+                .unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let mut session = open_live_session_at(&format!("ws://{address}"), &boot, None)
+            .await
+            .unwrap();
+        session.shutdown().await.unwrap();
+
+        assert!(
+            (&mut session.reader)
+                .await
+                .expect_err("a reader that was aborted cannot have joined")
+                .is_cancelled(),
+            "shutdown must end the reader task rather than detach it"
+        );
     }
 
     #[tokio::test]

--- a/src/gemini.rs
+++ b/src/gemini.rs
@@ -324,7 +324,7 @@ async fn generate_report_once(
     Ok(text)
 }
 
-async fn open_live_session_at(
+pub(crate) async fn open_live_session_at(
     url: &str,
     boot: &RuntimeBootstrap<'_>,
     resume: Option<&str>,
@@ -402,7 +402,7 @@ async fn open_live_session_at(
     })
 }
 
-fn gemini_live_websocket_url(api_key: &str) -> String {
+pub(crate) fn gemini_live_websocket_url(api_key: &str) -> String {
     format!(
         "{LIVE_WEBSOCKET_ENDPOINT}?key={}",
         percent_encode_query_value(api_key)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,20 @@ pub fn current_epoch_seconds() -> u64 {
         .as_secs()
 }
 
+/// The folder the executable itself sits in, which is where anything
+/// `codetrial` writes or looks for without being told a path belongs. A
+/// released binary is unpacked into a folder of its own and everything it
+/// needs ends up there, whatever directory it was launched from: a
+/// double-click makes the two the same, a shortcut or a terminal elsewhere
+/// does not. Falls back to the working directory when the path cannot be
+/// resolved, which leaves the old behaviour rather than no behaviour.
+pub fn exe_dir() -> std::path::PathBuf {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(std::path::Path::to_path_buf))
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+}
+
 /// One shared client so repeated Gemini and LiveKit RoomService calls reuse
 /// connections instead of renegotiating TLS per request. `reqwest::Client` is
 /// already an `Arc` internally and is meant to be reused.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,3 +53,20 @@ pub fn http_client() -> &'static reqwest::Client {
             .expect("http client should build")
     })
 }
+
+#[cfg(test)]
+mod tests {
+    /// The empty path is what a `PathBuf` defaults to, and joining a file name
+    /// onto it yields that name alone, which resolves against the working
+    /// directory. That is the fallback this function has for when the
+    /// executable cannot be located, not the answer it gives when it can, and
+    /// the difference decides where a released binary looks for its config.
+    #[test]
+    fn exe_dir_names_the_folder_the_running_binary_sits_in() {
+        let exe = std::env::current_exe().expect("a running test binary has a path");
+        assert_eq!(
+            super::exe_dir(),
+            exe.parent().expect("an executable sits in a folder")
+        );
+    }
+}

--- a/src/livekit.rs
+++ b/src/livekit.rs
@@ -951,10 +951,21 @@ pub(crate) async fn validate_livekit_credentials(
     }
 }
 
+/// The RoomService origin for a LiveKit URL: the same host, over the scheme an
+/// HTTP client will send.
+///
+/// The rewrite goes through `livekit_scheme` rather than matching the two
+/// websocket schemes here, because `validate_livekit_url` accepts a scheme in
+/// any case and this has to rewrite every spelling that accepts. A pasted
+/// `WSS://` used to survive unchanged, and reqwest refuses any scheme but http
+/// and https before the request leaves the process, so credentials that were
+/// good came back as credentials that did not work.
 fn livekit_http_base(url: &str) -> String {
-    url.trim_end_matches('/')
-        .replacen("wss://", "https://", 1)
-        .replacen("ws://", "http://", 1)
+    let trimmed = url.trim_end_matches('/');
+    match crate::config::livekit_scheme(trimmed) {
+        Some((scheme, _, http)) => format!("{http}{}", &trimmed[scheme.len()..]),
+        None => trimmed.to_string(),
+    }
 }
 
 fn parse_room_service_response(
@@ -2491,6 +2502,25 @@ mod tests {
         assert_eq!(
             livekit_http_base("ws://localhost:7880"),
             "http://localhost:7880"
+        );
+    }
+
+    /// `validate_livekit_url` compares the scheme without regard to case, so
+    /// every spelling it accepts reaches here. The host keeps the case it was
+    /// given: DNS does not care, and a path might.
+    #[test]
+    fn livekit_http_base_rewrites_a_scheme_in_any_case() {
+        assert_eq!(
+            livekit_http_base("WSS://Example.LiveKit.Cloud"),
+            "https://Example.LiveKit.Cloud"
+        );
+        assert_eq!(
+            livekit_http_base("Ws://localhost:7880/"),
+            "http://localhost:7880"
+        );
+        assert_eq!(
+            livekit_http_base("HTTPS://example.livekit.cloud"),
+            "https://example.livekit.cloud"
         );
     }
 

--- a/src/livekit.rs
+++ b/src/livekit.rs
@@ -923,6 +923,34 @@ async fn livekit_room_service_request(
     parse_room_service_response(method, &text)
 }
 
+/// Proves credentials like `check-gemini` proves a Google key: the server
+/// must accept a signed request. `ListRooms` needs no room to exist.
+pub(crate) async fn validate_livekit_credentials(
+    url: &str,
+    api_key: &str,
+    api_secret: &str,
+    now_seconds: u64,
+) -> Result<(), String> {
+    let token = crate::token::livekit_room_list_token(api_key, api_secret, now_seconds)
+        .map_err(|error| error.to_string())?;
+    let endpoint = format!(
+        "{}/twirp/livekit.RoomService/ListRooms",
+        livekit_http_base(url)
+    );
+    let response = crate::http_client()
+        .post(endpoint)
+        .bearer_auth(token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .map_err(|error| error.to_string())?;
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        Err(format!("LiveKit ListRooms failed: {}", response.status()))
+    }
+}
+
 fn livekit_http_base(url: &str) -> String {
     url.trim_end_matches('/')
         .replacen("wss://", "https://", 1)

--- a/src/livekit.rs
+++ b/src/livekit.rs
@@ -892,6 +892,25 @@ fn is_participant_gone(error: &str) -> bool {
     error.contains("RemoveParticipant") && error.contains("404") && error.contains("not_found")
 }
 
+/// The Twirp POST both RoomService callers make. Only the token and the base
+/// differ, and both are strings; the body comes back with the status because a
+/// refusal explains itself there and not in the code.
+async fn post_room_service(
+    base: &str,
+    token: &str,
+    method: &str,
+    body: &serde_json::Value,
+) -> Result<(reqwest::StatusCode, String), Box<dyn std::error::Error + Send + Sync>> {
+    let response = crate::http_client()
+        .post(format!("{base}/twirp/livekit.RoomService/{method}"))
+        .bearer_auth(token)
+        .json(body)
+        .send()
+        .await?;
+    let status = response.status();
+    Ok((status, response.text().await?))
+}
+
 async fn livekit_room_service_request(
     config: &AgentConfig,
     room_name: &str,
@@ -905,18 +924,13 @@ async fn livekit_room_service_request(
         room_name,
         now_seconds,
     )?;
-    let url = format!(
-        "{}/twirp/livekit.RoomService/{method}",
-        livekit_http_base(&config.livekit_url)
-    );
-    let response = crate::http_client()
-        .post(url)
-        .bearer_auth(token)
-        .json(&body)
-        .send()
-        .await?;
-    let status = response.status();
-    let text = response.text().await?;
+    let (status, text) = post_room_service(
+        &livekit_http_base(&config.livekit_url),
+        &token,
+        method,
+        &body,
+    )
+    .await?;
     if !status.is_success() {
         return Err(format!("LiveKit RoomService {method} failed: {status} {text}").into());
     }
@@ -933,22 +947,32 @@ pub(crate) async fn validate_livekit_credentials(
 ) -> Result<(), String> {
     let token = crate::token::livekit_room_list_token(api_key, api_secret, now_seconds)
         .map_err(|error| error.to_string())?;
-    let endpoint = format!(
-        "{}/twirp/livekit.RoomService/ListRooms",
-        livekit_http_base(url)
-    );
-    let response = crate::http_client()
-        .post(endpoint)
-        .bearer_auth(token)
-        .json(&serde_json::json!({}))
-        .send()
-        .await
-        .map_err(|error| error.to_string())?;
-    if response.status().is_success() {
-        Ok(())
-    } else {
-        Err(format!("LiveKit ListRooms failed: {}", response.status()))
+    let (status, text) = post_room_service(
+        &livekit_http_base(url),
+        &token,
+        "ListRooms",
+        &serde_json::json!({}),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    if status.is_success() {
+        return Ok(());
     }
+
+    // The body, because it is LiveKit's own account of the refusal and the
+    // Setup form is the one place a reader can act on it: a status alone says
+    // "did not work" to someone who already knows that. Bounded, because a
+    // wrong host answers with an HTML page and the form is one line.
+    const REASON_LIMIT: usize = 200;
+    let reason: String = text.chars().take(REASON_LIMIT).collect();
+    let ellipsis = if text.chars().count() > REASON_LIMIT {
+        "..."
+    } else {
+        ""
+    };
+    Err(format!(
+        "LiveKit ListRooms failed: {status} {reason}{ellipsis}"
+    ))
 }
 
 /// The RoomService origin for a LiveKit URL: the same host, over the scheme an

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,8 +232,11 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     // Falls through: once `serve_setup` returns, the config exists and the rest
     // of this function is an ordinary launch, on the socket Setup served on.
     // Why that socket is carried here rather than rebound: `serve_setup`.
-    let handed_over = if is_cold_start(&options) {
-        Some(serve_setup(&options)?)
+    // Read once, so the question and the page it opens answer from the same
+    // map.
+    let before_config = environment_and_flags(&options);
+    let handed_over = if is_cold_start(&options, &before_config) {
+        Some(serve_setup(&before_config)?)
     } else {
         None
     };
@@ -408,16 +411,42 @@ fn web_provider_pool(
     Ok(pool)
 }
 
-/// The solo self-serve cold start: no `--config` given and none of the
-/// searched paths holds a file. A named-but-missing `--config` is an
-/// operator's mistake, not this.
+/// The solo self-serve cold start: no `--config` given, none of the searched
+/// paths holds a file, and the environment has not supplied the credentials
+/// either. A named-but-missing `--config` is an operator's mistake, not this.
 ///
 /// The search order comes from `primary_config_path` rather than being
 /// written out again here. Spelled twice it was free to drift, and the drift
 /// is silent in the worst direction: a Setup page in front of someone whose
 /// config the rest of the process is about to read.
-fn is_cold_start(options: &CliOptions) -> bool {
-    options.config_path.is_none() && primary_config_path(options).is_err()
+///
+/// The environment counts because a file is not the only way to be configured.
+/// A headless launch with `LIVEKIT_*` exported and no file used to exit naming
+/// the file it wanted, which is a failure someone reading a log can act on;
+/// asking it instead put a page nobody would open in front of a process that
+/// then waited forever. Only the LiveKit keys, because those are what the web
+/// side refuses to start without, and `GOOGLE_API_KEY` decides whether this
+/// process also hosts interviewers rather than whether it can run.
+fn is_cold_start(options: &CliOptions, values: &BTreeMap<String, String>) -> bool {
+    options.config_path.is_none()
+        && primary_config_path(options).is_err()
+        && !environment_supplies_credentials(values)
+}
+
+/// Whether this launch is already configured without a file.
+///
+/// Its own function so it can be asserted without a filesystem: `is_cold_start`
+/// reaches this only after the config search misses, and the search hits in any
+/// checkout that has a config, which is every machine a developer runs the
+/// suite on.
+///
+/// The LiveKit keys and not `GOOGLE_API_KEY`, because those three are what the
+/// web side refuses to start without. The Google key decides whether this
+/// process also hosts interviewers, which is a shape rather than a requirement.
+fn environment_supplies_credentials(values: &BTreeMap<String, String>) -> bool {
+    ["LIVEKIT_URL", "LIVEKIT_API_KEY", "LIVEKIT_API_SECRET"]
+        .iter()
+        .all(|key| nonempty(values, key).is_some())
 }
 
 /// Serves Setup until a submission writes `codetrial.env.local`, then returns
@@ -429,14 +458,8 @@ fn is_cold_start(options: &CliOptions) -> bool {
 /// connections this page just served, and `TIME_WAIT` outlasts any retry worth
 /// writing. The loser has already written the config, so it has also spent the
 /// cold start that would have brought Setup back.
-fn serve_setup(options: &CliOptions) -> Result<std::net::TcpListener, String> {
-    // The environment and the flags, which in a cold start is everything
-    // `load_values` has: the file it reads on top of them is the file that does
-    // not exist yet.
-    let mut values = std::env::vars().collect::<BTreeMap<_, _>>();
-    apply_options(&mut values, options);
-
-    let listener = bind_web_listener(&value_or(&values, "CODETRIAL_WEB_ADDR", DEFAULT_WEB_ADDR))?;
+fn serve_setup(values: &BTreeMap<String, String>) -> Result<std::net::TcpListener, String> {
+    let listener = bind_web_listener(&value_or(values, "CODETRIAL_WEB_ADDR", DEFAULT_WEB_ADDR))?;
 
     // Fails closed on an address the socket cannot name, for the reason
     // `run_web` does: an impossible kernel answer must not be the way past a
@@ -444,13 +467,13 @@ fn serve_setup(options: &CliOptions) -> Result<std::net::TcpListener, String> {
     let bound = listener
         .local_addr()
         .map_err(|error| format!("bound listener has no address to check: {error}"))?;
-    if let Some(refusal) = public_setup_refusal(&values, bound) {
+    if let Some(refusal) = public_setup_refusal(values, bound) {
         return Err(refusal);
     }
     // Everything `run_web` will refuse for that this already knows the answer
     // to. There is one such rule today; the rest of its checks need the pool
     // the submission has not supplied yet.
-    if let Some(refusal) = production_secret_refusal(&values) {
+    if let Some(refusal) = production_secret_refusal(values) {
         return Err(refusal);
     }
     // The window stays open now, but still needs to say where to go.
@@ -474,7 +497,7 @@ fn serve_setup(options: &CliOptions) -> Result<std::net::TcpListener, String> {
             let listener = tokio::net::TcpListener::from_std(listener)?;
             let service = codetrial::web::setup_service(
                 ready.clone(),
-                is_production(&values),
+                is_production(values),
                 bound.port(),
                 cold_start_config_path(),
             );
@@ -648,6 +671,20 @@ fn load_agent_config(options: &CliOptions) -> Result<AgentConfig, String> {
         &provider_order,
     );
     Ok(config)
+}
+
+/// The environment and the flags, which in a cold start is everything
+/// `load_values` has: the file it reads between them is the file that does not
+/// exist yet.
+///
+/// Its own function so `run_web` does not name the process environment. Reading
+/// a deployment key straight from it there is what
+/// `binary_web_reads_deployment_keys_from_the_config_file` refuses, because a
+/// key set in the config file was once silently a no-op.
+fn environment_and_flags(options: &CliOptions) -> BTreeMap<String, String> {
+    let mut values = std::env::vars().collect::<BTreeMap<_, _>>();
+    apply_options(&mut values, options);
+    values
 }
 
 fn load_values(options: &CliOptions) -> Result<BTreeMap<String, String>, String> {
@@ -1391,15 +1428,52 @@ mod tests {
             ..super::CliOptions::default()
         };
 
+        let empty = values(&[]);
         assert!(
-            !super::is_cold_start(&named(root.join("Cargo.toml"))),
+            !super::is_cold_start(&named(root.join("Cargo.toml")), &empty),
             "a config file that exists was named, so there is nothing to set up"
         );
         assert!(
-            !super::is_cold_start(&named(root.join("no-such-config.env"))),
+            !super::is_cold_start(&named(root.join("no-such-config.env")), &empty),
             "a config file that is missing was still named, and a name is an \
              instruction to read that file rather than an invitation to ask"
         );
+    }
+
+    /// Exported credentials are a configured launch, so there is nothing to ask
+    /// for. Asking anyway put a page nobody would open in front of a headless
+    /// start that then waited forever, where naming the missing file and
+    /// exiting was something a log could carry.
+    #[test]
+    fn exported_credentials_are_a_configured_launch() {
+        assert!(super::environment_supplies_credentials(&values(&[
+            ("LIVEKIT_URL", "wss://example"),
+            ("LIVEKIT_API_KEY", "key"),
+            ("LIVEKIT_API_SECRET", "secret"),
+        ])));
+
+        // One short of the set the web side refuses to start without, which is
+        // still a launch that has to be asked.
+        assert!(!super::environment_supplies_credentials(&values(&[
+            ("LIVEKIT_URL", "wss://example"),
+            ("LIVEKIT_API_KEY", "key"),
+        ])));
+
+        // Present and blank is missing, the way `nonempty` reads it everywhere
+        // else, and the way `read_config_file` would have written it back.
+        assert!(!super::environment_supplies_credentials(&values(&[
+            ("LIVEKIT_URL", "wss://example"),
+            ("LIVEKIT_API_KEY", "key"),
+            ("LIVEKIT_API_SECRET", "   "),
+        ])));
+
+        // The optional one is not part of the question.
+        assert!(super::environment_supplies_credentials(&values(&[
+            ("LIVEKIT_URL", "wss://example"),
+            ("LIVEKIT_API_KEY", "key"),
+            ("LIVEKIT_API_SECRET", "secret"),
+            ("GOOGLE_API_KEY", ""),
+        ])));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,11 @@ fn bind_web_listener(addr: &str) -> Result<std::net::TcpListener, String> {
 }
 
 fn run_web(options: CliOptions) -> Result<(), String> {
+    if is_cold_start(&options) {
+        // Falls through: once `serve_setup` returns, the config exists, so
+        // the rest of this function is an ordinary launch — same process.
+        serve_setup(&options)?;
+    }
     let values = load_values(&options)?;
 
     // The built-in default is a published string, so in production it is not a
@@ -385,6 +390,35 @@ fn web_provider_pool(
         &value_or(values, codetrial::config::PROVIDER_ORDER_KEY, ""),
     );
     Ok(pool)
+}
+
+/// The solo self-serve cold start: no `--config` given and none of the
+/// searched paths holds a file. A named-but-missing `--config` is an
+/// operator's mistake, not this.
+///
+/// The search order comes from `primary_config_path` rather than being
+/// written out again here. Spelled twice it was free to drift, and the drift
+/// is silent in the worst direction: a Setup page in front of someone whose
+/// config the rest of the process is about to read.
+fn is_cold_start(options: &CliOptions) -> bool {
+    options.config_path.is_none() && primary_config_path(options).is_err()
+}
+
+/// Serves Setup until a submission writes `codetrial.env.local`, then
+/// returns so `run_web` continues as an ordinary launch. Drop-and-rebind,
+/// not a swappable router: the gap is milliseconds, worth one retry.
+fn serve_setup(options: &CliOptions) -> Result<(), String> {
+    let listener = bind_web_listener(options.web_addr.as_deref().unwrap_or(DEFAULT_WEB_ADDR))?;
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
+    runtime
+        .block_on(async {
+            let ready = Arc::new(tokio::sync::Notify::new());
+            let listener = tokio::net::TcpListener::from_std(listener)?;
+            axum::serve(listener, codetrial::web::setup_service(ready.clone()))
+                .with_graceful_shutdown(async move { ready.notified().await })
+                .await
+        })
+        .map_err(|error| format!("web server failed: {error}"))
 }
 
 fn run_livekit(config: AgentConfig, room_name: &str) -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,17 +239,8 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     };
     let values = load_values(&options)?;
 
-    // The built-in default is a published string, so in production it is not a
-    // weak signing key, it is a known one. Refuse rather than mint forgeable
-    // session cookies.
-    if is_production(&values)
-        && value_or(&values, "SESSION_SECRET", DEFAULT_SESSION_SECRET) == DEFAULT_SESSION_SECRET
-    {
-        return Err(
-            "SESSION_SECRET must be set when NODE_ENV=production; the built-in \
-                    default is a published value that would let anyone forge a session cookie"
-                .to_string(),
-        );
+    if let Some(refusal) = production_secret_refusal(&values) {
+        return Err(refusal);
     }
     for warning in relaxed_for_local_use(&values) {
         eprintln!("{warning}");
@@ -456,6 +447,12 @@ fn serve_setup(options: &CliOptions) -> Result<std::net::TcpListener, String> {
     if let Some(refusal) = public_setup_refusal(&values, bound) {
         return Err(refusal);
     }
+    // Everything `run_web` will refuse for that this already knows the answer
+    // to. There is one such rule today; the rest of its checks need the pool
+    // the submission has not supplied yet.
+    if let Some(refusal) = production_secret_refusal(&values) {
+        return Err(refusal);
+    }
     // The window stays open now, but still needs to say where to go.
     println!("codetrial: open http://{bound} in your browser to continue setup");
     // Taken before `axum::serve` consumes the listener: this descriptor stays
@@ -487,6 +484,29 @@ fn serve_setup(options: &CliOptions) -> Result<std::net::TcpListener, String> {
         })
         .map_err(|error| format!("web server failed: {error}"))?;
     Ok(retained)
+}
+
+/// Why a production launch may not sign session cookies, or `None` where it
+/// may. The built-in default is a published string, so in production it is not
+/// a weak signing key, it is a known one.
+///
+/// A function rather than an inline check because `serve_setup` asks it too.
+/// The verdict needs nothing from the submission, and a check that could have
+/// been made before the page was served but is made after it has taken
+/// credentials, written them and answered 200 is a launch that exits with the
+/// config already on disk -- which is what stops the next launch being a cold
+/// start, so the page never comes back to say why.
+fn production_secret_refusal(values: &BTreeMap<String, String>) -> Option<String> {
+    if is_production(values)
+        && value_or(values, "SESSION_SECRET", DEFAULT_SESSION_SECRET) == DEFAULT_SESSION_SECRET
+    {
+        return Some(
+            "SESSION_SECRET must be set when NODE_ENV=production; the built-in \
+             default is a published value that would let anyone forge a session cookie"
+                .to_string(),
+        );
+    }
+    None
 }
 
 /// Why Setup may not serve on `bound`, or `None` where it may.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1283,6 +1283,32 @@ mod tests {
         }
     }
 
+    /// A `--config` that names nothing is an operator's mistake, which
+    /// `primary_config_path` reports by name. Reading it as a cold start
+    /// instead would answer a wrong path with a Setup page and write a second
+    /// config beside the one they meant. Both halves are asserted here because
+    /// the missing file is the only case where the two conditions disagree,
+    /// and it is a unit test rather than a spawned binary because a launch
+    /// that wrongly believes it is a cold start serves Setup and waits there.
+    #[test]
+    fn a_named_config_is_never_a_cold_start() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let named = |path: std::path::PathBuf| super::CliOptions {
+            config_path: Some(path.display().to_string()),
+            ..super::CliOptions::default()
+        };
+
+        assert!(
+            !super::is_cold_start(&named(root.join("Cargo.toml"))),
+            "a config file that exists was named, so there is nothing to set up"
+        );
+        assert!(
+            !super::is_cold_start(&named(root.join("no-such-config.env"))),
+            "a config file that is missing was still named, and a name is an \
+             instruction to read that file rather than an invitation to ask"
+        );
+    }
+
     #[test]
     fn bare_config_paths_discover_providers_from_the_current_directory() {
         let options = super::CliOptions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,6 +327,14 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     // Same reason `serve_setup` prints this: say where to go.
     println!("codetrial: open http://{bound} in your browser");
 
+    // Past every startup check, so whatever a previous run left in the log is
+    // no longer true. Written on failure and removed on none, the file outlives
+    // what it describes: someone fixes what it named, starts again, and the
+    // next thing to go wrong sends them back to a message from days ago. This
+    // is the only moment that can tell those apart, and the error text points
+    // at nothing else.
+    clear_web_error_log();
+
     // Whether this process also hosts interviewers. A full agent config, which
     // is a Gemini key on top of what the web side needs, means yes; without it
     // this is the web half of a split deployment and agents arrive from
@@ -580,8 +588,19 @@ fn public_setup_refusal(
 /// no working directory anyone chose, so the folder it was unpacked into is
 /// the one place its owner knows to look.
 fn log_web_error(error: &str) {
-    let path = codetrial::exe_dir().join("codetrial-error.log");
-    let _ = std::fs::write(path, format!("{error}\n"));
+    let _ = std::fs::write(web_error_log_path(), format!("{error}\n"));
+}
+
+/// Dropped once a launch is past everything that could have written one, so
+/// the file's presence means the last `web` start failed rather than that one
+/// ever did. Best-effort, like the write: a log that cannot be removed must
+/// not stop a server that is otherwise ready.
+fn clear_web_error_log() {
+    let _ = std::fs::remove_file(web_error_log_path());
+}
+
+fn web_error_log_path() -> std::path::PathBuf {
+    codetrial::exe_dir().join("codetrial-error.log")
 }
 
 fn run_livekit(config: AgentConfig, room_name: &str) -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,17 +79,18 @@ fn run_agent_command(args: &[String]) -> i32 {
         }));
         return 0;
     }
-    let (positionals, options) = match parse_agent_args(args) {
+    let (mut positionals, options) = match parse_agent_args(args) {
         Ok(parsed) => parsed,
         Err(error) => {
             eprintln!("{error}");
             return 2;
         }
     };
-    let Some(mode) = positionals.first().map(String::as_str) else {
-        eprintln!("usage: codetrial MODE [OPTIONS]");
-        return 2;
-    };
+    // No console survives to show a usage line on double-click; default to `web`.
+    if positionals.is_empty() {
+        positionals.push("web".to_string());
+    }
+    let mode = positionals[0].as_str();
     let Some(&(_, arity, usage, run)) = MODES.iter().find(|(name, ..)| *name == mode) else {
         // The names, not just the refusal. A mode that was removed reaches this
         // line as an ordinary typo, and "unknown agent mode: serve" on its own

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,17 @@ use codetrial::config::{
 };
 use codetrial::web::{RoomDispatcher, WebServerConfig};
 
-const DEFAULT_CONFIG_PATH: &str = "config/codetrial.env.local";
+/// One installation keeps its config file and its account database together in
+/// `config/`, under whichever root it was installed as: a checkout, or the
+/// folder a released binary was unpacked into. Beside the executable is not
+/// that root for a checkout -- the executable is in `target/`, which
+/// `make clean` deletes -- so the two are named separately and joined per case.
+const CONFIG_DIR: &str = "config";
+const CONFIG_FILE_NAME: &str = "codetrial.env.local";
+/// Tracked, so it exists in a checkout and in no release archive. That makes it
+/// the one thing that tells a `config/` belonging to this project apart from a
+/// directory of the same name that happens to sit where the binary was run.
+const CONFIG_EXAMPLE_NAME: &str = "codetrial.env.example";
 const DEFAULT_ACCOUNT_DB_PATH: &str = "codetrial.db";
 const DEFAULT_SESSION_SECRET: &str = "codetrial-local-session";
 
@@ -219,11 +229,14 @@ fn bind_web_listener(addr: &str) -> Result<std::net::TcpListener, String> {
 }
 
 fn run_web(options: CliOptions) -> Result<(), String> {
-    if is_cold_start(&options) {
-        // Falls through: once `serve_setup` returns, the config exists, so the
-        // rest of this function is an ordinary launch — same process.
-        serve_setup(&options)?;
-    }
+    // Falls through: once `serve_setup` returns, the config exists and the rest
+    // of this function is an ordinary launch, on the socket Setup served on.
+    // Why that socket is carried here rather than rebound: `serve_setup`.
+    let handed_over = if is_cold_start(&options) {
+        Some(serve_setup(&options)?)
+    } else {
+        None
+    };
     let values = load_values(&options)?;
 
     // The built-in default is a published string, so in production it is not a
@@ -275,7 +288,7 @@ fn run_web(options: CliOptions) -> Result<(), String> {
         github_client_id: nonempty(&values, "GITHUB_CLIENT_ID"),
         github_client_secret: nonempty(&values, "GITHUB_CLIENT_SECRET"),
         session_secret: Some(value_or(&values, "SESSION_SECRET", DEFAULT_SESSION_SECRET)),
-        db_path: Some(account_db_path(&values)),
+        db_path: Some(account_db_path(&values, &options)),
         github_oauth_base_url: None,
         github_api_base_url: None,
         room_prefix: value_or(&values, "CODETRIAL_ROOM_PREFIX", DEFAULT_ROOM_PREFIX),
@@ -289,7 +302,13 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     };
 
     initialize_accounts(&config)?;
-    let listener = bind_web_listener(&value_or(&values, "CODETRIAL_WEB_ADDR", DEFAULT_WEB_ADDR))?;
+    // The address is not re-read for a cold start: `serve_setup` read it from
+    // the same environment and flags, and the config file written since holds
+    // credentials, not `CODETRIAL_WEB_ADDR`.
+    let listener = match handed_over {
+        Some(listener) => listener,
+        None => bind_web_listener(&value_or(&values, "CODETRIAL_WEB_ADDR", DEFAULT_WEB_ADDR))?,
+    };
 
     // The other half of the `SESSION_SECRET` guard above, and the half that
     // does not depend on the operator having said anything.
@@ -392,7 +411,7 @@ fn web_provider_pool(
     extend_pool(
         &mut pool,
         production,
-        &provider_dir(options),
+        &config_dir(options),
         &value_or(values, codetrial::config::PROVIDER_ORDER_KEY, ""),
     );
     Ok(pool)
@@ -410,15 +429,19 @@ fn is_cold_start(options: &CliOptions) -> bool {
     options.config_path.is_none() && primary_config_path(options).is_err()
 }
 
-/// Serves Setup until a submission writes `codetrial.env.local`, then
-/// returns so `run_web` continues as an ordinary launch. Drop-and-rebind,
-/// not a swappable router: the gap is milliseconds, worth one retry.
-fn serve_setup(options: &CliOptions) -> Result<(), String> {
+/// Serves Setup until a submission writes `codetrial.env.local`, then returns
+/// the still-bound listener so `run_web` continues on it.
+///
+/// Handed over rather than rebound because of Windows, the platform this
+/// feature exists for: `bind` sets `SO_REUSEADDR` on Unix and deliberately not
+/// there, so a rebind has to win against the `TIME_WAIT` left by the
+/// connections this page just served, and `TIME_WAIT` outlasts any retry worth
+/// writing. The loser has already written the config, so it has also spent the
+/// cold start that would have brought Setup back.
+fn serve_setup(options: &CliOptions) -> Result<std::net::TcpListener, String> {
     // The environment and the flags, which in a cold start is everything
     // `load_values` has: the file it reads on top of them is the file that does
-    // not exist yet. Built the same way here so this listener and the one
-    // `run_web` binds a moment later cannot land on different addresses --
-    // `CODETRIAL_WEB_ADDR` in the environment used to reach only the second.
+    // not exist yet.
     let mut values = std::env::vars().collect::<BTreeMap<_, _>>();
     apply_options(&mut values, options);
 
@@ -435,17 +458,35 @@ fn serve_setup(options: &CliOptions) -> Result<(), String> {
     }
     // The window stays open now, but still needs to say where to go.
     println!("codetrial: open http://{bound} in your browser to continue setup");
+    // Taken before `axum::serve` consumes the listener: this descriptor stays
+    // open, so the port stays bound whatever the server does with its own.
+    let retained = listener
+        .try_clone()
+        .map_err(|error| format!("could not retain the Setup listener: {error}"))?;
+    // Re-asserted rather than assumed: whether a duplicate carries the flag
+    // `bind_web_listener` set is a per-platform answer, and `from_std` in
+    // `run_web` needs it true on this descriptor.
+    retained
+        .set_nonblocking(true)
+        .expect("retained web listener should become nonblocking");
+
     let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
     runtime
         .block_on(async {
             let ready = Arc::new(tokio::sync::Notify::new());
             let listener = tokio::net::TcpListener::from_std(listener)?;
-            let service = codetrial::web::setup_service(ready.clone(), is_production(&values));
+            let service = codetrial::web::setup_service(
+                ready.clone(),
+                is_production(&values),
+                bound.port(),
+                cold_start_config_path(),
+            );
             axum::serve(listener, service)
                 .with_graceful_shutdown(async move { ready.notified().await })
                 .await
         })
-        .map_err(|error| format!("web server failed: {error}"))
+        .map_err(|error| format!("web server failed: {error}"))?;
+    Ok(retained)
 }
 
 /// Why Setup may not serve on `bound`, or `None` where it may.
@@ -583,7 +624,7 @@ fn load_agent_config(options: &CliOptions) -> Result<AgentConfig, String> {
     extend_pool(
         &mut config.pool,
         production,
-        &provider_dir(options),
+        &config_dir(options),
         &provider_order,
     );
     Ok(config)
@@ -637,10 +678,15 @@ fn primary_config_path(options: &CliOptions) -> Result<PathBuf, String> {
     // A release binary is unpacked into a folder of its own and its config is
     // written there, so it has to be findable from a shortcut or a terminal
     // opened somewhere else, not only from a double-click.
+    //
+    // Within each of those two roots, `config/` before the bare filename. The
+    // bare ones are where a release used to keep its config and where an
+    // operator may still keep one; they are searched, not written.
     for path in [
-        PathBuf::from(DEFAULT_CONFIG_PATH),
-        PathBuf::from("codetrial.env.local"),
-        codetrial::exe_dir().join("codetrial.env.local"),
+        PathBuf::from(CONFIG_DIR).join(CONFIG_FILE_NAME),
+        PathBuf::from(CONFIG_FILE_NAME),
+        codetrial::exe_dir().join(CONFIG_DIR).join(CONFIG_FILE_NAME),
+        codetrial::exe_dir().join(CONFIG_FILE_NAME),
     ] {
         if path.is_file() {
             return Ok(path);
@@ -653,20 +699,27 @@ fn primary_config_path(options: &CliOptions) -> Result<PathBuf, String> {
     // sends them looking for a file they were never given. Naming what the file
     // must contain is an instruction both audiences can act on.
     Err(format!(
-        "required configuration file is missing: ./{DEFAULT_CONFIG_PATH}, \
-         ./codetrial.env.local, or codetrial.env.local beside the executable; \
-         write one with LIVEKIT_URL, LIVEKIT_API_KEY and LIVEKIT_API_SECRET \
-         (config/codetrial.env.example lists the optional keys in a checkout)"
+        "required configuration file is missing: ./{CONFIG_DIR}/{CONFIG_FILE_NAME}, \
+         ./{CONFIG_FILE_NAME}, or {CONFIG_DIR}/{CONFIG_FILE_NAME} beside the \
+         executable; write one with LIVEKIT_URL, LIVEKIT_API_KEY and \
+         LIVEKIT_API_SECRET ({CONFIG_DIR}/{CONFIG_EXAMPLE_NAME} lists the \
+         optional keys in a checkout)"
     ))
 }
 
-/// Providers live beside the config file the operator named, so
-/// `--config /etc/codetrial/prod.env` discovers
+/// The directory of the config file this launch actually read, which is where
+/// everything else belonging to the installation lives: the provider files it
+/// discovers, and the account database it writes.
+///
+/// So `--config /etc/codetrial/prod.env` discovers
 /// `/etc/codetrial/codetrial.env.<id>` rather than whatever `config/` happens
-/// to sit in the current directory. Both
-/// halves of a deployment are launched with the same `--config`, and that is
-/// what makes them agree on the pool.
-fn provider_dir(options: &CliOptions) -> PathBuf {
+/// to sit in the current directory. Both halves of a deployment are launched
+/// with the same `--config`, and that is what makes them agree on the pool.
+///
+/// The database is written here rather than read, which is the one asymmetry:
+/// a `--config` pointing somewhere a process may not write is a startup
+/// failure that names the directory, and `CODETRIAL_DB_PATH` is the way out.
+fn config_dir(options: &CliOptions) -> PathBuf {
     // The search order comes from primary_config_path rather than being written
     // out again here. Spelled twice, it was free to drift, and the drift is
     // silent: the server keeps reading its own config while the pool quietly
@@ -681,7 +734,7 @@ fn provider_dir(options: &CliOptions) -> PathBuf {
         .as_deref()
         .map(PathBuf::from)
         .or_else(|| primary_config_path(options).ok())
-        .unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH));
+        .unwrap_or_else(|| PathBuf::from(CONFIG_DIR).join(CONFIG_FILE_NAME));
     match path.parent() {
         // A bare filename has an empty parent, and its siblings are in the
         // working directory, not in `config/`.
@@ -930,12 +983,32 @@ fn value_or(values: &BTreeMap<String, String>, key: &str, default: &str) -> Stri
 
 /// One place decides where accounts live, because `web` and `serve` both open
 /// the same database and disagreeing about it would split a person's reports.
-fn account_db_path(values: &BTreeMap<String, String>) -> PathBuf {
-    PathBuf::from(value_or(
-        values,
-        "CODETRIAL_DB_PATH",
-        DEFAULT_ACCOUNT_DB_PATH,
-    ))
+///
+/// Beside the config file rather than in the working directory: the database
+/// has to be the same file on the next launch, and the directory a process was
+/// started from is not. It used to be a bare filename, which meant a launch
+/// from a shortcut or from another terminal found the config it wrote and then
+/// opened an empty database next to wherever it had been started.
+fn account_db_path(values: &BTreeMap<String, String>, options: &CliOptions) -> PathBuf {
+    match nonempty(values, "CODETRIAL_DB_PATH") {
+        Some(path) => PathBuf::from(path),
+        None => config_dir(options).join(DEFAULT_ACCOUNT_DB_PATH),
+    }
+}
+
+/// Where a cold start writes the config it just took, which is the same
+/// `config/` the search above looks in first for the root this is installed as.
+///
+/// A checkout is told apart by the template it ships, not by `config/` merely
+/// existing: a released binary run from a directory that happens to hold one
+/// would otherwise write the credentials there and lose them the moment it was
+/// next started from somewhere else.
+fn cold_start_config_path() -> PathBuf {
+    let in_checkout = PathBuf::from(CONFIG_DIR);
+    if in_checkout.join(CONFIG_EXAMPLE_NAME).is_file() {
+        return in_checkout.join(CONFIG_FILE_NAME);
+    }
+    codetrial::exe_dir().join(CONFIG_DIR).join(CONFIG_FILE_NAME)
 }
 
 #[cfg(test)]
@@ -1315,7 +1388,28 @@ mod tests {
             config_path: Some("prod.env".to_string()),
             ..Default::default()
         };
-        assert_eq!(super::provider_dir(&options), std::path::PathBuf::from("."));
+        assert_eq!(super::config_dir(&options), std::path::PathBuf::from("."));
+    }
+
+    /// The database is the config directory's, so a named config carries it
+    /// along rather than leaving it wherever the process was started.
+    #[test]
+    fn the_account_database_sits_beside_the_config_that_was_named() {
+        let options = super::CliOptions {
+            config_path: Some("/etc/codetrial/prod.env".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            super::account_db_path(&values(&[]), &options),
+            std::path::PathBuf::from("/etc/codetrial/codetrial.db")
+        );
+        assert_eq!(
+            super::account_db_path(
+                &values(&[("CODETRIAL_DB_PATH", "/srv/accounts.db")]),
+                &options
+            ),
+            std::path::PathBuf::from("/srv/accounts.db")
+        );
     }
 
     /// The pair, not the id. `login_config` enables OAuth only when it has

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,9 +231,8 @@ fn bind_web_listener(addr: &str) -> Result<std::net::TcpListener, String> {
 fn run_web(options: CliOptions) -> Result<(), String> {
     // Falls through: once `serve_setup` returns, the config exists and the rest
     // of this function is an ordinary launch, on the socket Setup served on.
-    // Why that socket is carried here rather than rebound: `serve_setup`.
-    // Read once, so the question and the page it opens answer from the same
-    // map.
+    // Why that socket is carried here rather than rebound: `serve_setup`. Read
+    // once, so the question and the page it opens answer from the same map.
     let before_config = environment_and_flags(&options);
     let handed_over = if is_cold_start(&options, &before_config) {
         Some(serve_setup(&before_config)?)
@@ -296,6 +295,7 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     };
 
     initialize_accounts(&config)?;
+
     // The address is not re-read for a cold start: `serve_setup` read it from
     // the same environment and flags, and the config file written since holds
     // credentials, not `CODETRIAL_WEB_ADDR`.
@@ -478,6 +478,7 @@ fn serve_setup(values: &BTreeMap<String, String>) -> Result<std::net::TcpListene
     if let Some(refusal) = public_setup_refusal(values, bound) {
         return Err(refusal);
     }
+
     // Everything `run_web` will refuse for that this already knows the answer
     // to. There is one such rule today; the rest of its checks need the pool
     // the submission has not supplied yet.
@@ -486,11 +487,13 @@ fn serve_setup(values: &BTreeMap<String, String>) -> Result<std::net::TcpListene
     }
     // The window stays open now, but still needs to say where to go.
     println!("codetrial: open http://{bound} in your browser to continue setup");
+
     // Taken before `axum::serve` consumes the listener: this descriptor stays
     // open, so the port stays bound whatever the server does with its own.
     let retained = listener
         .try_clone()
         .map_err(|error| format!("could not retain the Setup listener: {error}"))?;
+
     // Re-asserted rather than assumed: whether a duplicate carries the flag
     // `bind_web_listener` set is a per-platform answer, and `from_std` in
     // `run_web` needs it true on this descriptor.

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,8 @@ struct CliOptions {
 /// check is a mode that silently ignores its extra arguments.
 const MODES: [(&str, usize, &str, ModeFn); 3] = [
     ("web", 1, "codetrial web [OPTIONS]", |_, options| {
-        run_web(options)
+        // Logged for `web` only: `run-livekit`/`check-gemini` are terminal-run tooling.
+        run_web(options).inspect_err(|error| log_web_error(error))
     }),
     (
         "run-livekit",
@@ -425,6 +426,19 @@ fn serve_setup(options: &CliOptions) -> Result<(), String> {
                 .await
         })
         .map_err(|error| format!("web server failed: {error}"))
+}
+
+/// Any `web` failure, not just a cold-start one. No attempt to tell a solo
+/// user's config apart from an operator's — the error text already says
+/// what's wrong. Best-effort: must not shadow the real error.
+///
+/// Beside the executable, where the config it just failed to read also
+/// lives. A double-clicked binary has no console to leave the reason in and
+/// no working directory anyone chose, so the folder it was unpacked into is
+/// the one place its owner knows to look.
+fn log_web_error(error: &str) {
+    let path = codetrial::exe_dir().join("codetrial-error.log");
+    let _ = std::fs::write(path, format!("{error}\n"));
 }
 
 fn run_livekit(config: AgentConfig, room_name: &str) -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -507,9 +507,15 @@ fn primary_config_path(options: &CliOptions) -> Result<PathBuf, String> {
         }
         return Ok(path);
     }
+    // The working directory first, which is a checkout's `config/` and an
+    // operator's deployment directory, then the folder the executable sits in.
+    // A release binary is unpacked into a folder of its own and its config is
+    // written there, so it has to be findable from a shortcut or a terminal
+    // opened somewhere else, not only from a double-click.
     for path in [
         PathBuf::from(DEFAULT_CONFIG_PATH),
         PathBuf::from("codetrial.env.local"),
+        codetrial::exe_dir().join("codetrial.env.local"),
     ] {
         if path.is_file() {
             return Ok(path);
@@ -522,7 +528,8 @@ fn primary_config_path(options: &CliOptions) -> Result<PathBuf, String> {
     // sends them looking for a file they were never given. Naming what the file
     // must contain is an instruction both audiences can act on.
     Err(format!(
-        "required configuration file is missing: ./{DEFAULT_CONFIG_PATH} or ./codetrial.env.local; \
+        "required configuration file is missing: ./{DEFAULT_CONFIG_PATH}, \
+         ./codetrial.env.local, or codetrial.env.local beside the executable; \
          write one with LIVEKIT_URL, LIVEKIT_API_KEY and LIVEKIT_API_SECRET \
          (config/codetrial.env.example lists the optional keys in a checkout)"
     ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ const DEFAULT_CONFIG_PATH: &str = "config/codetrial.env.local";
 const DEFAULT_ACCOUNT_DB_PATH: &str = "codetrial.db";
 const DEFAULT_SESSION_SECRET: &str = "codetrial-local-session";
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct CliOptions {
     config_path: Option<String>,
     web_addr: Option<String>,
@@ -28,7 +28,8 @@ struct CliOptions {
 /// check is a mode that silently ignores its extra arguments.
 const MODES: [(&str, usize, &str, ModeFn); 3] = [
     ("web", 1, "codetrial web [OPTIONS]", |_, options| {
-        // Logged for `web` only: `run-livekit`/`check-gemini` are terminal-run tooling.
+        // Logged for `web` only: `run-livekit`/`check-gemini` are terminal-run
+        // tooling.
         run_web(options).inspect_err(|error| log_web_error(error))
     }),
     (
@@ -87,7 +88,9 @@ fn run_agent_command(args: &[String]) -> i32 {
             return 2;
         }
     };
-    // No console survives to show a usage line on double-click; default to `web`.
+
+    // No console survives to show a usage line on double-click; default to
+    // `web`.
     if positionals.is_empty() {
         positionals.push("web".to_string());
     }
@@ -217,8 +220,8 @@ fn bind_web_listener(addr: &str) -> Result<std::net::TcpListener, String> {
 
 fn run_web(options: CliOptions) -> Result<(), String> {
     if is_cold_start(&options) {
-        // Falls through: once `serve_setup` returns, the config exists, so
-        // the rest of this function is an ordinary launch — same process.
+        // Falls through: once `serve_setup` returns, the config exists, so the
+        // rest of this function is an ordinary launch — same process.
         serve_setup(&options)?;
     }
     let values = load_values(&options)?;
@@ -411,21 +414,78 @@ fn is_cold_start(options: &CliOptions) -> bool {
 /// returns so `run_web` continues as an ordinary launch. Drop-and-rebind,
 /// not a swappable router: the gap is milliseconds, worth one retry.
 fn serve_setup(options: &CliOptions) -> Result<(), String> {
-    let listener = bind_web_listener(options.web_addr.as_deref().unwrap_or(DEFAULT_WEB_ADDR))?;
-    // The window stays open now, but still needs to say where to go.
-    if let Ok(bound) = listener.local_addr() {
-        println!("codetrial: open http://{bound} in your browser to continue setup");
+    // The environment and the flags, which in a cold start is everything
+    // `load_values` has: the file it reads on top of them is the file that does
+    // not exist yet. Built the same way here so this listener and the one
+    // `run_web` binds a moment later cannot land on different addresses --
+    // `CODETRIAL_WEB_ADDR` in the environment used to reach only the second.
+    let mut values = std::env::vars().collect::<BTreeMap<_, _>>();
+    apply_options(&mut values, options);
+
+    let listener = bind_web_listener(&value_or(&values, "CODETRIAL_WEB_ADDR", DEFAULT_WEB_ADDR))?;
+
+    // Fails closed on an address the socket cannot name, for the reason
+    // `run_web` does: an impossible kernel answer must not be the way past a
+    // security guard.
+    let bound = listener
+        .local_addr()
+        .map_err(|error| format!("bound listener has no address to check: {error}"))?;
+    if let Some(refusal) = public_setup_refusal(&values, bound) {
+        return Err(refusal);
     }
+    // The window stays open now, but still needs to say where to go.
+    println!("codetrial: open http://{bound} in your browser to continue setup");
     let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
     runtime
         .block_on(async {
             let ready = Arc::new(tokio::sync::Notify::new());
             let listener = tokio::net::TcpListener::from_std(listener)?;
-            axum::serve(listener, codetrial::web::setup_service(ready.clone()))
+            let service = codetrial::web::setup_service(ready.clone(), is_production(&values));
+            axum::serve(listener, service)
                 .with_graceful_shutdown(async move { ready.notified().await })
                 .await
         })
         .map_err(|error| format!("web server failed: {error}"))
+}
+
+/// Why Setup may not serve on `bound`, or `None` where it may.
+///
+/// Setup writes LiveKit credentials to disk for whoever posts them and has
+/// nothing to authenticate that person with: on a cold start there is no
+/// config, no account database and no secret either side could have agreed on
+/// beforehand. What confines it is the listener, so the listener is what gets
+/// checked. Adding a password to the page would only be a second credential
+/// the same person has to be told over the same channel, and a cold start has
+/// no console to print it on.
+///
+/// The reachability test is `published_secret_refusal`'s, whose doc says why it
+/// is written this way and why a declared proxy counts.
+///
+/// Each reason names the one thing its reader can change, because the remedy
+/// for the two is not the same: an address is passed on the command line, a
+/// declared proxy is a variable in the environment, and "bind loopback" is no
+/// help to someone already on it.
+fn public_setup_refusal(
+    values: &BTreeMap<String, String>,
+    bound: std::net::SocketAddr,
+) -> Option<String> {
+    let reason = if !bound.ip().to_canonical().is_loopback() {
+        format!("it is bound to {bound}, which is not a loopback address")
+    } else if trusted_proxy_hops(values) > 0 {
+        "CODETRIAL_TRUSTED_PROXY_HOPS says something in front of it forwards \
+         requests from elsewhere"
+            .to_string()
+    } else {
+        return None;
+    };
+
+    Some(format!(
+        "refusing to serve the Setup page because {reason}: it takes LiveKit credentials \
+         from anyone who can reach it, over plain HTTP, and has nothing to authenticate \
+         them with. Serve it where only this machine can reach it, or write \
+         codetrial.env.local with LIVEKIT_URL, LIVEKIT_API_KEY and LIVEKIT_API_SECRET \
+         before starting."
+    ))
 }
 
 /// Any `web` failure, not just a cold-start one. No attempt to tell a solo
@@ -535,6 +595,17 @@ fn load_values(options: &CliOptions) -> Result<BTreeMap<String, String>, String>
     for (key, value) in codetrial::config::read_config_file(&path)? {
         values.insert(key, value);
     }
+    apply_options(&mut values, options);
+    Ok(values)
+}
+
+/// The flags, over whatever the environment and the config file said.
+///
+/// Split out because a cold start has to build the same map without the file
+/// it does not have yet: `serve_setup` decides where to bind and what a
+/// submission must survive, and both answers have to be the ones `run_web`
+/// will reach a moment later. Spelled twice, this precedence is free to drift.
+fn apply_options(values: &mut BTreeMap<String, String>, options: &CliOptions) {
     if let Some(value) = &options.web_addr {
         values.insert("CODETRIAL_WEB_ADDR".to_string(), value.clone());
     }
@@ -547,7 +618,6 @@ fn load_values(options: &CliOptions) -> Result<BTreeMap<String, String>, String>
     if let Some(value) = options.duration_min {
         values.insert("CODETRIAL_DURATION_MIN".to_string(), value.to_string());
     }
-    Ok(values)
 }
 
 fn primary_config_path(options: &CliOptions) -> Result<PathBuf, String> {
@@ -561,6 +631,7 @@ fn primary_config_path(options: &CliOptions) -> Result<PathBuf, String> {
         }
         return Ok(path);
     }
+
     // The working directory first, which is a checkout's `config/` and an
     // operator's deployment directory, then the folder the executable sits in.
     // A release binary is unpacked into a folder of its own and its config is
@@ -976,6 +1047,96 @@ mod tests {
             ),
             None,
             "no declared proxy is the local run the default exists for"
+        );
+    }
+
+    /// The precedence two launches depend on: a cold start builds this map
+    /// without a config file and has to reach the same address and the same
+    /// verdict `run_web` will reach with one. A flag overrides what was in the
+    /// environment; no flag leaves it alone.
+    #[test]
+    fn the_flags_override_the_environment_and_only_where_given() {
+        let mut values = values(&[
+            ("CODETRIAL_WEB_ADDR", "127.0.0.1:1"),
+            ("CODETRIAL_WEB_DIR", "env-dir"),
+            ("NODE_ENV", "production"),
+        ]);
+        super::apply_options(
+            &mut values,
+            &super::CliOptions {
+                web_addr: Some("127.0.0.1:2".to_string()),
+                room_prefix: Some("flag".to_string()),
+                duration_min: Some(45),
+                ..super::CliOptions::default()
+            },
+        );
+
+        assert_eq!(values["CODETRIAL_WEB_ADDR"], "127.0.0.1:2");
+        assert_eq!(values["CODETRIAL_ROOM_PREFIX"], "flag");
+        assert_eq!(values["CODETRIAL_DURATION_MIN"], "45");
+        assert_eq!(
+            values["CODETRIAL_WEB_DIR"], "env-dir",
+            "a flag that was not passed must not erase the environment"
+        );
+        assert_eq!(
+            values["NODE_ENV"], "production",
+            "and must not touch the rest"
+        );
+    }
+
+    /// Setup is confined to the same interface the published session secret is,
+    /// and for a sharper reason: this listener hands `codetrial.env.local` to
+    /// whoever posts to it. Unlike `published_secret_refusal` there is no value
+    /// an operator can set to lift it, so every address is tested against one
+    /// empty environment.
+    #[test]
+    fn the_setup_page_is_confined_to_loopback() {
+        for local in [
+            "127.0.0.1:3000",
+            "127.0.0.53:3000",
+            "[::1]:3000",
+            "[::ffff:127.0.0.1]:3000",
+        ] {
+            assert_eq!(
+                super::public_setup_refusal(&values(&[]), addr(local)),
+                None,
+                "{local} reaches no further than this machine"
+            );
+        }
+
+        for public in ["0.0.0.0:3000", "[::]:3000", "192.168.1.10:3000"] {
+            let refusal = super::public_setup_refusal(&values(&[]), addr(public))
+                .unwrap_or_else(|| panic!("{public} must be refused"));
+            assert!(refusal.contains(public), "{refusal}");
+            assert!(refusal.contains("codetrial.env.local"), "{refusal}");
+        }
+    }
+
+    /// The same admission that makes a loopback bind public for the session
+    /// secret makes it public for Setup: a tunnel or an nginx in front is how
+    /// the internet reaches 127.0.0.1.
+    #[test]
+    fn a_declared_proxy_closes_the_setup_page_too() {
+        let refusal = super::public_setup_refusal(
+            &values(&[("CODETRIAL_TRUSTED_PROXY_HOPS", "1")]),
+            addr("127.0.0.1:3000"),
+        )
+        .expect("loopback behind a declared proxy must be refused");
+
+        // The variable by name: it is the only thing the reader of this message
+        // can change, and the address they are on is already loopback.
+        assert!(
+            refusal.contains("CODETRIAL_TRUSTED_PROXY_HOPS"),
+            "{refusal}"
+        );
+
+        assert_eq!(
+            super::public_setup_refusal(
+                &values(&[("CODETRIAL_TRUSTED_PROXY_HOPS", "0")]),
+                addr("127.0.0.1:3000")
+            ),
+            None,
+            "no declared proxy is the solo cold start this page exists for"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,6 +307,8 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     if let Some(refusal) = published_secret_refusal(&values, bound) {
         return Err(refusal);
     }
+    // Same reason `serve_setup` prints this: say where to go.
+    println!("codetrial: open http://{bound} in your browser");
 
     // Whether this process also hosts interviewers. A full agent config, which
     // is a Gemini key on top of what the web side needs, means yes; without it
@@ -409,6 +411,10 @@ fn is_cold_start(options: &CliOptions) -> bool {
 /// not a swappable router: the gap is milliseconds, worth one retry.
 fn serve_setup(options: &CliOptions) -> Result<(), String> {
     let listener = bind_web_listener(options.web_addr.as_deref().unwrap_or(DEFAULT_WEB_ADDR))?;
+    // The window stays open now, but still needs to say where to go.
+    if let Ok(bound) = listener.local_addr() {
+        println!("codetrial: open http://{bound} in your browser to continue setup");
+    }
     let runtime = tokio::runtime::Runtime::new().expect("tokio runtime should start");
     runtime
         .block_on(async {

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,14 +553,13 @@ fn public_setup_refusal(
     values: &BTreeMap<String, String>,
     bound: std::net::SocketAddr,
 ) -> Option<String> {
-    let reason = if !bound.ip().to_canonical().is_loopback() {
-        format!("it is bound to {bound}, which is not a loopback address")
-    } else if trusted_proxy_hops(values) > 0 {
-        "CODETRIAL_TRUSTED_PROXY_HOPS says something in front of it forwards \
-         requests from elsewhere"
-            .to_string()
-    } else {
-        return None;
+    let reason = match reachable_from_elsewhere(values, bound)? {
+        Reachable::Address => {
+            format!("it is bound to {bound}, which is not a loopback address")
+        }
+        Reachable::DeclaredProxy => "CODETRIAL_TRUSTED_PROXY_HOPS says something in front of \
+             it forwards requests from elsewhere"
+            .to_string(),
     };
 
     Some(format!(
@@ -573,7 +572,7 @@ fn public_setup_refusal(
 }
 
 /// Any `web` failure, not just a cold-start one. No attempt to tell a solo
-/// user's config apart from an operator's — the error text already says
+/// user's config apart from an operator's: the error text already says
 /// what's wrong. Best-effort: must not shadow the real error.
 ///
 /// Beside the executable, where the config it just failed to read also
@@ -986,6 +985,36 @@ fn relaxed_for_local_use(values: &BTreeMap<String, String>) -> Vec<String> {
 /// `::1` and of nothing else: a dual-stack socket that landed on
 /// `::ffff:127.0.0.1`, which is a name for the same interface, would otherwise
 /// be refused an address only this machine can reach.
+/// How a listener on `bound` can be reached from somewhere other than this
+/// machine, or `None` where it cannot.
+///
+/// Shared, because two guards ask it and a third answer added to one of them
+/// would drift silently -- in the direction that leaves the page taking
+/// credentials open. What each guard says about it is not shared: the remedies
+/// differ, an address is passed on the command line and a declared proxy is a
+/// variable in the environment.
+enum Reachable {
+    /// The bind address is not loopback.
+    Address,
+    /// `CODETRIAL_TRUSTED_PROXY_HOPS` is the operator saying requests arrive
+    /// through something in front, which is the same admission: a server on
+    /// loopback behind nginx or a tunnel is as public as one on `0.0.0.0`.
+    DeclaredProxy,
+}
+
+fn reachable_from_elsewhere(
+    values: &BTreeMap<String, String>,
+    bound: std::net::SocketAddr,
+) -> Option<Reachable> {
+    if !bound.ip().to_canonical().is_loopback() {
+        Some(Reachable::Address)
+    } else if trusted_proxy_hops(values) > 0 {
+        Some(Reachable::DeclaredProxy)
+    } else {
+        None
+    }
+}
+
 fn published_secret_refusal(
     values: &BTreeMap<String, String>,
     bound: std::net::SocketAddr,
@@ -999,16 +1028,9 @@ fn published_secret_refusal(
         return None;
     }
 
-    // Two ways to be reachable, and the second is the one a bind address cannot
-    // see: a server on loopback behind nginx or a tunnel is as public as one on
-    // `0.0.0.0`. `CODETRIAL_TRUSTED_PROXY_HOPS` is the operator saying requests
-    // arrive through something in front, which is the same admission.
-    let reason = if !bound.ip().to_canonical().is_loopback() {
-        format!("bind {bound}")
-    } else if trusted_proxy_hops(values) > 0 {
-        "serve from behind a declared proxy".to_string()
-    } else {
-        return None;
+    let reason = match reachable_from_elsewhere(values, bound)? {
+        Reachable::Address => format!("bind {bound}"),
+        Reachable::DeclaredProxy => "serve from behind a declared proxy".to_string(),
     };
 
     Some(format!(

--- a/src/token.rs
+++ b/src/token.rs
@@ -137,6 +137,27 @@ pub fn livekit_room_admin_token(
     )
 }
 
+/// Validation-only: `roomList` proves the key works without needing a room,
+/// unlike `livekit_room_admin_token`.
+pub fn livekit_room_list_token(
+    api_key: &str,
+    api_secret: &str,
+    now_seconds: u64,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    sign_jwt(
+        api_secret,
+        &json!({
+            "iss": api_key,
+            "sub": "credential-check",
+            "nbf": now_seconds,
+            "exp": now_seconds + TOKEN_TTL_SECONDS,
+            "video": {
+                "roomList": true
+            }
+        }),
+    )
+}
+
 fn sign_jwt(
     api_secret: &str,
     claims: &Value,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -24,6 +24,7 @@ mod interviews;
 mod policy;
 mod pool;
 mod recordings;
+mod setup;
 mod token;
 
 // Flattened back into one namespace so the split is a file boundary and not an
@@ -39,6 +40,7 @@ pub use assets::static_file_meta;
 pub use auth::login_config;
 pub use interviews::REPLAY_RATE_LIMIT;
 use pool::{ProviderQuota, QuotaRefresher, spawn_provider_quota_refresher};
+pub use setup::setup_service;
 pub use token::{TOKEN_RATE_LIMIT, TokenConfig, TokenResponse, token_response};
 
 pub const MAX_BODY_BYTES: usize = 8 * 1024;

--- a/src/web/policy.rs
+++ b/src/web/policy.rs
@@ -193,13 +193,8 @@ pub(crate) fn livekit_cloud_domain(url: &str) -> Option<&'static str> {
 /// `/rtc/validate`.
 pub(crate) fn livekit_http_origin(url: &str) -> Option<String> {
     let origin = url_origin(url)?;
-    let (scheme, host) = origin.split_once("://")?;
-    let http = match scheme {
-        "wss" | "https" => "https",
-        "ws" | "http" => "http",
-        _ => return None,
-    };
-    Some(format!("{http}://{host}"))
+    let (scheme, _, http) = crate::config::livekit_scheme(&origin)?;
+    Some(format!("{http}{}", &origin[scheme.len()..]))
 }
 
 /// Scheme and authority, without pulling in a URL parser for one field. The

--- a/src/web/setup.rs
+++ b/src/web/setup.rs
@@ -1,0 +1,225 @@
+//! The solo self-serve cold start's Setup page: served instead of the full
+//! app when `run_web` finds no config file at all.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::Router;
+use axum::http::StatusCode;
+use axum::response::{Html, Response};
+use axum::routing::{get, post};
+use serde_json::{Value, json};
+use tokio::sync::Notify;
+
+use crate::config::load_from_pairs;
+use crate::gemini::{gemini_live_websocket_url, open_live_session_at};
+use crate::runtime::bootstrap;
+
+/// Notified on a successful submission: the caller's shutdown signal to
+/// drop this listener and rebind as the full app.
+pub fn setup_service(ready: Arc<Notify>) -> Router {
+    Router::new()
+        .route("/healthz", get(|| async { "ok\n" }))
+        .route("/", get(setup_page))
+        .route(
+            "/api/setup",
+            post(move |body| submit_setup(body, ready.clone())),
+        )
+}
+
+async fn setup_page() -> Html<&'static str> {
+    Html(SETUP_PAGE)
+}
+
+/// Field `name`s are the contract with `submit_setup`'s JSON keys. Inline,
+/// not a `web/` file: served before any config exists, outside the embedded
+/// asset tree.
+const SETUP_PAGE: &str = r#"<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>codetrial Setup</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 32rem; margin: 2rem auto; padding: 0 1rem; }
+  label { display: block; margin-top: 1rem; font-weight: 600; }
+  input { display: block; width: 100%; margin-top: .25rem; padding: .4rem; box-sizing: border-box; }
+  small { display: block; color: #555; margin-top: .15rem; }
+  button { margin-top: 1.5rem; padding: .5rem 1rem; }
+  #status { margin-top: 1rem; white-space: pre-wrap; }
+  #status.error { color: #b00020; }
+  #status.ok { color: #0a7a2f; }
+</style>
+</head>
+<body>
+<h1>Setup</h1>
+<p>Enter your LiveKit and Google credentials to get started.</p>
+<form id="setup-form">
+  <label for="livekitUrl">LiveKit URL</label>
+  <input id="livekitUrl" name="livekitUrl" type="text" placeholder="wss://your-project.livekit.cloud" required>
+  <small>From your project at <a href="https://cloud.livekit.io" target="_blank" rel="noopener">cloud.livekit.io</a>.</small>
+
+  <label for="livekitApiKey">LiveKit API Key</label>
+  <input id="livekitApiKey" name="livekitApiKey" type="text" required>
+
+  <label for="livekitApiSecret">LiveKit API Secret</label>
+  <input id="livekitApiSecret" name="livekitApiSecret" type="password" required>
+  <small>Both come from the same project's Keys page.</small>
+
+  <label for="googleApiKey">Google API Key</label>
+  <input id="googleApiKey" name="googleApiKey" type="password">
+  <small>From <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener">aistudio.google.com</a>.</small>
+
+  <button type="submit">Save and continue</button>
+</form>
+<div id="status"></div>
+<script>
+  const form = document.getElementById('setup-form');
+  const status = document.getElementById('status');
+
+  async function waitForRestart() {
+    // Server rebinds after success; poll instead of reloading once so the gap is invisible.
+    for (let attempt = 0; attempt < 40; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      try {
+        const probe = await fetch('/healthz', { cache: 'no-store' });
+        if (probe.ok) break;
+      } catch (error) {
+        // keep polling
+      }
+    }
+    location.reload();
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    status.className = '';
+    status.textContent = 'Checking credentials…';
+    const data = Object.fromEntries(new FormData(form).entries());
+    let response;
+    try {
+      response = await fetch('/api/setup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+    } catch (error) {
+      status.className = 'error';
+      status.textContent = 'Request failed: ' + error;
+      return;
+    }
+    const body = await response.json().catch(() => ({}));
+    if (response.ok) {
+      status.className = 'ok';
+      status.textContent = 'Saved. Starting codetrial…';
+      waitForRestart();
+    } else {
+      status.className = 'error';
+      status.textContent = body.error || ('Request failed: ' + response.status);
+    }
+  });
+</script>
+</body>
+</html>
+"#;
+
+/// Writes `codetrial.env.local` into the executable's own folder, which is
+/// the last path `primary_config_path` searches: the file has to be found
+/// again on the next launch, and that folder is the one thing about a
+/// double-clicked binary that does not depend on where it was started from.
+/// Parsed as `Value`, not a derived struct — this crate has no `serde`
+/// derive dependency, and a missing field reads as empty rather than a
+/// parse error.
+async fn submit_setup(Json(submission): Json<Value>, ready: Arc<Notify>) -> Response {
+    let field = |key: &str| {
+        submission
+            .get(key)
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string()
+    };
+
+    // Field order, so the first missing one is reported. `googleApiKey` is
+    // optional here, same as an operator's config file: empty means web-only,
+    // no interviewer hosted by this process.
+    for key in ["livekitUrl", "livekitApiKey", "livekitApiSecret"] {
+        if field(key).is_empty() {
+            return super::json_response(
+                StatusCode::BAD_REQUEST,
+                json!({ "error": format!("{key} is required") }),
+            );
+        }
+    }
+
+    let livekit_url = field("livekitUrl");
+    let livekit_api_key = field("livekitApiKey");
+    let livekit_api_secret = field("livekitApiSecret");
+    let google_api_key = field("googleApiKey");
+
+    if let Err(error) = crate::livekit::validate_livekit_credentials(
+        &livekit_url,
+        &livekit_api_key,
+        &livekit_api_secret,
+        crate::current_epoch_seconds(),
+    )
+    .await
+    {
+        return super::json_response(
+            StatusCode::BAD_REQUEST,
+            json!({
+                "error": format!(
+                    "livekitUrl, livekitApiKey or livekitApiSecret did not work: {error}"
+                )
+            }),
+        );
+    }
+
+    if !google_api_key.is_empty() {
+        let pairs = [
+            ("LIVEKIT_URL", livekit_url.clone()),
+            ("LIVEKIT_API_KEY", livekit_api_key.clone()),
+            ("LIVEKIT_API_SECRET", livekit_api_secret.clone()),
+            ("GOOGLE_API_KEY", google_api_key.clone()),
+        ];
+        let config = match load_from_pairs(pairs) {
+            Ok(config) => config,
+            Err(error) => {
+                return super::json_response(
+                    StatusCode::BAD_REQUEST,
+                    json!({ "error": error.to_string() }),
+                );
+            }
+        };
+
+        // Same proof as `check-gemini`: open a real session. `CODETRIAL_GEMINI_LIVE_URL`
+        // lets tests redirect this away from the real endpoint.
+        let room_name = format!("{}-smoke", config.room_prefix);
+        let boot = bootstrap(&config, &room_name, None, config.default_duration_min);
+        let url = std::env::var("CODETRIAL_GEMINI_LIVE_URL")
+            .unwrap_or_else(|_| gemini_live_websocket_url(&config.google_api_key));
+        match open_live_session_at(&url, &boot, None).await {
+            Ok(session) => {
+                let _ = session.close().await;
+            }
+            Err(error) => {
+                return super::json_response(
+                    StatusCode::BAD_REQUEST,
+                    json!({ "error": format!("googleApiKey did not work: {error}") }),
+                );
+            }
+        }
+    }
+
+    let contents = format!(
+        "LIVEKIT_URL={livekit_url}\nLIVEKIT_API_KEY={livekit_api_key}\nLIVEKIT_API_SECRET={livekit_api_secret}\nGOOGLE_API_KEY={google_api_key}\n",
+    );
+    let path = crate::exe_dir().join("codetrial.env.local");
+    if let Err(error) = std::fs::write(&path, contents) {
+        return super::json_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            json!({ "error": format!("could not write {}: {error}", path.display()) }),
+        );
+    }
+    // Only reached once the file is on disk; tells the caller to rebind as the full app.
+    ready.notify_one();
+    super::json_response(StatusCode::OK, json!({ "saved": true }))
+}

--- a/src/web/setup.rs
+++ b/src/web/setup.rs
@@ -201,7 +201,7 @@ const SETUP_PAGE: &str = r#"<!doctype html>
 /// for: the file has to be found again on the next launch, from whatever
 /// directory that launch happens to start in.
 ///
-/// Parsed as `Value`, not a derived struct — this crate has no `serde`
+/// Parsed as `Value`, not a derived struct: this crate has no `serde`
 /// derive dependency, and a missing field reads as empty rather than a
 /// parse error.
 async fn submit_setup(
@@ -369,10 +369,14 @@ async fn submit_setup(
                 let _ = session.close().await;
             }
             Err(error) => {
-                return super::json_response(
-                    StatusCode::BAD_REQUEST,
-                    json!({ "error": format!("googleApiKey did not work: {error}") }),
+                // Redacted like every other caller of this chain. The close
+                // frame's reason is folded in at the bottom of it, so the text
+                // here is partly Gemini's, and the key was sent in the URL.
+                let reason = crate::gemini::redact_api_key(
+                    &format!("googleApiKey did not work: {error}"),
+                    &google_api_key,
                 );
+                return super::json_response(StatusCode::BAD_REQUEST, json!({ "error": reason }));
             }
         }
     }

--- a/src/web/setup.rs
+++ b/src/web/setup.rs
@@ -77,6 +77,7 @@ fn host_is_loopback(host: Option<&HeaderValue>, port: u16) -> bool {
     let Some(host) = host.and_then(|value| value.to_str().ok()) else {
         return false;
     };
+
     // An IPv6 literal is bracketed, so a colon inside the brackets is not the
     // port separator.
     let (name, host_port) = match host.rsplit_once(':') {
@@ -85,6 +86,7 @@ fn host_is_loopback(host: Option<&HeaderValue>, port: u16) -> bool {
     };
     let port_matches = match host_port {
         Some(digits) => digits.parse::<u16>() == Ok(port),
+
         // A browser omits the port only for the scheme's default, and this page
         // is plain HTTP.
         None => port == 80,
@@ -276,12 +278,13 @@ async fn submit_setup(
                 json!({ "error": format!("{key} must not contain control characters") }),
             );
         }
-        // `read_config_file` does `trim_matches('"')` then `trim_matches('\'')`,
-        // so a value edged with either is probed as one string and loaded as
-        // another. Refused rather than written, for the reason the newline
-        // above is: this file format cannot carry the value, and answering 200
-        // would mean the file does not hold what was checked. Refusing says so
-        // while there is still a form to say it in.
+
+        // `read_config_file` does `trim_matches('"')` then
+        // `trim_matches('\'')`, so a value edged with either is probed as one
+        // string and loaded as another. Refused rather than written, for the
+        // reason the newline above is: this file format cannot carry the value,
+        // and answering 200 would mean the file does not hold what was checked.
+        // Refusing says so while there is still a form to say it in.
         if let Some(edge) = ['"', '\'']
             .into_iter()
             .find(|quote| field(key).starts_with(*quote) || field(key).ends_with(*quote))
@@ -401,6 +404,7 @@ async fn submit_setup(
         .iter()
         .map(|(key, value)| format!("{key}={value}\n"))
         .collect::<String>();
+
     // The directory is the caller's answer, and a released binary's copy of it
     // does not exist until the first submission.
     if let Some(parent) = path.parent()
@@ -411,6 +415,7 @@ async fn submit_setup(
             json!({ "error": format!("could not create {}: {error}", parent.display()) }),
         );
     }
+
     // `create_new`, so an existing name is reported rather than followed and
     // truncated. `is_cold_start` reached this page by finding no config, and
     // the `is_file` it asked answers no for a symlink with nothing at the end
@@ -503,5 +508,9 @@ mod tests {
         assert!(host_is_loopback(Some(&host("localhost")), 80));
         assert!(host_is_loopback(Some(&host("localhost:80")), 80));
         assert!(!host_is_loopback(Some(&host("localhost")), 3000));
+
+        // The bracket guard's case: the last colon of `[::1]` is inside the
+        // brackets, and reading it as the separator refuses a real browser.
+        assert!(host_is_loopback(Some(&host("[::1]")), 80));
     }
 }

--- a/src/web/setup.rs
+++ b/src/web/setup.rs
@@ -210,11 +210,22 @@ async fn submit_setup(
     production: bool,
     path: PathBuf,
 ) -> Response {
+    // Trimmed here, once, because everything downstream assumes it was. A
+    // pasted URL keeps its leading space through `validate_livekit_url`, which
+    // trims to decide and hands the original on, and `livekit_scheme` then
+    // matches at offset 0 and rewrites nothing: working credentials come back
+    // as "did not work". A key with a trailing space is signed into the JWT
+    // verbatim and refused, though the same value hand-written into the config
+    // file works, because `read_config_file` trims what it reads. And a
+    // `googleApiKey` of spaces is not empty to `is_empty`, so it takes the
+    // branch that probes Gemini and fails there for a field the form calls
+    // optional.
     let field = |key: &str| {
         submission
             .get(key)
             .and_then(Value::as_str)
             .unwrap_or("")
+            .trim()
             .to_string()
     };
 
@@ -222,10 +233,11 @@ async fn submit_setup(
     // optional here, same as an operator's config file: empty means web-only,
     // no interviewer hosted by this process.
     for key in ["livekitUrl", "livekitApiKey", "livekitApiSecret"] {
-        // Trimmed, because `read_config_file` trims when it reads this back and
-        // `nonempty` then calls it missing: a value of spaces would be accepted
-        // here, written, and refused by the launch this page hands over to.
-        if field(key).trim().is_empty() {
+        // A value of spaces is empty by now, which is what it has to be:
+        // `read_config_file` trims when it reads this back and `nonempty` then
+        // calls it missing, so accepting one here would write a file the launch
+        // on the other side of this page refuses.
+        if field(key).is_empty() {
             return super::json_response(
                 StatusCode::BAD_REQUEST,
                 json!({ "error": format!("{key} is required") }),
@@ -261,12 +273,21 @@ async fn submit_setup(
     // The keys this submission becomes, in the order the file below writes
     // them. One list: what the launch is asked about has to be what gets
     // written, or the answer was about a different config.
-    let pairs = [
+    //
+    // A blank `googleApiKey` leaves the key out rather than writing it empty.
+    // `read_config_file` keeps an empty value, and `load_values` lays file
+    // pairs over the environment, so the line would erase a `GOOGLE_API_KEY`
+    // the operator had exported and drop the process to web-only -- announced
+    // on a console a double-clicked binary does not have. A hand-written config
+    // omits the key to defer to the environment, and this writes the same file.
+    let mut pairs = vec![
         ("LIVEKIT_URL", livekit_url.as_str()),
         ("LIVEKIT_API_KEY", livekit_api_key.as_str()),
         ("LIVEKIT_API_SECRET", livekit_api_secret.as_str()),
-        ("GOOGLE_API_KEY", google_api_key.as_str()),
     ];
+    if !google_api_key.is_empty() {
+        pairs.push(("GOOGLE_API_KEY", google_api_key.as_str()));
+    }
 
     // The rule the launch on the other side of this page applies to the URL,
     // applied while there is still a form to report it in. Without it a URL
@@ -305,7 +326,7 @@ async fn submit_setup(
     }
 
     if !google_api_key.is_empty() {
-        let config = match load_from_pairs(pairs) {
+        let config = match load_from_pairs(pairs.iter().copied()) {
             Ok(config) => config,
             Err(error) => {
                 return super::json_response(

--- a/src/web/setup.rs
+++ b/src/web/setup.rs
@@ -1,11 +1,14 @@
 //! The solo self-serve cold start's Setup page: served instead of the full
 //! app when `run_web` finds no config file at all.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::Json;
 use axum::Router;
-use axum::http::StatusCode;
+use axum::extract::Request;
+use axum::http::{HeaderValue, StatusCode, header};
+use axum::middleware::{self, Next};
 use axum::response::{Html, Response};
 use axum::routing::{get, post};
 use serde_json::{Value, json};
@@ -15,19 +18,76 @@ use crate::config::load_from_pairs;
 use crate::gemini::{gemini_live_websocket_url, open_live_session_at};
 use crate::runtime::bootstrap;
 
-/// Notified on a successful submission: the caller's shutdown signal to
-/// drop this listener and rebind as the full app.
+/// Notified on a successful submission: the caller's shutdown signal to stop
+/// serving Setup and continue as the full app on the same socket.
 ///
 /// `production` is the caller's, not one read here. The launch this hands over
 /// to enforces the production rules on the file this writes, and a second
 /// reading of `NODE_ENV` is a second answer waiting to disagree with it.
-pub fn setup_service(ready: Arc<Notify>, production: bool) -> Router {
+///
+/// `port` is the one the listener bound, which is what a `Host` has to name.
+/// `config_path` is where a submission is written, decided by the caller: the
+/// rest of the path rules live there and a second answer here could disagree
+/// with the search the next launch performs.
+pub fn setup_service(
+    ready: Arc<Notify>,
+    production: bool,
+    port: u16,
+    config_path: PathBuf,
+) -> Router {
     Router::new()
         .route("/healthz", get(|| async { "ok\n" }))
         .route("/", get(setup_page))
         .route(
             "/api/setup",
-            post(move |body| submit_setup(body, ready.clone(), production)),
+            post(move |body| submit_setup(body, ready.clone(), production, config_path.clone())),
+        )
+        .layer(middleware::from_fn(
+            move |request: Request, next: Next| async move {
+                if host_is_loopback(request.headers().get(header::HOST), port) {
+                    next.run(request).await
+                } else {
+                    super::json_response(
+                        StatusCode::FORBIDDEN,
+                        json!({
+                            "error": "Setup answers only to a loopback Host. Open it at the \
+                                      address the console printed."
+                        }),
+                    )
+                }
+            },
+        ))
+}
+
+/// The `Host` a browser sends for a loopback origin on `port`, and nothing
+/// else.
+///
+/// The loopback bind keeps the network out, not a browser. Any origin can give
+/// a name a short TTL, repoint it at 127.0.0.1 after the first load and POST
+/// here as same origin, which skips the preflight `Content-Type:
+/// application/json` would otherwise force. That submission writes the
+/// attacker's own LiveKit project into the config every later interview routes
+/// through, and the rebound name is the one thing the request still carries.
+fn host_is_loopback(host: Option<&HeaderValue>, port: u16) -> bool {
+    let Some(host) = host.and_then(|value| value.to_str().ok()) else {
+        return false;
+    };
+    // An IPv6 literal is bracketed, so a colon inside the brackets is not the
+    // port separator.
+    let (name, host_port) = match host.rsplit_once(':') {
+        Some((name, digits)) if !digits.contains(']') => (name, Some(digits)),
+        _ => (host, None),
+    };
+    let port_matches = match host_port {
+        Some(digits) => digits.parse::<u16>() == Ok(port),
+        // A browser omits the port only for the scheme's default, and this page
+        // is plain HTTP.
+        None => port == 80,
+    };
+    port_matches
+        && matches!(
+            name.to_ascii_lowercase().as_str(),
+            "localhost" | "127.0.0.1" | "[::1]"
         )
 }
 
@@ -73,17 +133,19 @@ const SETUP_PAGE: &str = r#"<!doctype html>
   <input id="googleApiKey" name="googleApiKey" type="password">
   <small>From <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener">aistudio.google.com</a>.</small>
 
-  <button type="submit">Save and continue</button>
+  <button id="submit" type="submit">Save and continue</button>
 </form>
 <div id="status"></div>
 <script>
   const form = document.getElementById('setup-form');
   const status = document.getElementById('status');
+  const submit = document.getElementById('submit');
 
   async function waitForRestart() {
-    // Server rebinds after success; poll instead of reloading once so the gap is invisible.
-    // /api/session and not /healthz: this page's own server answers /healthz too, so a
-    // probe that beats its shutdown would reload into the gap before the app has bound.
+    // The server keeps the port and swaps what answers on it, so a request landing in
+    // the handover waits in the accept backlog rather than failing. Poll anyway: the
+    // gap is not zero. /api/session and not /healthz, because this page's own server
+    // answers /healthz too and a probe that beats its shutdown reloads into the gap.
     for (let attempt = 0; attempt < 40; attempt++) {
       await new Promise((resolve) => setTimeout(resolve, 250));
       try {
@@ -98,6 +160,11 @@ const SETUP_PAGE: &str = r#"<!doctype html>
 
   form.addEventListener('submit', async (event) => {
     event.preventDefault();
+    // A second submission would reach a config file the first one has already
+    // written, and the write refuses to overwrite: the double-click would report
+    // a failure over a setup that worked. Re-enabled only where the form is
+    // still the way forward, which a successful submission is not.
+    submit.disabled = true;
     status.className = '';
     status.textContent = 'Checking credentials…';
     const data = Object.fromEntries(new FormData(form).entries());
@@ -111,6 +178,7 @@ const SETUP_PAGE: &str = r#"<!doctype html>
     } catch (error) {
       status.className = 'error';
       status.textContent = 'Request failed: ' + error;
+      submit.disabled = false;
       return;
     }
     const body = await response.json().catch(() => ({}));
@@ -121,6 +189,7 @@ const SETUP_PAGE: &str = r#"<!doctype html>
     } else {
       status.className = 'error';
       status.textContent = body.error || ('Request failed: ' + response.status);
+      submit.disabled = false;
     }
   });
 </script>
@@ -128,10 +197,10 @@ const SETUP_PAGE: &str = r#"<!doctype html>
 </html>
 "#;
 
-/// Writes `codetrial.env.local` into the executable's own folder, which is
-/// the last path `primary_config_path` searches: the file has to be found
-/// again on the next launch, and that folder is the one thing about a
-/// double-clicked binary that does not depend on where it was started from.
+/// Writes the config to `config_path`, which `primary_config_path` searches
+/// for: the file has to be found again on the next launch, from whatever
+/// directory that launch happens to start in.
+///
 /// Parsed as `Value`, not a derived struct — this crate has no `serde`
 /// derive dependency, and a missing field reads as empty rather than a
 /// parse error.
@@ -139,6 +208,7 @@ async fn submit_setup(
     Json(submission): Json<Value>,
     ready: Arc<Notify>,
     production: bool,
+    path: PathBuf,
 ) -> Response {
     let field = |key: &str| {
         submission
@@ -272,16 +342,107 @@ async fn submit_setup(
         .iter()
         .map(|(key, value)| format!("{key}={value}\n"))
         .collect::<String>();
-    let path = crate::exe_dir().join("codetrial.env.local");
-    if let Err(error) = std::fs::write(&path, contents) {
+    // The directory is the caller's answer, and a released binary's copy of it
+    // does not exist until the first submission.
+    if let Some(parent) = path.parent()
+        && let Err(error) = std::fs::create_dir_all(parent)
+    {
         return super::json_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            json!({ "error": format!("could not write {}: {error}", path.display()) }),
+            json!({ "error": format!("could not create {}: {error}", parent.display()) }),
+        );
+    }
+    // `create_new`, so an existing name is reported rather than followed and
+    // truncated. `is_cold_start` reached this page by finding no config, and
+    // the `is_file` it asked answers no for a symlink with nothing at the end
+    // of it: without `O_EXCL` a dangling one planted here sends these
+    // credentials wherever it points.
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        // Otherwise the umask decides, and its usual answer is world-readable.
+        // This file holds `LIVEKIT_API_SECRET` and `GOOGLE_API_KEY`. Windows
+        // has no equivalent here and inherits the folder's ACL.
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let written = options
+        .open(&path)
+        .and_then(|mut file| std::io::Write::write_all(&mut file, contents.as_bytes()));
+    if let Err(error) = written {
+        let reason = if error.kind() == std::io::ErrorKind::AlreadyExists {
+            format!(
+                "{} already exists; move it aside and reload",
+                path.display()
+            )
+        } else {
+            format!("could not write {}: {error}", path.display())
+        };
+        return super::json_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            json!({ "error": reason }),
         );
     }
 
-    // Only reached once the file is on disk; tells the caller to rebind as the
-    // full app.
+    // Only reached once the file is on disk; tells the caller to stop serving
+    // Setup and continue as the full app.
     ready.notify_one();
     super::json_response(StatusCode::OK, json!({ "saved": true }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::host_is_loopback;
+    use axum::http::HeaderValue;
+
+    fn host(value: &str) -> HeaderValue {
+        HeaderValue::from_str(value).expect("a test Host should be a header value")
+    }
+
+    #[test]
+    fn a_loopback_host_naming_the_bound_port_is_accepted() {
+        for value in [
+            "127.0.0.1:3000",
+            "localhost:3000",
+            "[::1]:3000",
+            "LocalHost:3000",
+        ] {
+            assert!(host_is_loopback(Some(&host(value)), 3000), "{value}");
+        }
+    }
+
+    /// The rebinding case: the name is the attacker's, the port is ours, and
+    /// the port is the half that matches.
+    #[test]
+    fn a_host_that_is_not_a_loopback_name_is_refused() {
+        for value in [
+            "codetrial.example:3000",
+            "127.0.0.1.codetrial.example:3000",
+            "localhost.codetrial.example:3000",
+        ] {
+            assert!(!host_is_loopback(Some(&host(value)), 3000), "{value}");
+        }
+    }
+
+    /// A `Host` is only missing or portless from something that is not the
+    /// browser this page was opened in, since the console printed the port.
+    #[test]
+    fn a_missing_or_mismatched_port_is_refused() {
+        assert!(!host_is_loopback(None, 3000));
+        assert!(!host_is_loopback(Some(&host("127.0.0.1")), 3000));
+        assert!(!host_is_loopback(Some(&host("127.0.0.1:3001")), 3000));
+        assert!(!host_is_loopback(Some(&host("[::1]")), 3000));
+        assert!(!host_is_loopback(Some(&host("127.0.0.1:")), 3000));
+    }
+
+    /// Port 80 is the one a browser leaves out of the `Host`, so it is the one
+    /// case where a portless value is the real thing rather than a hand-written
+    /// request.
+    #[test]
+    fn the_default_http_port_is_accepted_without_one() {
+        assert!(host_is_loopback(Some(&host("localhost")), 80));
+        assert!(host_is_loopback(Some(&host("localhost:80")), 80));
+        assert!(!host_is_loopback(Some(&host("localhost")), 3000));
+    }
 }

--- a/src/web/setup.rs
+++ b/src/web/setup.rs
@@ -17,13 +17,17 @@ use crate::runtime::bootstrap;
 
 /// Notified on a successful submission: the caller's shutdown signal to
 /// drop this listener and rebind as the full app.
-pub fn setup_service(ready: Arc<Notify>) -> Router {
+///
+/// `production` is the caller's, not one read here. The launch this hands over
+/// to enforces the production rules on the file this writes, and a second
+/// reading of `NODE_ENV` is a second answer waiting to disagree with it.
+pub fn setup_service(ready: Arc<Notify>, production: bool) -> Router {
     Router::new()
         .route("/healthz", get(|| async { "ok\n" }))
         .route("/", get(setup_page))
         .route(
             "/api/setup",
-            post(move |body| submit_setup(body, ready.clone())),
+            post(move |body| submit_setup(body, ready.clone(), production)),
         )
 }
 
@@ -78,10 +82,12 @@ const SETUP_PAGE: &str = r#"<!doctype html>
 
   async function waitForRestart() {
     // Server rebinds after success; poll instead of reloading once so the gap is invisible.
+    // /api/session and not /healthz: this page's own server answers /healthz too, so a
+    // probe that beats its shutdown would reload into the gap before the app has bound.
     for (let attempt = 0; attempt < 40; attempt++) {
       await new Promise((resolve) => setTimeout(resolve, 250));
       try {
-        const probe = await fetch('/healthz', { cache: 'no-store' });
+        const probe = await fetch('/api/session', { cache: 'no-store' });
         if (probe.ok) break;
       } catch (error) {
         // keep polling
@@ -129,7 +135,11 @@ const SETUP_PAGE: &str = r#"<!doctype html>
 /// Parsed as `Value`, not a derived struct — this crate has no `serde`
 /// derive dependency, and a missing field reads as empty rather than a
 /// parse error.
-async fn submit_setup(Json(submission): Json<Value>, ready: Arc<Notify>) -> Response {
+async fn submit_setup(
+    Json(submission): Json<Value>,
+    ready: Arc<Notify>,
+    production: bool,
+) -> Response {
     let field = |key: &str| {
         submission
             .get(key)
@@ -142,10 +152,33 @@ async fn submit_setup(Json(submission): Json<Value>, ready: Arc<Notify>) -> Resp
     // optional here, same as an operator's config file: empty means web-only,
     // no interviewer hosted by this process.
     for key in ["livekitUrl", "livekitApiKey", "livekitApiSecret"] {
-        if field(key).is_empty() {
+        // Trimmed, because `read_config_file` trims when it reads this back and
+        // `nonempty` then calls it missing: a value of spaces would be accepted
+        // here, written, and refused by the launch this page hands over to.
+        if field(key).trim().is_empty() {
             return super::json_response(
                 StatusCode::BAD_REQUEST,
                 json!({ "error": format!("{key} is required") }),
+            );
+        }
+    }
+
+    // Every field, including the optional one, and before anything is sent
+    // anywhere. These are written as `KEY=value` lines below and read back by
+    // `read_config_file`, which parses one line at a time: a newline inside a
+    // value is a second line, and a second line is a config key nobody
+    // submitted. `SESSION_SECRET` is one such key, and this process reads the
+    // file it just wrote.
+    for key in [
+        "livekitUrl",
+        "livekitApiKey",
+        "livekitApiSecret",
+        "googleApiKey",
+    ] {
+        if field(key).chars().any(char::is_control) {
+            return super::json_response(
+                StatusCode::BAD_REQUEST,
+                json!({ "error": format!("{key} must not contain control characters") }),
             );
         }
     }
@@ -154,6 +187,34 @@ async fn submit_setup(Json(submission): Json<Value>, ready: Arc<Notify>) -> Resp
     let livekit_api_key = field("livekitApiKey");
     let livekit_api_secret = field("livekitApiSecret");
     let google_api_key = field("googleApiKey");
+
+    // The keys this submission becomes, in the order the file below writes
+    // them. One list: what the launch is asked about has to be what gets
+    // written, or the answer was about a different config.
+    let pairs = [
+        ("LIVEKIT_URL", livekit_url.as_str()),
+        ("LIVEKIT_API_KEY", livekit_api_key.as_str()),
+        ("LIVEKIT_API_SECRET", livekit_api_secret.as_str()),
+        ("GOOGLE_API_KEY", google_api_key.as_str()),
+    ];
+
+    // The rule the launch on the other side of this page applies to the URL,
+    // applied while there is still a form to report it in. Without it a URL
+    // this accepts and `web_provider_pool` refuses is written, answered with
+    // 200, and then kills the process that was about to serve it -- and because
+    // the file now exists, the next launch is no longer a cold start, so the
+    // page never comes back to correct it. Before the probes, which are the
+    // slow half and reach the network.
+    //
+    // The URL is one rule of several that `run_web` applies to this file; the
+    // rest still fire after the write, which is a separate change.
+    //
+    // Reported as it stands, naming `LIVEKIT_URL` rather than the form's
+    // `livekitUrl`: the two spellings are the same value, and the one in the
+    // message is what the reader will find in the file afterwards.
+    if let Err(error) = crate::config::validate_livekit_url(&livekit_url, production) {
+        return super::json_response(StatusCode::BAD_REQUEST, json!({ "error": error }));
+    }
 
     if let Err(error) = crate::livekit::validate_livekit_credentials(
         &livekit_url,
@@ -174,12 +235,6 @@ async fn submit_setup(Json(submission): Json<Value>, ready: Arc<Notify>) -> Resp
     }
 
     if !google_api_key.is_empty() {
-        let pairs = [
-            ("LIVEKIT_URL", livekit_url.clone()),
-            ("LIVEKIT_API_KEY", livekit_api_key.clone()),
-            ("LIVEKIT_API_SECRET", livekit_api_secret.clone()),
-            ("GOOGLE_API_KEY", google_api_key.clone()),
-        ];
         let config = match load_from_pairs(pairs) {
             Ok(config) => config,
             Err(error) => {
@@ -190,8 +245,9 @@ async fn submit_setup(Json(submission): Json<Value>, ready: Arc<Notify>) -> Resp
             }
         };
 
-        // Same proof as `check-gemini`: open a real session. `CODETRIAL_GEMINI_LIVE_URL`
-        // lets tests redirect this away from the real endpoint.
+        // Same proof as `check-gemini`: open a real session.
+        // `CODETRIAL_GEMINI_LIVE_URL` lets tests redirect this away from the
+        // real endpoint.
         let room_name = format!("{}-smoke", config.room_prefix);
         let boot = bootstrap(&config, &room_name, None, config.default_duration_min);
         let url = std::env::var("CODETRIAL_GEMINI_LIVE_URL")
@@ -209,9 +265,13 @@ async fn submit_setup(Json(submission): Json<Value>, ready: Arc<Notify>) -> Resp
         }
     }
 
-    let contents = format!(
-        "LIVEKIT_URL={livekit_url}\nLIVEKIT_API_KEY={livekit_api_key}\nLIVEKIT_API_SECRET={livekit_api_secret}\nGOOGLE_API_KEY={google_api_key}\n",
-    );
+    // From `pairs`, so the file holds exactly the config that was checked and
+    // probed above. Every value is known to carry no newline by now, which is
+    // what makes one line per key a faithful encoding of it.
+    let contents = pairs
+        .iter()
+        .map(|(key, value)| format!("{key}={value}\n"))
+        .collect::<String>();
     let path = crate::exe_dir().join("codetrial.env.local");
     if let Err(error) = std::fs::write(&path, contents) {
         return super::json_response(
@@ -219,7 +279,9 @@ async fn submit_setup(Json(submission): Json<Value>, ready: Arc<Notify>) -> Resp
             json!({ "error": format!("could not write {}: {error}", path.display()) }),
         );
     }
-    // Only reached once the file is on disk; tells the caller to rebind as the full app.
+
+    // Only reached once the file is on disk; tells the caller to rebind as the
+    // full app.
     ready.notify_one();
     super::json_response(StatusCode::OK, json!({ "saved": true }))
 }

--- a/src/web/setup.rs
+++ b/src/web/setup.rs
@@ -263,6 +263,27 @@ async fn submit_setup(
                 json!({ "error": format!("{key} must not contain control characters") }),
             );
         }
+        // `read_config_file` does `trim_matches('"')` then `trim_matches('\'')`,
+        // so a value edged with either is probed as one string and loaded as
+        // another. Refused rather than written, for the reason the newline
+        // above is: this file format cannot carry the value, and answering 200
+        // would mean the file does not hold what was checked. Refusing says so
+        // while there is still a form to say it in.
+        if let Some(edge) = ['"', '\'']
+            .into_iter()
+            .find(|quote| field(key).starts_with(*quote) || field(key).ends_with(*quote))
+        {
+            return super::json_response(
+                StatusCode::BAD_REQUEST,
+                json!({
+                    "error": format!(
+                        "{key} must not start or end with {edge}: the config file drops \
+                         a quote at either end, so the value read back would not be the \
+                         one checked here"
+                    )
+                }),
+            );
+        }
     }
 
     let livekit_url = field("livekitUrl");

--- a/src/web/setup.rs
+++ b/src/web/setup.rs
@@ -29,6 +29,12 @@ use crate::runtime::bootstrap;
 /// `config_path` is where a submission is written, decided by the caller: the
 /// rest of the path rules live there and a second answer here could disagree
 /// with the search the next launch performs.
+///
+/// No `/healthz`. Nothing polls it here any more, and the full app routes it,
+/// so its absence is the readiness answer a probe wants: a container
+/// healthcheck against a process that has no config and is serving a
+/// credential form used to be told 200 by a server that will never host an
+/// interview.
 pub fn setup_service(
     ready: Arc<Notify>,
     production: bool,
@@ -36,7 +42,6 @@ pub fn setup_service(
     config_path: PathBuf,
 ) -> Router {
     Router::new()
-        .route("/healthz", get(|| async { "ok\n" }))
         .route("/", get(setup_page))
         .route(
             "/api/setup",
@@ -98,6 +103,11 @@ async fn setup_page() -> Html<&'static str> {
 /// Field `name`s are the contract with `submit_setup`'s JSON keys. Inline,
 /// not a `web/` file: served before any config exists, outside the embedded
 /// asset tree.
+///
+/// The Google field says what leaving it blank buys, because the only other
+/// place that says so is `run_web`'s `eprintln!`, and this page exists for a
+/// launch with no console to print it on. Blank is a server that looks
+/// finished: the lobby loads, the interview starts, and nothing ever joins.
 const SETUP_PAGE: &str = r#"<!doctype html>
 <html>
 <head>
@@ -131,7 +141,10 @@ const SETUP_PAGE: &str = r#"<!doctype html>
 
   <label for="googleApiKey">Google API Key</label>
   <input id="googleApiKey" name="googleApiKey" type="password">
-  <small>From <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener">aistudio.google.com</a>.</small>
+  <small>From <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener">aistudio.google.com</a>.
+  Optional, and what it decides is whether this server hosts the interviewer. Without it
+  the app still loads and an interview still starts, but nobody joins the room: something
+  running elsewhere would have to.</small>
 
   <button id="submit" type="submit">Save and continue</button>
 </form>
@@ -144,8 +157,8 @@ const SETUP_PAGE: &str = r#"<!doctype html>
   async function waitForRestart() {
     // The server keeps the port and swaps what answers on it, so a request landing in
     // the handover waits in the accept backlog rather than failing. Poll anyway: the
-    // gap is not zero. /api/session and not /healthz, because this page's own server
-    // answers /healthz too and a probe that beats its shutdown reloads into the gap.
+    // gap is not zero. Any route the full app alone answers would do; /api/session is
+    // one, and it is the route this page is on its way to.
     for (let attempt = 0; attempt < 40; attempt++) {
       await new Promise((resolve) => setTimeout(resolve, 250));
       try {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -641,7 +641,7 @@ fn setup_page_renders_a_form_with_all_four_credential_fields() {
     assert!(response.contains("/api/setup"), "{response}");
 }
 
-/// Accept, validate, write: the mocks answer as working credentials would —
+/// Accept, validate, write: the mocks answer as working credentials would,
 /// LiveKit's `ListRooms` with 200, Gemini's handshake with `setupComplete`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn setup_page_accepts_credentials_and_writes_the_primary_config_file() {
@@ -1446,7 +1446,7 @@ fn setup_page_rejects_a_submission_missing_a_field() {
 }
 
 /// `CODETRIAL_GEMINI_LIVE_URL` redirects validation to a local mock that
-/// never sends `setupComplete` — a rejected key. LiveKit's mock has to pass
+/// never sends `setupComplete`, which is a rejected key. LiveKit's mock passes
 /// so this isolates the Gemini rejection.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn setup_page_rejects_a_google_api_key_that_fails_live_validation() {
@@ -1845,7 +1845,7 @@ fn binary_web_prints_the_url_to_open_when_setup_starts_serving() {
     assert!(output.contains(&addr), "{output}");
 }
 
-/// Same gap for an already-configured launch — reached via a config file
+/// Same gap for an already-configured launch, reached via a config file
 /// instead of a missing one.
 #[test]
 fn binary_web_prints_the_url_to_open_for_the_full_app_too() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -474,6 +474,27 @@ fn binary_web_requires_a_primary_config_file() {
     assert!(stderr.contains("required configuration file is missing"));
 }
 
+/// `--config` alone still leaves zero positionals but skips the cold-start
+/// path, so the credentials refusal proves `web` was picked, not
+/// `run-livekit`/`check-gemini`.
+#[test]
+fn binary_with_no_arguments_defaults_to_web_mode() {
+    let dir = temp_path("default-mode");
+    std::fs::create_dir_all(&dir).unwrap();
+    let config = dir.join("codetrial.env.local");
+    std::fs::write(&config, "CODETRIAL_WEB_ADDR=127.0.0.1:1\n").unwrap();
+
+    let (code, stdout, stderr) = run_cli_args(&["--config", config.to_str().unwrap()]);
+    let _ = std::fs::remove_dir_all(dir);
+
+    assert_eq!(code, 1, "{stderr}");
+    assert!(stdout.is_empty());
+    assert!(
+        stderr.contains("missing required LiveKit credentials"),
+        "{stderr}"
+    );
+}
+
 #[test]
 fn binary_web_refuses_a_public_listener_without_a_session_secret() {
     let config_dir = temp_path("serve-public-default-secret");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -639,6 +639,7 @@ fn setup_page_renders_a_form_with_all_four_credential_fields() {
         );
     }
     assert!(response.contains("/api/setup"), "{response}");
+
     // What leaving the optional field blank buys. The only other place that
     // says it is a console this launch does not have.
     assert!(response.contains("nobody joins the room"), "{response}");
@@ -699,6 +700,7 @@ async fn setup_page_accepts_credentials_and_writes_the_primary_config_file() {
 
     let written = std::fs::read_to_string(dir.join("config").join("codetrial.env.local"))
         .expect("codetrial.env.local should have been written");
+
     // The file holds two secrets, so the umask does not get to decide who reads
     // it. Windows has no mode to check and inherits the folder's ACL.
     #[cfg(unix)]
@@ -764,6 +766,7 @@ fn setup_page_accepts_credentials_without_a_google_api_key() {
     let _ = std::fs::remove_dir_all(&dir);
 
     assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+
     // Absent, not empty. `read_config_file` keeps an empty value and
     // `load_values` lays the file over the environment, so the line would erase
     // a `GOOGLE_API_KEY` the operator exported.
@@ -853,6 +856,7 @@ fn setup_page_refuses_a_request_carrying_a_foreign_host() {
             body
         ),
     );
+
     // The page itself too, so the rebound origin cannot read the form it would
     // be posting.
     let page = http_request(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,6 +2,8 @@ use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -210,7 +212,7 @@ fn wait_for_http(addr: &str, child: &mut Child) -> Result<(), String> {
     while std::time::Instant::now() < deadline {
         if try_http(
             addr,
-            "GET /healthz HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+            &format!("GET /healthz HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"),
         )
         .is_some_and(|response| response.starts_with("HTTP/"))
         {
@@ -601,7 +603,7 @@ fn binary_web_serves_a_setup_page_when_no_config_exists() {
     let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
     let response = http_request(
         &addr,
-        "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+        &format!("GET / HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"),
     );
     let _ = std::fs::remove_dir_all(&dir);
 
@@ -620,7 +622,7 @@ fn setup_page_renders_a_form_with_all_four_credential_fields() {
     let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
     let response = http_request(
         &addr,
-        "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+        &format!("GET / HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"),
     );
     let _ = std::fs::remove_dir_all(&dir);
 
@@ -686,17 +688,30 @@ async fn setup_page_accepts_credentials_and_writes_the_primary_config_file() {
     let response = http_request(
         &addr,
         &format!(
-            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
             body.len(),
             body
         ),
     );
 
-    let written = std::fs::read_to_string(dir.join("codetrial.env.local"))
+    let written = std::fs::read_to_string(dir.join("config").join("codetrial.env.local"))
         .expect("codetrial.env.local should have been written");
+    // The file holds two secrets, so the umask does not get to decide who reads
+    // it. Windows has no mode to check and inherits the folder's ACL.
+    #[cfg(unix)]
+    let mode = {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(dir.join("config").join("codetrial.env.local"))
+            .expect("the written config should be readable")
+            .permissions()
+            .mode()
+            & 0o777
+    };
     let _ = std::fs::remove_dir_all(&dir);
 
     assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+    #[cfg(unix)]
+    assert_eq!(mode, 0o600, "{mode:o}");
     assert!(
         written.contains(&format!("LIVEKIT_URL=http://{livekit_addr}")),
         "{written}"
@@ -735,13 +750,13 @@ fn setup_page_accepts_credentials_without_a_google_api_key() {
     let response = http_request(
         &addr,
         &format!(
-            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
             body.len(),
             body
         ),
     );
 
-    let written = std::fs::read_to_string(dir.join("codetrial.env.local"))
+    let written = std::fs::read_to_string(dir.join("config").join("codetrial.env.local"))
         .expect("codetrial.env.local should have been written");
     let _ = std::fs::remove_dir_all(&dir);
 
@@ -749,9 +764,172 @@ fn setup_page_accepts_credentials_without_a_google_api_key() {
     assert!(written.contains("GOOGLE_API_KEY=\n"), "{written}");
 }
 
-/// Drop-and-rebind means a brief gap, so this polls rather than asserting
-/// the next request lands immediately. `/api/session` only exists on the
-/// full app, so 200 there proves the switch happened.
+/// A checkout keeps its config in its own `config/`, not in the one beside the
+/// binary, which for `make web` is under `target/` and goes with `make clean`.
+/// The working directory and the executable's folder are separate here for
+/// that reason: the same two directories a source build has.
+///
+/// `codetrial.env.example` is what marks the directory as this project's. A
+/// released binary run from a directory that happens to hold a `config/` must
+/// still write beside itself, or the credentials are lost the moment it is
+/// started from somewhere else.
+#[test]
+fn a_cold_start_in_a_checkout_writes_into_the_checkout_config_directory() {
+    let work = temp_path("setup-checkout-work");
+    let home = exe_temp_path("setup-checkout-exe");
+    std::fs::create_dir_all(work.join("config")).unwrap();
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::write(
+        work.join("config").join("codetrial.env.example"),
+        "# keys\n",
+    )
+    .unwrap();
+    let exe = binary_beside(&home);
+
+    let mock = TcpListener::bind("127.0.0.1:0").unwrap();
+    let mock_addr = mock.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut socket, _)) = mock.accept() {
+            let mut buffer = [0u8; 1024];
+            let _ = socket.read(&mut buffer);
+            let _ = socket.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 10\r\nConnection: close\r\n\r\n{\"rooms\":[]}",
+            );
+        }
+    });
+
+    let (addr, _server) = spawn_cold_start(&exe, &work, &[]);
+
+    let body = format!(
+        r#"{{"livekitUrl":"http://{mock_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":""}}"#
+    );
+    let response = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+
+    let in_checkout = work.join("config").join("codetrial.env.local").exists();
+    let beside_exe = home.join("config").join("codetrial.env.local").exists();
+    let _ = std::fs::remove_dir_all(&work);
+    let _ = std::fs::remove_dir_all(&home);
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+    assert!(in_checkout, "the checkout's config/ should have the file");
+    assert!(
+        !beside_exe,
+        "nothing should have been written under target/"
+    );
+}
+
+/// The loopback bind stops the network, not a browser that was handed a name
+/// resolving to 127.0.0.1. The `Host` is what survives that trick, so a
+/// submission carrying a foreign one is refused before it can write the
+/// attacker's LiveKit project into the config.
+#[test]
+fn setup_page_refuses_a_request_carrying_a_foreign_host() {
+    let dir = exe_temp_path("setup-foreign-host");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
+    let port = addr.rsplit_once(':').expect("the address names a port").1;
+
+    let body = r#"{"livekitUrl":"wss://attacker.example","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":""}"#;
+    let submission = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: codetrial.example:{port}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+    // The page itself too, so the rebound origin cannot read the form it would
+    // be posting.
+    let page = http_request(
+        &addr,
+        &format!("GET / HTTP/1.1\r\nHost: codetrial.example:{port}\r\nConnection: close\r\n\r\n"),
+    );
+
+    let written = dir.join("config").join("codetrial.env.local").exists();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(!written, "a foreign Host must not write a config file");
+    assert!(
+        submission.starts_with("HTTP/1.1 403 Forbidden"),
+        "{submission}"
+    );
+    assert!(page.starts_with("HTTP/1.1 403 Forbidden"), "{page}");
+}
+
+/// A symlink with nothing at the end of it is not a file to `is_file`, so it
+/// does not stop the cold start, and a plain write would follow it and put
+/// `LIVEKIT_API_SECRET` wherever it points. The submission is refused instead.
+///
+/// Unix only: this plants a symlink, and creating one on Windows needs a
+/// privilege the test runner is not assumed to have.
+#[cfg(unix)]
+#[test]
+fn setup_page_refuses_to_write_through_a_dangling_symlink() {
+    let dir = exe_temp_path("setup-symlink");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let target = dir.join("stolen.env");
+    std::fs::create_dir_all(dir.join("config")).unwrap();
+    std::os::unix::fs::symlink(&target, dir.join("config").join("codetrial.env.local"))
+        .expect("the symlink should be planted");
+
+    let livekit_mock = TcpListener::bind("127.0.0.1:0").unwrap();
+    let livekit_addr = livekit_mock.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut socket, _)) = livekit_mock.accept() {
+            let mut buffer = [0u8; 1024];
+            let _ = socket.read(&mut buffer);
+            let _ = socket.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 10\r\nConnection: close\r\n\r\n{\"rooms\":[]}",
+            );
+        }
+    });
+
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
+
+    let body = format!(
+        r#"{{"livekitUrl":"http://{livekit_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":""}}"#
+    );
+    let response = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+
+    let followed = target.exists();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(!followed, "the symlink target must not be created");
+    assert!(
+        response.starts_with("HTTP/1.1 500 Internal Server Error"),
+        "{response}"
+    );
+    assert!(response.contains("already exists"), "{response}");
+}
+
+/// `/api/session` only exists on the full app, so 200 there proves the switch
+/// happened. Polled rather than asserted on the next request: the config is
+/// reread, the pool built and the account database migrated in between.
+///
+/// The watcher thread is what pins the socket being handed over rather than
+/// rebound. While something is listening, binding the same address has to fail,
+/// so a bind that succeeds is a moment when the port was free -- the moment
+/// `TIME_WAIT` takes it away on Windows, which builds in CI but does not run
+/// this suite. A bind and not a connection, which would sit in the accept
+/// backlog for the length of the gap.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn setup_page_continues_serving_the_full_app_after_a_successful_submission() {
     let dir = exe_temp_path("setup-continue");
@@ -791,13 +969,30 @@ async fn setup_page_continues_serving_the_full_app_after_a_successful_submission
         &[("CODETRIAL_GEMINI_LIVE_URL", format!("ws://{gemini_addr}"))],
     );
 
+    let watching = Arc::new(AtomicBool::new(true));
+    let stole = Arc::new(AtomicBool::new(false));
+    let watcher = thread::spawn({
+        let (addr, watching, stole) = (addr.clone(), watching.clone(), stole.clone());
+        move || {
+            while watching.load(Ordering::Relaxed) {
+                // Released immediately: holding it would fail the server's own
+                // bind and report this as the poll below timing out.
+                if TcpListener::bind(&addr).is_ok() {
+                    stole.store(true, Ordering::Relaxed);
+                    break;
+                }
+                thread::sleep(Duration::from_millis(1));
+            }
+        }
+    });
+
     let body = format!(
         r#"{{"livekitUrl":"http://{livekit_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":"google"}}"#
     );
     let submit_response = http_request(
         &addr,
         &format!(
-            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
             body.len(),
             body
         ),
@@ -812,7 +1007,7 @@ async fn setup_page_continues_serving_the_full_app_after_a_successful_submission
     while Instant::now() < deadline {
         if let Some(candidate) = try_http(
             &addr,
-            "GET /api/session HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+            &format!("GET /api/session HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"),
         ) {
             response = candidate;
             if response.starts_with("HTTP/1.1 200 OK") {
@@ -822,8 +1017,20 @@ async fn setup_page_continues_serving_the_full_app_after_a_successful_submission
         thread::sleep(Duration::from_millis(50));
     }
 
+    watching.store(false, Ordering::Relaxed);
+    watcher.join().expect("the bind watcher should finish");
+    let database = dir.join("config").join("codetrial.db").exists();
     let _ = std::fs::remove_dir_all(&dir);
 
+    assert!(
+        database,
+        "the account database belongs beside the config, not in the working directory"
+    );
+
+    assert!(
+        !stole.load(Ordering::Relaxed),
+        "the port must stay bound across the handover"
+    );
     assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
     assert!(response.contains(r#""loginRequired":true"#), "{response}");
 }
@@ -845,7 +1052,7 @@ fn binary_web_refuses_to_serve_setup_on_a_public_address() {
         .expect("codetrial should exit");
     let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
     let log = std::fs::read_to_string(dir.join("codetrial-error.log"));
-    let written = dir.join("codetrial.env.local").exists();
+    let written = dir.join("config").join("codetrial.env.local").exists();
     let _ = std::fs::remove_dir_all(&dir);
 
     assert_eq!(output.status.code(), Some(1), "{stderr}");
@@ -925,7 +1132,7 @@ fn setup_page_rejects_a_field_carrying_a_newline() {
         let response = http_request(
             &addr,
             &format!(
-                "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 body.len(),
                 body
             ),
@@ -941,7 +1148,7 @@ fn setup_page_rejects_a_field_carrying_a_newline() {
             "{carrier}: {response}"
         );
         assert!(
-            !dir.join("codetrial.env.local").exists(),
+            !dir.join("config").join("codetrial.env.local").exists(),
             "{carrier}: a rejected submission must not write a config file"
         );
     }
@@ -969,13 +1176,13 @@ fn setup_page_refuses_a_plaintext_url_when_node_env_is_production() {
     let response = http_request(
         &addr,
         &format!(
-            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
             body.len(),
             body
         ),
     );
 
-    let written = dir.join("codetrial.env.local").exists();
+    let written = dir.join("config").join("codetrial.env.local").exists();
     let _ = std::fs::remove_dir_all(&dir);
 
     assert!(
@@ -1005,7 +1212,7 @@ fn setup_page_waits_on_a_route_only_the_full_app_serves() {
     let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
     let page = http_request(
         &addr,
-        "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+        &format!("GET / HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"),
     );
 
     // Both halves of the contract. The page naming the route is one; the other
@@ -1014,11 +1221,11 @@ fn setup_page_waits_on_a_route_only_the_full_app_serves() {
     // test still green.
     let probed = http_request(
         &addr,
-        "GET /api/session HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+        &format!("GET /api/session HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"),
     );
     let health = http_request(
         &addr,
-        "GET /healthz HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+        &format!("GET /healthz HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"),
     );
     let _ = std::fs::remove_dir_all(&dir);
 
@@ -1052,13 +1259,13 @@ fn setup_page_rejects_a_submission_missing_a_field() {
     let response = http_request(
         &addr,
         &format!(
-            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
             body.len(),
             body
         ),
     );
 
-    let written = dir.join("codetrial.env.local").exists();
+    let written = dir.join("config").join("codetrial.env.local").exists();
     let _ = std::fs::remove_dir_all(&dir);
 
     assert!(
@@ -1115,13 +1322,13 @@ async fn setup_page_rejects_a_google_api_key_that_fails_live_validation() {
     let response = http_request(
         &addr,
         &format!(
-            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
             body.len(),
             body
         ),
     );
 
-    let written = dir.join("codetrial.env.local").exists();
+    let written = dir.join("config").join("codetrial.env.local").exists();
     let _ = std::fs::remove_dir_all(&dir);
 
     assert!(
@@ -1160,13 +1367,13 @@ fn setup_page_rejects_livekit_credentials_that_fail_live_validation() {
     let response = http_request(
         &addr,
         &format!(
-            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
             body.len(),
             body
         ),
     );
 
-    let written = dir.join("codetrial.env.local").exists();
+    let written = dir.join("config").join("codetrial.env.local").exists();
     let _ = std::fs::remove_dir_all(&dir);
 
     assert!(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -153,6 +153,33 @@ fn with_free_addr<T>(attempt: impl Fn(&str) -> Option<T>) -> T {
 /// both the same directory, and the first one to finish deletes the other's web
 /// root out from under a live server.
 fn temp_path(name: &str) -> PathBuf {
+    temp_path_in(std::env::temp_dir(), name)
+}
+
+/// Under the target directory rather than the system temp one, because
+/// `binary_beside` hard-links the test binary in and a hard link needs both
+/// ends on one filesystem.
+fn exe_temp_path(name: &str) -> PathBuf {
+    temp_path_in(PathBuf::from(env!("CARGO_TARGET_TMPDIR")), name)
+}
+
+/// The binary itself, linked so that `current_exe` names a path inside `dir`:
+/// these tests are about the folder the executable sits in. A hard link and
+/// not a copy, which would be a 300 MB debug build per test, and not a
+/// symlink, which `current_exe` resolves back to the original.
+fn binary_beside(dir: &Path) -> PathBuf {
+    let name = if cfg!(windows) {
+        "codetrial.exe"
+    } else {
+        "codetrial"
+    };
+    let exe = dir.join(name);
+    std::fs::hard_link(env!("CARGO_BIN_EXE_codetrial"), &exe)
+        .expect("the test binary should link into the target directory");
+    exe
+}
+
+fn temp_path_in(base: PathBuf, name: &str) -> PathBuf {
     static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
     let nanos = SystemTime::now()
@@ -160,7 +187,7 @@ fn temp_path(name: &str) -> PathBuf {
         .unwrap()
         .as_nanos();
     let unique = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    std::env::temp_dir().join(format!(
+    base.join(format!(
         "codetrial-cli-{}-{nanos}-{unique}-{name}",
         std::process::id()
     ))
@@ -435,6 +462,47 @@ fn binary_web_names_the_config_it_read_when_credentials_are_missing() {
         "{stderr}"
     );
     assert!(stderr.contains(config.to_str().unwrap()), "{stderr}");
+}
+
+/// A release binary is unpacked into a folder of its own and keeps its config
+/// there, so the file has to be found from a shortcut or a terminal opened
+/// somewhere else and not only from a double-click, where the working
+/// directory happens to be the same folder.
+#[test]
+fn binary_reads_a_config_file_beside_the_executable() {
+    let dir = exe_temp_path("config-beside-exe");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+    let config = dir.join("codetrial.env.local");
+    std::fs::write(&config, "CODETRIAL_WEB_ADDR=127.0.0.1:1\n").unwrap();
+
+    // An empty working directory, so nothing but the executable's own folder
+    // can be what answered.
+    let cwd = temp_path("elsewhere");
+    std::fs::create_dir_all(&cwd).unwrap();
+    let output = Command::new(&exe)
+        .arg("web")
+        .current_dir(&cwd)
+        .env_remove("LIVEKIT_URL")
+        .env_remove("LIVEKIT_API_KEY")
+        .env_remove("LIVEKIT_API_SECRET")
+        .env_remove("GOOGLE_API_KEY")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("codetrial should exit");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let _ = std::fs::remove_dir_all(&dir);
+    let _ = std::fs::remove_dir_all(&cwd);
+
+    assert!(
+        !stderr.contains("required configuration file is missing"),
+        "the file beside the executable should have answered: {stderr}"
+    );
+    assert!(
+        stderr.contains(config.to_str().unwrap()),
+        "and it should be the file the error names: {stderr}"
+    );
 }
 
 /// Every mode that reads configuration refuses without a file, and says which

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5,12 +5,15 @@ use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use futures_util::{SinkExt, StreamExt};
+use tokio_tungstenite::accept_async;
+
 fn run_cli_args(args: &[&str]) -> (i32, String, String) {
     run_cli_args_with_env(args, &[])
 }
 
 fn run_cli_args_with_env(args: &[&str], envs: &[(&str, &str)]) -> (i32, String, String) {
-    let cwd = temp_path("empty-cwd");
+    let cwd = exe_temp_path("empty-cwd");
     std::fs::create_dir_all(&cwd).expect("empty cwd should create");
     let output = cli_command(args, envs, &cwd)
         .output()
@@ -40,7 +43,7 @@ fn run_cli_until_exit(args: &[&str]) -> (i32, String, String) {
     // whole helper exists to remove.
     const LIMIT: Duration = Duration::from_secs(10);
 
-    let cwd = temp_path("empty-cwd");
+    let cwd = exe_temp_path("empty-cwd");
     std::fs::create_dir_all(&cwd).expect("empty cwd should create");
     let mut child = cli_command(args, &[], &cwd)
         .spawn()
@@ -92,8 +95,12 @@ fn run_cli_until_exit(args: &[&str]) -> (i32, String, String) {
 /// environment the child inherits. The removals matter: a developer with
 /// `NODE_ENV` or `SESSION_SECRET` exported would otherwise change what these
 /// tests are testing.
+/// Runs a linked binary inside `cwd`, not the one in the target directory:
+/// the executable's own folder is a config search path and a place the Setup
+/// page writes, so a stray `codetrial.env.local` next to the real test binary
+/// would decide these tests.
 fn cli_command(args: &[&str], envs: &[(&str, &str)], cwd: &Path) -> Command {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codetrial"));
+    let mut command = Command::new(binary_beside(cwd));
     command
         .args(args)
         .current_dir(cwd)
@@ -510,14 +517,13 @@ fn binary_reads_a_config_file_beside_the_executable() {
 /// assertion is the same sentence three times, and a mode added to MODES that
 /// forgets this belongs in this list rather than in a fourth copy.
 ///
-/// `serve` is not here. It needs a free address to reach the same refusal, so
-/// it carries its own test below.
+/// `web` is not here: a missing config is a cold start for it, covered by
+/// `binary_web_serves_a_setup_page_when_no_config_exists`.
 #[test]
 fn binary_modes_that_read_configuration_require_a_primary_config_file() {
     for args in [
         &["run-livekit", "interview-fixed"][..],
         &["check-gemini"][..],
-        &["web"][..],
     ] {
         let (code, stdout, stderr) = run_cli_args(args);
 
@@ -528,18 +534,6 @@ fn binary_modes_that_read_configuration_require_a_primary_config_file() {
             "{args:?}: {stderr}"
         );
     }
-}
-
-#[test]
-fn binary_web_requires_a_primary_config_file() {
-    let (code, stdout, stderr) = with_free_addr(|addr| {
-        let result = run_cli_args(&["web", "--web-addr", addr]);
-        (!result.2.contains("failed to bind")).then_some(result)
-    });
-
-    assert_eq!(code, 1);
-    assert!(stdout.is_empty());
-    assert!(stderr.contains("required configuration file is missing"));
 }
 
 /// `--config` alone still leaves zero positionals but skips the cold-start
@@ -560,6 +554,474 @@ fn binary_with_no_arguments_defaults_to_web_mode() {
     assert!(
         stderr.contains("missing required LiveKit credentials"),
         "{stderr}"
+    );
+}
+
+/// The solo self-serve cold start: no config anywhere, so it serves the
+/// Setup page instead of refusing.
+#[test]
+fn binary_web_serves_a_setup_page_when_no_config_exists() {
+    let dir = exe_temp_path("cold-start");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let (addr, _server) = spawn_server(|addr| {
+        let mut command = Command::new(&exe);
+        command
+            .args(["web", "--web-addr", addr])
+            .current_dir(&dir)
+            .env_remove("LIVEKIT_URL")
+            .env_remove("LIVEKIT_API_KEY")
+            .env_remove("LIVEKIT_API_SECRET")
+            .env_remove("GOOGLE_API_KEY")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    });
+    let response = http_request(
+        &addr,
+        "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+    assert!(response.contains("Setup"), "{response}");
+}
+
+/// Field names are the contract with `submit_setup`'s JSON keys; pinned so
+/// page and handler can't drift apart.
+#[test]
+fn setup_page_renders_a_form_with_all_four_credential_fields() {
+    let dir = exe_temp_path("setup-form");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let (addr, _server) = spawn_server(|addr| {
+        let mut command = Command::new(&exe);
+        command
+            .args(["web", "--web-addr", addr])
+            .current_dir(&dir)
+            .env_remove("LIVEKIT_URL")
+            .env_remove("LIVEKIT_API_KEY")
+            .env_remove("LIVEKIT_API_SECRET")
+            .env_remove("GOOGLE_API_KEY")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    });
+    let response = http_request(
+        &addr,
+        "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+    for field in [
+        "livekitUrl",
+        "livekitApiKey",
+        "livekitApiSecret",
+        "googleApiKey",
+    ] {
+        assert!(
+            response.contains(&format!("name=\"{field}\"")),
+            "missing {field} field: {response}"
+        );
+    }
+    assert!(response.contains("/api/setup"), "{response}");
+}
+
+/// Accept, validate, write: the mocks answer as working credentials would —
+/// LiveKit's `ListRooms` with 200, Gemini's handshake with `setupComplete`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn setup_page_accepts_credentials_and_writes_the_primary_config_file() {
+    let dir = exe_temp_path("setup-submit");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let livekit_mock = TcpListener::bind("127.0.0.1:0").unwrap();
+    let livekit_addr = livekit_mock.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut socket, _)) = livekit_mock.accept() {
+            let mut buffer = [0u8; 1024];
+            let _ = socket.read(&mut buffer);
+            let _ = socket.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 10\r\nConnection: close\r\n\r\n{\"rooms\":[]}",
+            );
+        }
+    });
+
+    let gemini_mock = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let gemini_addr = gemini_mock.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((socket, _)) = gemini_mock.accept().await
+            && let Ok(mut socket) = accept_async(socket).await
+        {
+            let _ = socket.next().await;
+            let _ = socket
+                .send(tokio_tungstenite::tungstenite::Message::Text(
+                    r#"{"setupComplete":{}}"#.into(),
+                ))
+                .await;
+        }
+    });
+
+    let (addr, _server) = spawn_server(|addr| {
+        let mut command = Command::new(&exe);
+        command
+            .args(["web", "--web-addr", addr])
+            .current_dir(&dir)
+            .env("CODETRIAL_GEMINI_LIVE_URL", format!("ws://{gemini_addr}"))
+            .env_remove("LIVEKIT_URL")
+            .env_remove("LIVEKIT_API_KEY")
+            .env_remove("LIVEKIT_API_SECRET")
+            .env_remove("GOOGLE_API_KEY")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    });
+
+    let body = format!(
+        r#"{{"livekitUrl":"http://{livekit_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":"google"}}"#
+    );
+    let response = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+
+    let written = std::fs::read_to_string(dir.join("codetrial.env.local"))
+        .expect("codetrial.env.local should have been written");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+    assert!(
+        written.contains(&format!("LIVEKIT_URL=http://{livekit_addr}")),
+        "{written}"
+    );
+    assert!(written.contains("LIVEKIT_API_KEY=key"), "{written}");
+    assert!(written.contains("LIVEKIT_API_SECRET=secret"), "{written}");
+    assert!(written.contains("GOOGLE_API_KEY=google"), "{written}");
+}
+
+/// `googleApiKey` is optional, same as an operator's config file: omitting it
+/// writes an empty `GOOGLE_API_KEY` and skips the Gemini live check, so no
+/// Gemini mock is needed here.
+#[test]
+fn setup_page_accepts_credentials_without_a_google_api_key() {
+    let dir = exe_temp_path("setup-submit-no-google-key");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let livekit_mock = TcpListener::bind("127.0.0.1:0").unwrap();
+    let livekit_addr = livekit_mock.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut socket, _)) = livekit_mock.accept() {
+            let mut buffer = [0u8; 1024];
+            let _ = socket.read(&mut buffer);
+            let _ = socket.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 10\r\nConnection: close\r\n\r\n{\"rooms\":[]}",
+            );
+        }
+    });
+
+    let (addr, _server) = spawn_server(|addr| {
+        let mut command = Command::new(&exe);
+        command
+            .args(["web", "--web-addr", addr])
+            .current_dir(&dir)
+            .env_remove("LIVEKIT_URL")
+            .env_remove("LIVEKIT_API_KEY")
+            .env_remove("LIVEKIT_API_SECRET")
+            .env_remove("GOOGLE_API_KEY")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    });
+
+    let body = format!(
+        r#"{{"livekitUrl":"http://{livekit_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":""}}"#
+    );
+    let response = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+
+    let written = std::fs::read_to_string(dir.join("codetrial.env.local"))
+        .expect("codetrial.env.local should have been written");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+    assert!(written.contains("GOOGLE_API_KEY=\n"), "{written}");
+}
+
+/// Drop-and-rebind means a brief gap, so this polls rather than asserting
+/// the next request lands immediately. `/api/session` only exists on the
+/// full app, so 200 there proves the switch happened.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn setup_page_continues_serving_the_full_app_after_a_successful_submission() {
+    let dir = exe_temp_path("setup-continue");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let livekit_mock = TcpListener::bind("127.0.0.1:0").unwrap();
+    let livekit_addr = livekit_mock.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut socket, _)) = livekit_mock.accept() {
+            let mut buffer = [0u8; 1024];
+            let _ = socket.read(&mut buffer);
+            let _ = socket.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 10\r\nConnection: close\r\n\r\n{\"rooms\":[]}",
+            );
+        }
+    });
+
+    let gemini_mock = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let gemini_addr = gemini_mock.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((socket, _)) = gemini_mock.accept().await
+            && let Ok(mut socket) = accept_async(socket).await
+        {
+            let _ = socket.next().await;
+            let _ = socket
+                .send(tokio_tungstenite::tungstenite::Message::Text(
+                    r#"{"setupComplete":{}}"#.into(),
+                ))
+                .await;
+        }
+    });
+
+    let (addr, _server) = spawn_server(|addr| {
+        let mut command = Command::new(&exe);
+        command
+            .args(["web", "--web-addr", addr])
+            .current_dir(&dir)
+            .env("CODETRIAL_GEMINI_LIVE_URL", format!("ws://{gemini_addr}"))
+            .env_remove("LIVEKIT_URL")
+            .env_remove("LIVEKIT_API_KEY")
+            .env_remove("LIVEKIT_API_SECRET")
+            .env_remove("GOOGLE_API_KEY")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    });
+
+    let body = format!(
+        r#"{{"livekitUrl":"http://{livekit_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":"google"}}"#
+    );
+    let submit_response = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+    assert!(
+        submit_response.starts_with("HTTP/1.1 200 OK"),
+        "{submit_response}"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut response = String::new();
+    while Instant::now() < deadline {
+        if let Some(candidate) = try_http(
+            &addr,
+            "GET /api/session HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+        ) {
+            response = candidate;
+            if response.starts_with("HTTP/1.1 200 OK") {
+                break;
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+    assert!(response.contains(r#""loginRequired":true"#), "{response}");
+}
+
+/// A missing field is refused before anything touches disk.
+#[test]
+fn setup_page_rejects_a_submission_missing_a_field() {
+    let dir = exe_temp_path("setup-missing-field");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let (addr, _server) = spawn_server(|addr| {
+        let mut command = Command::new(&exe);
+        command
+            .args(["web", "--web-addr", addr])
+            .current_dir(&dir)
+            .env_remove("LIVEKIT_URL")
+            .env_remove("LIVEKIT_API_KEY")
+            .env_remove("LIVEKIT_API_SECRET")
+            .env_remove("GOOGLE_API_KEY")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    });
+
+    // `livekitUrl` is absent entirely; the others are merely blank, so this
+    // exercises both ways a field can fail to be there.
+    let body = r#"{"livekitApiKey":"","livekitApiSecret":"secret","googleApiKey":"google"}"#;
+    let response = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+
+    let written = dir.join("codetrial.env.local").exists();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(
+        response.starts_with("HTTP/1.1 400 Bad Request"),
+        "{response}"
+    );
+    assert!(response.contains("livekitUrl"), "{response}");
+    assert!(
+        !written,
+        "a rejected submission must not write a config file"
+    );
+}
+
+/// `CODETRIAL_GEMINI_LIVE_URL` redirects validation to a local mock that
+/// never sends `setupComplete` — a rejected key. LiveKit's mock has to pass
+/// so this isolates the Gemini rejection.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn setup_page_rejects_a_google_api_key_that_fails_live_validation() {
+    let dir = exe_temp_path("setup-bad-gemini-key");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let livekit_mock = TcpListener::bind("127.0.0.1:0").unwrap();
+    let livekit_addr = livekit_mock.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut socket, _)) = livekit_mock.accept() {
+            let mut buffer = [0u8; 1024];
+            let _ = socket.read(&mut buffer);
+            let _ = socket.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 10\r\nConnection: close\r\n\r\n{\"rooms\":[]}",
+            );
+        }
+    });
+
+    let gemini_mock = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let gemini_addr = gemini_mock.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((socket, _)) = gemini_mock.accept().await
+            && let Ok(mut socket) = accept_async(socket).await
+        {
+            let _ = socket.close(None).await;
+        }
+    });
+
+    let (addr, _server) = spawn_server(|addr| {
+        let mut command = Command::new(&exe);
+        command
+            .args(["web", "--web-addr", addr])
+            .current_dir(&dir)
+            .env("CODETRIAL_GEMINI_LIVE_URL", format!("ws://{gemini_addr}"))
+            .env_remove("LIVEKIT_URL")
+            .env_remove("LIVEKIT_API_KEY")
+            .env_remove("LIVEKIT_API_SECRET")
+            .env_remove("GOOGLE_API_KEY")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    });
+
+    let body = format!(
+        r#"{{"livekitUrl":"http://{livekit_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":"bad-key"}}"#
+    );
+    let response = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+
+    let written = dir.join("codetrial.env.local").exists();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(
+        response.starts_with("HTTP/1.1 400 Bad Request"),
+        "{response}"
+    );
+    assert!(response.contains("googleApiKey"), "{response}");
+    assert!(!written, "a rejected key must not write a config file");
+}
+
+/// LiveKit is validated too, via `ListRooms`; the mock refuses every
+/// request, standing in for a wrong key/secret.
+#[test]
+fn setup_page_rejects_livekit_credentials_that_fail_live_validation() {
+    let dir = exe_temp_path("setup-bad-livekit");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let mock = TcpListener::bind("127.0.0.1:0").unwrap();
+    let mock_addr = mock.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut socket, _)) = mock.accept() {
+            let mut buffer = [0u8; 1024];
+            let _ = socket.read(&mut buffer);
+            let _ = socket.write_all(
+                b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            );
+        }
+    });
+
+    let (addr, _server) = spawn_server(|addr| {
+        let mut command = Command::new(&exe);
+        command
+            .args(["web", "--web-addr", addr])
+            .current_dir(&dir)
+            .env_remove("LIVEKIT_URL")
+            .env_remove("LIVEKIT_API_KEY")
+            .env_remove("LIVEKIT_API_SECRET")
+            .env_remove("GOOGLE_API_KEY")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    });
+
+    let body = format!(
+        r#"{{"livekitUrl":"http://{mock_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":"google"}}"#
+    );
+    let response = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+
+    let written = dir.join("codetrial.env.local").exists();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(
+        response.starts_with("HTTP/1.1 400 Bad Request"),
+        "{response}"
+    );
+    assert!(response.contains("livekitUrl"), "{response}");
+    assert!(
+        !written,
+        "a rejected LiveKit credential must not write a config file"
     );
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -112,6 +112,7 @@ fn cli_command(args: &[&str], envs: &[(&str, &str)], cwd: &Path) -> Command {
         .env_remove("CODETRIAL_DURATION_MIN")
         .env_remove("CODETRIAL_WEB_DIR")
         .env_remove("CODETRIAL_WEB_ADDR")
+        .env_remove("CODETRIAL_TRUSTED_PROXY_HOPS")
         .env_remove("NODE_ENV")
         .env_remove("SESSION_SECRET")
         .envs(envs.iter().copied())
@@ -243,6 +244,38 @@ fn spawn_server(build: impl Fn(&str) -> Command) -> (String, ServerProcess) {
         }
     }
     panic!("could not start the server on a free port");
+}
+
+/// A cold-start server: the binary beside `dir`, with no config file on any
+/// path it searches and no credentials in the environment.
+///
+/// Three more variables are cleared than the credentials, because
+/// `serve_setup` reads all three: `CODETRIAL_WEB_ADDR` decides where it binds,
+/// `CODETRIAL_TRUSTED_PROXY_HOPS` can refuse the launch outright, and
+/// `NODE_ENV` decides what a submission has to survive. A suite that inherits
+/// any of them from whoever ran it tests a different program on their machine
+/// than in CI -- and the failure arrives as `spawn_server` panicking on a
+/// startup refusal, which reads as the behavior under test breaking.
+fn spawn_cold_start(exe: &Path, dir: &Path, envs: &[(&str, String)]) -> (String, ServerProcess) {
+    spawn_server(|addr| {
+        let mut command = Command::new(exe);
+        command
+            .args(["web", "--web-addr", addr])
+            .current_dir(dir)
+            .env_remove("LIVEKIT_URL")
+            .env_remove("LIVEKIT_API_KEY")
+            .env_remove("LIVEKIT_API_SECRET")
+            .env_remove("GOOGLE_API_KEY")
+            .env_remove("CODETRIAL_WEB_ADDR")
+            .env_remove("CODETRIAL_TRUSTED_PROXY_HOPS")
+            .env_remove("NODE_ENV")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for (key, value) in envs {
+            command.env(key, value);
+        }
+        command
+    })
 }
 
 fn try_http(addr: &str, request: &str) -> Option<String> {
@@ -565,19 +598,7 @@ fn binary_web_serves_a_setup_page_when_no_config_exists() {
     std::fs::create_dir_all(&dir).unwrap();
     let exe = binary_beside(&dir);
 
-    let (addr, _server) = spawn_server(|addr| {
-        let mut command = Command::new(&exe);
-        command
-            .args(["web", "--web-addr", addr])
-            .current_dir(&dir)
-            .env_remove("LIVEKIT_URL")
-            .env_remove("LIVEKIT_API_KEY")
-            .env_remove("LIVEKIT_API_SECRET")
-            .env_remove("GOOGLE_API_KEY")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        command
-    });
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
     let response = http_request(
         &addr,
         "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
@@ -596,19 +617,7 @@ fn setup_page_renders_a_form_with_all_four_credential_fields() {
     std::fs::create_dir_all(&dir).unwrap();
     let exe = binary_beside(&dir);
 
-    let (addr, _server) = spawn_server(|addr| {
-        let mut command = Command::new(&exe);
-        command
-            .args(["web", "--web-addr", addr])
-            .current_dir(&dir)
-            .env_remove("LIVEKIT_URL")
-            .env_remove("LIVEKIT_API_KEY")
-            .env_remove("LIVEKIT_API_SECRET")
-            .env_remove("GOOGLE_API_KEY")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        command
-    });
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
     let response = http_request(
         &addr,
         "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
@@ -665,20 +674,11 @@ async fn setup_page_accepts_credentials_and_writes_the_primary_config_file() {
         }
     });
 
-    let (addr, _server) = spawn_server(|addr| {
-        let mut command = Command::new(&exe);
-        command
-            .args(["web", "--web-addr", addr])
-            .current_dir(&dir)
-            .env("CODETRIAL_GEMINI_LIVE_URL", format!("ws://{gemini_addr}"))
-            .env_remove("LIVEKIT_URL")
-            .env_remove("LIVEKIT_API_KEY")
-            .env_remove("LIVEKIT_API_SECRET")
-            .env_remove("GOOGLE_API_KEY")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        command
-    });
+    let (addr, _server) = spawn_cold_start(
+        &exe,
+        &dir,
+        &[("CODETRIAL_GEMINI_LIVE_URL", format!("ws://{gemini_addr}"))],
+    );
 
     let body = format!(
         r#"{{"livekitUrl":"http://{livekit_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":"google"}}"#
@@ -727,19 +727,7 @@ fn setup_page_accepts_credentials_without_a_google_api_key() {
         }
     });
 
-    let (addr, _server) = spawn_server(|addr| {
-        let mut command = Command::new(&exe);
-        command
-            .args(["web", "--web-addr", addr])
-            .current_dir(&dir)
-            .env_remove("LIVEKIT_URL")
-            .env_remove("LIVEKIT_API_KEY")
-            .env_remove("LIVEKIT_API_SECRET")
-            .env_remove("GOOGLE_API_KEY")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        command
-    });
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
 
     let body = format!(
         r#"{{"livekitUrl":"http://{livekit_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":""}}"#
@@ -797,20 +785,11 @@ async fn setup_page_continues_serving_the_full_app_after_a_successful_submission
         }
     });
 
-    let (addr, _server) = spawn_server(|addr| {
-        let mut command = Command::new(&exe);
-        command
-            .args(["web", "--web-addr", addr])
-            .current_dir(&dir)
-            .env("CODETRIAL_GEMINI_LIVE_URL", format!("ws://{gemini_addr}"))
-            .env_remove("LIVEKIT_URL")
-            .env_remove("LIVEKIT_API_KEY")
-            .env_remove("LIVEKIT_API_SECRET")
-            .env_remove("GOOGLE_API_KEY")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        command
-    });
+    let (addr, _server) = spawn_cold_start(
+        &exe,
+        &dir,
+        &[("CODETRIAL_GEMINI_LIVE_URL", format!("ws://{gemini_addr}"))],
+    );
 
     let body = format!(
         r#"{{"livekitUrl":"http://{livekit_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":"google"}}"#
@@ -849,6 +828,215 @@ async fn setup_page_continues_serving_the_full_app_after_a_successful_submission
     assert!(response.contains(r#""loginRequired":true"#), "{response}");
 }
 
+/// Setup writes credentials to disk for whoever posts them, and on a cold
+/// start there is nothing it could authenticate them with. A public listener
+/// is refused outright rather than served with a warning: the old behavior for
+/// this launch was an exit naming the missing config, and that is a safer
+/// answer than an open one.
+#[test]
+fn binary_web_refuses_to_serve_setup_on_a_public_address() {
+    let dir = exe_temp_path("setup-public-address");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // Port 0 on the unspecified address: bound and named by the kernel, so the
+    // test needs no fixed port, and not loopback, which is the whole question.
+    let output = cli_command(&["web", "--web-addr", "0.0.0.0:0"], &[], &dir)
+        .output()
+        .expect("codetrial should exit");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let log = std::fs::read_to_string(dir.join("codetrial-error.log"));
+    let written = dir.join("codetrial.env.local").exists();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(
+        stderr.contains("refusing to serve the Setup page"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("codetrial.env.local"), "{stderr}");
+    assert!(!written, "a refused Setup must not write a config file");
+    let log = log.expect("codetrial-error.log should have been written");
+    assert!(log.contains("refusing to serve the Setup page"), "{log}");
+}
+
+/// The flag is not the only way to ask for a public listener. `serve_setup`
+/// used to read `--web-addr` alone while the launch it hands over to reads
+/// `CODETRIAL_WEB_ADDR` as well, so an operator who set the variable got a
+/// Setup page on loopback and then a server on every interface: two addresses
+/// in one start, and only the second one guarded.
+#[test]
+fn binary_web_refuses_a_public_setup_address_from_the_environment() {
+    let dir = exe_temp_path("setup-public-address-env");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let output = cli_command(&["web"], &[("CODETRIAL_WEB_ADDR", "0.0.0.0:0")], &dir)
+        .output()
+        .expect("codetrial should exit");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(
+        stderr.contains("refusing to serve the Setup page"),
+        "{stderr}"
+    );
+}
+
+/// `codetrial.env.local` is read back a line at a time, so a newline inside a
+/// submitted value is a config key nobody submitted -- `SESSION_SECRET` among
+/// them, in the file this same process is about to read. Refused before the
+/// probe, so a value like this never reaches the network either.
+#[test]
+fn setup_page_rejects_a_field_carrying_a_newline() {
+    let dir = exe_temp_path("setup-newline-field");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
+
+    // Every field, because every field is written as a line of that file.
+    // `livekitApiSecret` is the one that would otherwise get furthest: it is
+    // only ever signed into a JWT, so a newline in it is nothing a LiveKit
+    // server has any reason to reject, and the submission would reach the
+    // write.
+    //
+    // The newline is JSON's `\n` escape, not a raw byte: serde refuses a
+    // control character inside a string outright, so the escaped form is the
+    // only one that reaches the handler, and it decodes to the same newline.
+    for carrier in [
+        "livekitUrl",
+        "livekitApiKey",
+        "livekitApiSecret",
+        "googleApiKey",
+    ] {
+        let value = |field: &str| match field {
+            _ if field == carrier => r"poisoned\nSESSION_SECRET=known",
+            "livekitUrl" => "wss://example.livekit.cloud",
+            "googleApiKey" => "",
+            _ => "value",
+        };
+        let body = format!(
+            r#"{{"livekitUrl":"{}","livekitApiKey":"{}","livekitApiSecret":"{}","googleApiKey":"{}"}}"#,
+            value("livekitUrl"),
+            value("livekitApiKey"),
+            value("livekitApiSecret"),
+            value("googleApiKey")
+        );
+        let response = http_request(
+            &addr,
+            &format!(
+                "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            ),
+        );
+
+        assert!(
+            response.starts_with("HTTP/1.1 400 Bad Request"),
+            "{carrier}: {response}"
+        );
+        assert!(response.contains(carrier), "{carrier}: {response}");
+        assert!(
+            response.contains("control characters"),
+            "{carrier}: {response}"
+        );
+        assert!(
+            !dir.join("codetrial.env.local").exists(),
+            "{carrier}: a rejected submission must not write a config file"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The rules the launch on the far side of this page applies to the file are
+/// applied while the form is still on screen. Without this the URL is written,
+/// answered with 200, and then refused by `web_provider_pool`, which exits --
+/// and the file now exists, so the next start is not a cold start and the page
+/// never comes back.
+///
+/// No LiveKit mock: the refusal has to come before the probe, and a test that
+/// stood up a server to answer `ListRooms` could not tell the two apart.
+#[test]
+fn setup_page_refuses_a_plaintext_url_when_node_env_is_production() {
+    let dir = exe_temp_path("setup-production-plaintext");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[("NODE_ENV", "production".to_string())]);
+
+    let body = r#"{"livekitUrl":"http://example.livekit.cloud","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":""}"#;
+    let response = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+
+    let written = dir.join("codetrial.env.local").exists();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(
+        response.starts_with("HTTP/1.1 400 Bad Request"),
+        "{response}"
+    );
+    assert!(
+        response.contains("must use wss:// or https://"),
+        "{response}"
+    );
+    assert!(
+        !written,
+        "a rejected submission must not write a config file"
+    );
+}
+
+/// The page polls for the app that replaces it, and both servers answer
+/// `/healthz`: a probe on that route can be satisfied by the listener that is
+/// shutting down, and the reload then lands in the gap before the app has
+/// bound. `/api/session` is routed by the full app alone.
+#[test]
+fn setup_page_waits_on_a_route_only_the_full_app_serves() {
+    let dir = exe_temp_path("setup-readiness-probe");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
+    let page = http_request(
+        &addr,
+        "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+    );
+
+    // Both halves of the contract. The page naming the route is one; the other
+    // is that this server does not answer it, without which a route added to
+    // `setup_service` would put the bug back with the page unchanged and this
+    // test still green.
+    let probed = http_request(
+        &addr,
+        "GET /api/session HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+    );
+    let health = http_request(
+        &addr,
+        "GET /healthz HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(page.contains("fetch('/api/session'"), "{page}");
+    assert!(
+        !page.contains("fetch('/healthz'"),
+        "the readiness probe must not use a route this server answers itself"
+    );
+    assert!(
+        probed.starts_with("HTTP/1.1 404 Not Found"),
+        "the setup server must not answer the route the page waits on: {probed}"
+    );
+    assert!(
+        health.starts_with("HTTP/1.1 200 OK"),
+        "and /healthz is the one it does answer, which is why it cannot be the probe: {health}"
+    );
+}
+
 /// A missing field is refused before anything touches disk.
 #[test]
 fn setup_page_rejects_a_submission_missing_a_field() {
@@ -856,19 +1044,7 @@ fn setup_page_rejects_a_submission_missing_a_field() {
     std::fs::create_dir_all(&dir).unwrap();
     let exe = binary_beside(&dir);
 
-    let (addr, _server) = spawn_server(|addr| {
-        let mut command = Command::new(&exe);
-        command
-            .args(["web", "--web-addr", addr])
-            .current_dir(&dir)
-            .env_remove("LIVEKIT_URL")
-            .env_remove("LIVEKIT_API_KEY")
-            .env_remove("LIVEKIT_API_SECRET")
-            .env_remove("GOOGLE_API_KEY")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        command
-    });
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
 
     // `livekitUrl` is absent entirely; the others are merely blank, so this
     // exercises both ways a field can fail to be there.
@@ -927,20 +1103,11 @@ async fn setup_page_rejects_a_google_api_key_that_fails_live_validation() {
         }
     });
 
-    let (addr, _server) = spawn_server(|addr| {
-        let mut command = Command::new(&exe);
-        command
-            .args(["web", "--web-addr", addr])
-            .current_dir(&dir)
-            .env("CODETRIAL_GEMINI_LIVE_URL", format!("ws://{gemini_addr}"))
-            .env_remove("LIVEKIT_URL")
-            .env_remove("LIVEKIT_API_KEY")
-            .env_remove("LIVEKIT_API_SECRET")
-            .env_remove("GOOGLE_API_KEY")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        command
-    });
+    let (addr, _server) = spawn_cold_start(
+        &exe,
+        &dir,
+        &[("CODETRIAL_GEMINI_LIVE_URL", format!("ws://{gemini_addr}"))],
+    );
 
     let body = format!(
         r#"{{"livekitUrl":"http://{livekit_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":"bad-key"}}"#
@@ -985,19 +1152,7 @@ fn setup_page_rejects_livekit_credentials_that_fail_live_validation() {
         }
     });
 
-    let (addr, _server) = spawn_server(|addr| {
-        let mut command = Command::new(&exe);
-        command
-            .args(["web", "--web-addr", addr])
-            .current_dir(&dir)
-            .env_remove("LIVEKIT_URL")
-            .env_remove("LIVEKIT_API_KEY")
-            .env_remove("LIVEKIT_API_SECRET")
-            .env_remove("GOOGLE_API_KEY")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        command
-    });
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
 
     let body = format!(
         r#"{{"livekitUrl":"http://{mock_addr}","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":"google"}}"#
@@ -1283,33 +1438,27 @@ fn binary_web_logs_any_startup_failure_not_just_a_cold_start_one() {
 fn binary_web_prints_the_url_to_open_when_setup_starts_serving() {
     let dir = exe_temp_path("setup-prints-url");
     std::fs::create_dir_all(&dir).unwrap();
-    let addr = free_addr();
+    let exe = binary_beside(&dir);
 
-    let mut child = Command::new(binary_beside(&dir))
-        .args(["web", "--web-addr", &addr])
-        .current_dir(&dir)
-        .env_remove("LIVEKIT_URL")
-        .env_remove("LIVEKIT_API_KEY")
-        .env_remove("LIVEKIT_API_SECRET")
-        .env_remove("GOOGLE_API_KEY")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("codetrial should start");
+    // Through `spawn_cold_start` rather than a bare `free_addr`, because the
+    // port it hands out is only free until its listener closes: a sibling
+    // socket taking it first is a bind failure, and read as this assertion
+    // failing it would say the server stopped printing its URL.
+    let (addr, mut server) = spawn_cold_start(&exe, &dir, &[]);
 
-    let mut stdout = child.stdout.take().expect("stdout is piped");
+    // Taken after the server is answering, and read to EOF only once the child
+    // is stopped: the pipe stays open for as long as it is running.
+    let mut stdout = server.stdout.take().expect("stdout is piped");
     let stdout_reader = thread::spawn(move || {
         let mut text = String::new();
         let _ = stdout.read_to_string(&mut text);
         text
     });
 
-    let started = wait_for_http(&addr, &mut child);
-    stop_child(&mut child);
+    stop_child(&mut server);
     let _ = std::fs::remove_dir_all(&dir);
     let output = stdout_reader.join().expect("stdout reader should finish");
 
-    assert!(started.is_ok(), "{started:?}");
     assert!(output.contains(&addr), "{output}");
 }
 
@@ -1320,35 +1469,37 @@ fn binary_web_prints_the_url_to_open_for_the_full_app_too() {
     let dir = temp_path("full-app-prints-url");
     std::fs::create_dir_all(&dir).unwrap();
     let config = dir.join("codetrial.env.local");
+
+    // The address in the file is never bound: `--web-addr` overrides it in
+    // `load_values`, and `spawn_server` picks a fresh one for each attempt.
     write_config(&config, &dir, "127.0.0.1:1");
-    let addr = free_addr();
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_codetrial"))
-        .args([
-            "web",
-            "--web-addr",
-            &addr,
-            "--config",
-            config.to_str().unwrap(),
-        ])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("codetrial should start");
+    let (addr, mut server) = spawn_server(|addr| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_codetrial"));
+        command
+            .args([
+                "web",
+                "--web-addr",
+                addr,
+                "--config",
+                config.to_str().unwrap(),
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    });
 
-    let mut stdout = child.stdout.take().expect("stdout is piped");
+    let mut stdout = server.stdout.take().expect("stdout is piped");
     let stdout_reader = thread::spawn(move || {
         let mut text = String::new();
         let _ = stdout.read_to_string(&mut text);
         text
     });
 
-    let started = wait_for_http(&addr, &mut child);
-    stop_child(&mut child);
+    stop_child(&mut server);
     let _ = std::fs::remove_dir_all(&dir);
     let output = stdout_reader.join().expect("stdout reader should finish");
 
-    assert!(started.is_ok(), "{started:?}");
     assert!(output.contains(&addr), "{output}");
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1226,6 +1226,81 @@ fn binary_web_reports_bind_failure_after_config_validation() {
     assert!(stderr.contains("failed to bind"), "{stderr}");
 }
 
+/// The console stays open now, but still needs to say where to look:
+/// stdout must name the URL.
+#[test]
+fn binary_web_prints_the_url_to_open_when_setup_starts_serving() {
+    let dir = temp_path("setup-prints-url");
+    std::fs::create_dir_all(&dir).unwrap();
+    let addr = free_addr();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_codetrial"))
+        .args(["web", "--web-addr", &addr])
+        .current_dir(&dir)
+        .env_remove("LIVEKIT_URL")
+        .env_remove("LIVEKIT_API_KEY")
+        .env_remove("LIVEKIT_API_SECRET")
+        .env_remove("GOOGLE_API_KEY")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("codetrial should start");
+
+    let mut stdout = child.stdout.take().expect("stdout is piped");
+    let stdout_reader = thread::spawn(move || {
+        let mut text = String::new();
+        let _ = stdout.read_to_string(&mut text);
+        text
+    });
+
+    let started = wait_for_http(&addr, &mut child);
+    stop_child(&mut child);
+    let _ = std::fs::remove_dir_all(&dir);
+    let output = stdout_reader.join().expect("stdout reader should finish");
+
+    assert!(started.is_ok(), "{started:?}");
+    assert!(output.contains(&addr), "{output}");
+}
+
+/// Same gap for an already-configured launch — reached via a config file
+/// instead of a missing one.
+#[test]
+fn binary_web_prints_the_url_to_open_for_the_full_app_too() {
+    let dir = temp_path("full-app-prints-url");
+    std::fs::create_dir_all(&dir).unwrap();
+    let config = dir.join("codetrial.env.local");
+    write_config(&config, &dir, "127.0.0.1:1");
+    let addr = free_addr();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_codetrial"))
+        .args([
+            "web",
+            "--web-addr",
+            &addr,
+            "--config",
+            config.to_str().unwrap(),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("codetrial should start");
+
+    let mut stdout = child.stdout.take().expect("stdout is piped");
+    let stdout_reader = thread::spawn(move || {
+        let mut text = String::new();
+        let _ = stdout.read_to_string(&mut text);
+        text
+    });
+
+    let started = wait_for_http(&addr, &mut child);
+    stop_child(&mut child);
+    let _ = std::fs::remove_dir_all(&dir);
+    let output = stdout_reader.join().expect("stdout reader should finish");
+
+    assert!(started.is_ok(), "{started:?}");
+    assert!(output.contains(&addr), "{output}");
+}
+
 #[test]
 fn binary_agent_modes_reject_usage_errors_with_exit_two() {
     for args in [

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -38,7 +38,7 @@ fn run_cli_args_with_env(args: &[&str], envs: &[(&str, &str)]) -> (i32, String, 
 /// That is not hypothetical; it is how `replace == with != in run_web` reached
 /// CI as a 33-second timeout. Bounded, so a guard that stopped guarding is a
 /// red test.
-fn run_cli_until_exit(args: &[&str]) -> (i32, String, String) {
+fn run_cli_until_exit(args: &[&str], envs: &[(&str, &str)]) -> (i32, String, String) {
     // Generous for a loaded runner, and well inside the timeout `cargo mutants`
     // derives from the baseline (33s when this was written). A bound above that
     // would score a caught mutant as a timeout again, which is the failure this
@@ -47,7 +47,7 @@ fn run_cli_until_exit(args: &[&str]) -> (i32, String, String) {
 
     let cwd = exe_temp_path("empty-cwd");
     std::fs::create_dir_all(&cwd).expect("empty cwd should create");
-    let mut child = cli_command(args, &[], &cwd)
+    let mut child = cli_command(args, envs, &cwd)
         .spawn()
         .expect("codetrial should start");
 
@@ -1045,40 +1045,18 @@ async fn setup_page_continues_serving_the_full_app_after_a_successful_submission
 /// launch is a cold start and the page cannot come back to say why.
 #[test]
 fn a_production_cold_start_without_a_session_secret_refuses_to_serve() {
-    let dir = exe_temp_path("setup-production-no-secret");
-    std::fs::create_dir_all(&dir).unwrap();
-
-    // `cli_command` links the binary into `dir` itself and clears
-    // `SESSION_SECRET`, which is the state under test.
+    // Through the bounded runner, because the behaviour this guards against is
+    // a page that serves and waits: an unbounded wait would report that as a
+    // hung suite rather than as this assertion.
     let (code, stdout, stderr) = with_free_addr(|addr| {
-        let output = cli_command(
-            &["web", "--web-addr", addr],
-            &[("NODE_ENV", "production")],
-            &dir,
-        )
-        .output()
-        .expect("codetrial should exit");
-        let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
-        if stderr.contains("Address already in use") {
-            return None;
-        }
-        Some((
-            output.status.code(),
-            String::from_utf8(output.stdout).expect("stdout should be UTF-8"),
-            stderr,
-        ))
+        let result =
+            run_cli_until_exit(&["web", "--web-addr", addr], &[("NODE_ENV", "production")]);
+        (!result.2.contains("failed to bind")).then_some(result)
     });
 
-    let written = dir.join("config").join("codetrial.env.local").exists();
-    let _ = std::fs::remove_dir_all(&dir);
-
-    assert_eq!(code, Some(1));
+    assert_eq!(code, 1);
     assert!(stderr.contains("SESSION_SECRET"), "{stderr}");
     assert!(!stdout.contains("continue setup"), "{stdout}");
-    assert!(
-        !written,
-        "nothing may be written by a launch that never served"
-    );
 }
 
 /// Whitespace survives a paste, and everything after the required-field check
@@ -1131,6 +1109,87 @@ fn setup_page_trims_what_it_was_given() {
     assert!(written.contains("LIVEKIT_API_SECRET=secret\n"), "{written}");
     // Spaces are an empty optional field, not a key to probe Gemini with.
     assert!(!written.contains("GOOGLE_API_KEY"), "{written}");
+}
+
+/// `read_config_file` drops a quote at either end of a value, so one written
+/// raw is probed as one string and loaded as another. The file format cannot
+/// carry it, and saying so on the form is the only place a user can act on it.
+///
+/// The LiveKit mock answers as working credentials would, so the refusal has
+/// to be this rule: without it the submission is accepted and written, and a
+/// 400 for any other reason would be a test that passes for the wrong one.
+#[test]
+fn setup_page_rejects_a_value_edged_with_a_quote() {
+    let dir = exe_temp_path("setup-quoted");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let mock = TcpListener::bind("127.0.0.1:0").unwrap();
+    let mock_addr = mock.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut socket, _)) = mock.accept() {
+            let mut buffer = [0u8; 1024];
+            let _ = socket.read(&mut buffer);
+            let _ = socket.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 10\r\nConnection: close\r\n\r\n{\"rooms\":[]}",
+            );
+        }
+    });
+
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
+
+    let body = format!(
+        r#"{{"livekitUrl":"http://{mock_addr}","livekitApiKey":"key","livekitApiSecret":"'abc","googleApiKey":""}}"#
+    );
+    let response = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+
+    let written = dir.join("config").join("codetrial.env.local").exists();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(
+        response.starts_with("HTTP/1.1 400 Bad Request"),
+        "{response}"
+    );
+    assert!(
+        response.contains("must not start or end with"),
+        "{response}"
+    );
+    assert!(
+        !written,
+        "a value the file cannot carry must not be written"
+    );
+}
+
+/// A file is not the only way to be configured. Exported credentials used to
+/// exit naming the file that was wanted, which a log carries; serving the page
+/// instead left a headless launch waiting on something nobody would open.
+#[test]
+fn binary_web_does_not_ask_when_the_environment_already_answered() {
+    let (code, stdout, stderr) = with_free_addr(|addr| {
+        let result = run_cli_until_exit(
+            &["web", "--web-addr", addr],
+            &[
+                ("LIVEKIT_URL", "wss://example.livekit.cloud"),
+                ("LIVEKIT_API_KEY", "key"),
+                ("LIVEKIT_API_SECRET", "secret"),
+            ],
+        );
+        (!result.2.contains("failed to bind")).then_some(result)
+    });
+
+    assert_eq!(code, 1);
+    assert!(
+        stderr.contains("required configuration file is missing"),
+        "{stderr}"
+    );
+    assert!(!stdout.contains("continue setup"), "{stdout}");
 }
 
 /// Setup writes credentials to disk for whoever posts them, and on a cold
@@ -1507,13 +1566,16 @@ fn binary_web_refuses_a_public_listener_without_a_session_secret() {
 
     let (code, stdout, stderr) = with_free_addr(|addr| {
         let port = addr.rsplit_once(':').unwrap().1;
-        let result = run_cli_until_exit(&[
-            "web",
-            "--web-addr",
-            &format!("0.0.0.0:{port}"),
-            "--config",
-            config.to_str().unwrap(),
-        ]);
+        let result = run_cli_until_exit(
+            &[
+                "web",
+                "--web-addr",
+                &format!("0.0.0.0:{port}"),
+                "--config",
+                config.to_str().unwrap(),
+            ],
+            &[],
+        );
         (!result.2.contains("failed to bind")).then_some(result)
     });
     let _ = std::fs::remove_dir_all(&config_dir);
@@ -1546,13 +1608,16 @@ fn binary_web_refuses_production_without_a_session_secret() {
 
     // No free-port dance: the refusal comes before the bind, so no listener is
     // ever created and there is no port to race for.
-    let (code, stdout, stderr) = run_cli_until_exit(&[
-        "web",
-        "--web-addr",
-        "127.0.0.1:0",
-        "--config",
-        config.to_str().unwrap(),
-    ]);
+    let (code, stdout, stderr) = run_cli_until_exit(
+        &[
+            "web",
+            "--web-addr",
+            "127.0.0.1:0",
+            "--config",
+            config.to_str().unwrap(),
+        ],
+        &[],
+    );
     let _ = std::fs::remove_dir_all(&dir);
 
     assert_eq!(code, 1);
@@ -1628,9 +1693,13 @@ fn binary_web_reads_deployment_keys_from_the_config_file() {
 /// than left to whoever writes the next spawning test.
 #[test]
 fn a_spawned_server_pipes_stderr_so_a_bind_failure_can_be_read() {
-    // No arguments: it exits on a usage error immediately, which is all this
-    // needs. The assertion is about the pipe, not about the server.
-    let child = ServerProcess::spawn(&mut Command::new(env!("CARGO_BIN_EXE_codetrial")));
+    // A mode that does not exist: it exits on a usage error before reading any
+    // config, which is all this needs. No arguments used to do the same and now
+    // means `web`, which in a checkout finds the developer's own config and
+    // starts a server here, in the crate root, with the real environment and
+    // beside the real test binary.
+    let child =
+        ServerProcess::spawn(Command::new(env!("CARGO_BIN_EXE_codetrial")).arg("no-such-mode"));
     assert!(
         child.stderr.is_some(),
         "a child whose stderr is inherited reports an empty reason, and a lost \

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -639,6 +639,9 @@ fn setup_page_renders_a_form_with_all_four_credential_fields() {
         );
     }
     assert!(response.contains("/api/setup"), "{response}");
+    // What leaving the optional field blank buys. The only other place that
+    // says it is a console this launch does not have.
+    assert!(response.contains("nobody joins the room"), "{response}");
 }
 
 /// Accept, validate, write: the mocks answer as working credentials would,
@@ -1365,10 +1368,14 @@ fn setup_page_refuses_a_plaintext_url_when_node_env_is_production() {
     );
 }
 
-/// The page polls for the app that replaces it, and both servers answer
-/// `/healthz`: a probe on that route can be satisfied by the listener that is
-/// shutting down, and the reload then lands in the gap before the app has
-/// bound. `/api/session` is routed by the full app alone.
+/// The page polls for the app that replaces it, so the route it polls has to be
+/// one this server does not answer. Both are asserted: the page naming it, and
+/// this server refusing it, without which a route added to `setup_service`
+/// would put the bug back with the page unchanged and this test still green.
+///
+/// `/healthz` is the same assertion from the other side. The full app routes
+/// it, so a probe answered here would say ready of a process that has no config
+/// and is serving a credential form.
 #[test]
 fn setup_page_waits_on_a_route_only_the_full_app_serves() {
     let dir = exe_temp_path("setup-readiness-probe");
@@ -1381,10 +1388,6 @@ fn setup_page_waits_on_a_route_only_the_full_app_serves() {
         &format!("GET / HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"),
     );
 
-    // Both halves of the contract. The page naming the route is one; the other
-    // is that this server does not answer it, without which a route added to
-    // `setup_service` would put the bug back with the page unchanged and this
-    // test still green.
     let probed = http_request(
         &addr,
         &format!("GET /api/session HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"),
@@ -1405,8 +1408,8 @@ fn setup_page_waits_on_a_route_only_the_full_app_serves() {
         "the setup server must not answer the route the page waits on: {probed}"
     );
     assert!(
-        health.starts_with("HTTP/1.1 200 OK"),
-        "and /healthz is the one it does answer, which is why it cannot be the probe: {health}"
+        health.starts_with("HTTP/1.1 404 Not Found"),
+        "a probe must not be told ready by a server that is asking for credentials: {health}"
     );
 }
 
@@ -1684,6 +1687,48 @@ fn binary_web_reads_deployment_keys_from_the_config_file() {
 
     assert!(serve.contains("trusted_proxy_hops(&values)"), "{serve}");
     assert!(!serve.contains("std::env::var"), "{serve}");
+}
+
+/// The log is the one place the error text sends a reader with no console, so
+/// it has to describe the last start rather than any start. Written on failure
+/// and removed on none: a reader who fixes what it named and starts again
+/// would otherwise be sent back to it by the next thing to go wrong.
+#[test]
+fn a_start_that_reaches_the_server_removes_the_log_of_the_last_failure() {
+    let dir = exe_temp_path("stale-error-log");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+    let config = dir.join("run.env");
+    write_config(&config, &dir, "127.0.0.1:1");
+
+    let log = dir.join("codetrial-error.log");
+    std::fs::write(&log, "a reason from a launch that has been fixed\n").unwrap();
+
+    let (_addr, mut server) = spawn_server(|addr| {
+        let mut command = Command::new(&exe);
+        command
+            .args([
+                "web",
+                "--web-addr",
+                addr,
+                "--config",
+                config.to_str().unwrap(),
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    });
+
+    // `spawn_server` returns once the server answers, which is past everything
+    // that could have written a log.
+    let cleared = !log.exists();
+    stop_child(&mut server);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(
+        cleared,
+        "a start that got as far as serving must not leave the last failure's log behind"
+    );
 }
 
 /// `spawn_server` decides whether a failed start was a lost port race by

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -761,7 +761,10 @@ fn setup_page_accepts_credentials_without_a_google_api_key() {
     let _ = std::fs::remove_dir_all(&dir);
 
     assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
-    assert!(written.contains("GOOGLE_API_KEY=\n"), "{written}");
+    // Absent, not empty. `read_config_file` keeps an empty value and
+    // `load_values` lays the file over the environment, so the line would erase
+    // a `GOOGLE_API_KEY` the operator exported.
+    assert!(!written.contains("GOOGLE_API_KEY"), "{written}");
 }
 
 /// A checkout keeps its config in its own `config/`, not in the one beside the
@@ -1035,6 +1038,101 @@ async fn setup_page_continues_serving_the_full_app_after_a_successful_submission
     assert!(response.contains(r#""loginRequired":true"#), "{response}");
 }
 
+/// A verdict the launch behind the page already had can only be delivered
+/// before the page takes anything. Served instead, this one lets the
+/// submission be probed, written and answered 200, and then exits on a rule
+/// that never needed the submission -- with the file on disk, so no later
+/// launch is a cold start and the page cannot come back to say why.
+#[test]
+fn a_production_cold_start_without_a_session_secret_refuses_to_serve() {
+    let dir = exe_temp_path("setup-production-no-secret");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // `cli_command` links the binary into `dir` itself and clears
+    // `SESSION_SECRET`, which is the state under test.
+    let (code, stdout, stderr) = with_free_addr(|addr| {
+        let output = cli_command(
+            &["web", "--web-addr", addr],
+            &[("NODE_ENV", "production")],
+            &dir,
+        )
+        .output()
+        .expect("codetrial should exit");
+        let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+        if stderr.contains("Address already in use") {
+            return None;
+        }
+        Some((
+            output.status.code(),
+            String::from_utf8(output.stdout).expect("stdout should be UTF-8"),
+            stderr,
+        ))
+    });
+
+    let written = dir.join("config").join("codetrial.env.local").exists();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(code, Some(1));
+    assert!(stderr.contains("SESSION_SECRET"), "{stderr}");
+    assert!(!stdout.contains("continue setup"), "{stdout}");
+    assert!(
+        !written,
+        "nothing may be written by a launch that never served"
+    );
+}
+
+/// Whitespace survives a paste, and everything after the required-field check
+/// used to assume it had not. The URL is the reachable half: it passes
+/// `validate_livekit_url`, which trims to decide, and then reaches the rewrite
+/// that only matches `wss` at offset 0, so working credentials come back as
+/// "did not work".
+#[test]
+fn setup_page_trims_what_it_was_given() {
+    let dir = exe_temp_path("setup-untrimmed");
+    std::fs::create_dir_all(&dir).unwrap();
+    let exe = binary_beside(&dir);
+
+    let mock = TcpListener::bind("127.0.0.1:0").unwrap();
+    let mock_addr = mock.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut socket, _)) = mock.accept() {
+            let mut buffer = [0u8; 1024];
+            let _ = socket.read(&mut buffer);
+            let _ = socket.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 10\r\nConnection: close\r\n\r\n{\"rooms\":[]}",
+            );
+        }
+    });
+
+    let (addr, _server) = spawn_cold_start(&exe, &dir, &[]);
+
+    let body = format!(
+        r#"{{"livekitUrl":" http://{mock_addr} ","livekitApiKey":" key ","livekitApiSecret":" secret ","googleApiKey":"   "}}"#
+    );
+    let response = http_request(
+        &addr,
+        &format!(
+            "POST /api/setup HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        ),
+    );
+
+    let written = std::fs::read_to_string(dir.join("config").join("codetrial.env.local"))
+        .expect("codetrial.env.local should have been written");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+    assert!(
+        written.contains(&format!("LIVEKIT_URL=http://{mock_addr}\n")),
+        "{written}"
+    );
+    assert!(written.contains("LIVEKIT_API_KEY=key\n"), "{written}");
+    assert!(written.contains("LIVEKIT_API_SECRET=secret\n"), "{written}");
+    // Spaces are an empty optional field, not a key to probe Gemini with.
+    assert!(!written.contains("GOOGLE_API_KEY"), "{written}");
+}
+
 /// Setup writes credentials to disk for whoever posts them, and on a cold
 /// start there is nothing it could authenticate them with. A public listener
 /// is refused outright rather than served with a warning: the old behavior for
@@ -1170,7 +1268,16 @@ fn setup_page_refuses_a_plaintext_url_when_node_env_is_production() {
     std::fs::create_dir_all(&dir).unwrap();
     let exe = binary_beside(&dir);
 
-    let (addr, _server) = spawn_cold_start(&exe, &dir, &[("NODE_ENV", "production".to_string())]);
+    // A real `SESSION_SECRET`, because a production cold start without one is
+    // now refused before the page is served, and this test is about the URL.
+    let (addr, _server) = spawn_cold_start(
+        &exe,
+        &dir,
+        &[
+            ("NODE_ENV", "production".to_string()),
+            ("SESSION_SECRET", "a-real-secret".to_string()),
+        ],
+    );
 
     let body = r#"{"livekitUrl":"http://example.livekit.cloud","livekitApiKey":"key","livekitApiSecret":"secret","googleApiKey":""}"#;
     let response = http_request(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1226,15 +1226,66 @@ fn binary_web_reports_bind_failure_after_config_validation() {
     assert!(stderr.contains("failed to bind"), "{stderr}");
 }
 
+/// The listener never bound, so there's no Setup page to show this either;
+/// `codetrial-error.log` is the fallback.
+#[test]
+fn binary_web_logs_a_cold_start_bind_failure_beside_the_exe() {
+    let occupied = TcpListener::bind("127.0.0.1:0").expect("occupied port should bind");
+    let addr = occupied.local_addr().unwrap().to_string();
+    let dir = exe_temp_path("cold-start-bind-failure");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let output = cli_command(&["web", "--web-addr", &addr], &[], &dir)
+        .output()
+        .expect("codetrial should exit");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let log = std::fs::read_to_string(dir.join("codetrial-error.log"));
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stderr.contains("failed to bind"), "{stderr}");
+    let log = log.expect("codetrial-error.log should have been written");
+    assert!(log.contains("failed to bind"), "{log}");
+}
+
+/// Generalized past the cold start: an existing-but-invalid config fails
+/// through the ordinary `web` path, not `serve_setup`, and loses the reason
+/// the same way.
+#[test]
+fn binary_web_logs_any_startup_failure_not_just_a_cold_start_one() {
+    let dir = exe_temp_path("invalid-config-log");
+    std::fs::create_dir_all(&dir).unwrap();
+    let config = dir.join("codetrial.env.local");
+    std::fs::write(&config, "CODETRIAL_WEB_ADDR=127.0.0.1:1\n").unwrap();
+
+    let output = cli_command(&["web", "--config", config.to_str().unwrap()], &[], &dir)
+        .output()
+        .expect("codetrial should exit");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let log = std::fs::read_to_string(dir.join("codetrial-error.log"));
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        stderr.contains("missing required LiveKit credentials"),
+        "{stderr}"
+    );
+    let log = log.expect("codetrial-error.log should have been written");
+    assert!(
+        log.contains("missing required LiveKit credentials"),
+        "{log}"
+    );
+}
+
 /// The console stays open now, but still needs to say where to look:
 /// stdout must name the URL.
 #[test]
 fn binary_web_prints_the_url_to_open_when_setup_starts_serving() {
-    let dir = temp_path("setup-prints-url");
+    let dir = exe_temp_path("setup-prints-url");
     std::fs::create_dir_all(&dir).unwrap();
     let addr = free_addr();
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_codetrial"))
+    let mut child = Command::new(binary_beside(&dir))
         .args(["web", "--web-addr", &addr])
         .current_dir(&dir)
         .env_remove("LIVEKIT_URL")

--- a/tests/token.rs
+++ b/tests/token.rs
@@ -5,8 +5,9 @@
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use codetrial::token::{
     LivekitTokenInput, TOKEN_TTL_SECONDS, WebhookRejection, livekit_egress_token,
-    livekit_observer_token, livekit_room_admin_token, livekit_room_from_token, livekit_token,
-    livekit_token_issuer, sign_hs256, verify_hs256, verify_livekit_webhook,
+    livekit_observer_token, livekit_room_admin_token, livekit_room_from_token,
+    livekit_room_list_token, livekit_token, livekit_token_issuer, sign_hs256, verify_hs256,
+    verify_livekit_webhook,
 };
 use serde_json::{Value, json};
 use sha2::{Digest as _, Sha256};
@@ -127,6 +128,18 @@ fn each_token_carries_only_the_grant_its_purpose_needs() {
     let egress = claims_of(&livekit_egress_token(KEY, SECRET, "interview-a1b2c3d4", NOW).unwrap());
     assert_eq!(egress["video"]["roomRecord"], json!(true));
     assert_eq!(egress["video"]["roomAdmin"], Value::Null);
+
+    // Named no room, and cannot be given one after the fact: the Setup page
+    // signs this with credentials nobody has verified yet, only to learn from
+    // LiveKit whether they are real. Listing is the least it can ask for and
+    // still get an answer.
+    let list = claims_of(&livekit_room_list_token(KEY, SECRET, NOW).unwrap());
+    assert_eq!(list["iss"], json!(KEY));
+    assert_eq!(list["video"]["roomList"], json!(true));
+    assert_eq!(list["video"]["room"], Value::Null);
+    assert_eq!(list["video"]["roomJoin"], Value::Null);
+    assert_eq!(list["video"]["roomAdmin"], Value::Null);
+    assert_eq!(list["video"]["roomRecord"], Value::Null);
 }
 
 #[test]
@@ -146,6 +159,7 @@ fn every_token_expires() {
         livekit_observer_token(KEY, SECRET, "observer-1", "interview-a1b2c3d4", NOW).unwrap(),
         livekit_room_admin_token(KEY, SECRET, "interview-a1b2c3d4", NOW).unwrap(),
         livekit_egress_token(KEY, SECRET, "interview-a1b2c3d4", NOW).unwrap(),
+        livekit_room_list_token(KEY, SECRET, NOW).unwrap(),
     ];
     for token in tokens {
         let claims = claims_of(&token);


### PR DESCRIPTION
A release binary had no way to enter credentials: the only input path was
hand-editing `codetrial.env.local` before ever running it. A double-clicked
exe on Windows exits before anyone can read why — no arguments, no config,
and a console that closes with the process.

`web` mode now starts anyway. With no config anywhere it serves a Setup page,
validates each value against the live service (LiveKit through `ListRooms`,
Google through a real Gemini Live handshake), writes `codetrial.env.local`,
then rebinds as the ordinary app in the same process. Zero arguments now mean
`web`; startup prints the URL; a failed start writes `codetrial-error.log`.
Both files, and the config search, sit beside the executable, which is the one
thing about a double-click that does not depend on where it was started from.

An operator deployment is untouched: `--config` still decides, a named but
missing one is still an error, and `GOOGLE_API_KEY` stays optional.

13 new tests in `tests/cli.rs` (18 → 31), driving the real binary. Every commit
builds and passes on its own.

The first commit is unrelated: the `pre-commit` hook checked out only the staged
diff, leaving a module parent without its children and failing rustfmt over
untouched files. It is first because the rest of the branch trips over it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets a double-clicked Windows binary start: previously the only input path was hand-editing a config file, and the exe exited before any error was visible. `web` mode with no config anywhere now serves a Setup page that validates credentials, writes `codetrial.env.local`, and rebinds as the app; operator deployments are unaffected.

- Zero arguments now defaults to `web` mode; startup prints the URL to open.
- The Setup page validates LiveKit and optional Google credentials against the live services before writing the config file beside the executable.
- The config search now also checks beside the executable, after `./config/` and the working directory.
- Any web startup failure writes `codetrial-error.log` beside the executable.
- Fixes the pre-commit hook checking out only the staged diff, which broke rustfmt over untouched files.

<sup>Written for commit 97b86d2d9881747014dddfd969a082572f92843e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/codetrial/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

