### PR TITLE
Show the response window on the replay page

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -94,6 +94,13 @@
 # `parse_and_validate_report`, which is tested; the wait in between is the part
 # that needs the network.
 #
+# `publish_report` is the two lines around `report_packet`: it takes `&Room` and
+# publishes what that returns, so `Ok(())` looks the same from outside as
+# publishing, exactly as `publish_interviewer_state` above does. It belonged
+# here as soon as `report_packet` did and was missed because both lived in
+# `livekit.rs`, where `report_packet`'s own entry already covered the pair;
+# splitting `src/livekit/report.rs` out scored the wrapper on its own.
+#
 # The media helpers are the same shape one layer down. `handle_media_event`
 # and `attach_audio` take a LiveKit participant, `next_audio_frame` and
 # `next_video_frame` poll a track, and `pump_video` and
@@ -120,6 +127,7 @@ exclude_re = [
     "close_turns",
     "generate_report",
     "report_packet",
+    "publish_report",
     "restart_after_close",
     "open_cold_session",
     "open_live_session_at",

--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ and duration from `ffprobe`. Candidate-visible seconds, audio-source count, and
 production-avatar rendering are operator attestations until recorder-side
 telemetry exists; they are not presented as measurements.
 
+## Integrity evidence
+
+Integrity features produce evidence for a person to review. Nothing here scores
+a candidate, and nothing here is a claim that anybody cheated.
+
+The replay page shows a *response window* for each interviewer turn, with what
+that number is worth written beside it: whose clock measured it, what bounds how
+long one can run, and why a long one is a place to go and watch rather than a
+finding. Overlay detection and gaze reading are refused, and the reasons are
+recorded rather than left implicit. See
+[docs/integrity-evidence.md](docs/integrity-evidence.md).
+
 ## Further documentation
 
 | Document | Covers |
@@ -206,6 +218,7 @@ telemetry exists; they are not presented as measurements.
 | [Development](docs/development.md) | The gate, formatters, hooks, generated files, releases |
 | [Installing a binary](docs/install.md) | Published binaries, platform notes, the config beside them |
 | [Interview length](docs/interview-length.md) | What the lobby offers and what the endpoints enforce |
+| [Integrity evidence](docs/integrity-evidence.md) | Response windows, and what CodeTrial declines to look for |
 | [Third-party notices](THIRD-PARTY-NOTICES.md) | Bundled software, model attribution, licenses, checksums |
 | [Avatar contract](docs/avatar-contract.md) | Renderer behavior, asset limits, privacy, accessibility |
 | [Provider pooling](docs/providers.md) | Spreading rooms over several LiveKit projects |

--- a/README.md
+++ b/README.md
@@ -28,21 +28,20 @@ LiveKit tokens, and runs the interviewer agent.
 └────────────────────────────┘
 ```
 
-The browser sends code updates and test outcomes over LiveKit's data channel;
-the agent receives structured code, not editor screenshots. Candidate code runs
-locally for Python and JavaScript. C, C++, and Java runs use Compiler Explorer,
-so source code leaves the browser for those languages.
+The browser sends code updates and test outcomes over LiveKit's data channel, so
+the agent receives structured code rather than editor screenshots. Python and
+JavaScript run locally; C, C++, and Java run through Compiler Explorer, so
+source code leaves the browser for those three.
 
-Camera and microphone are required to start an interview. Audio and code
-snapshots are kept in memory only unless recording is enabled, which is off by
-default and described under [Recording](#recording). Candidate video is not
-forwarded to Gemini
-unless `CODETRIAL_GEMINI_CANDIDATE_VIDEO_ENABLED=true` is set. Face-presence
-analysis runs locally in the browser; when unsupported, it is reported as
-unavailable rather than inferred. See [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md)
-for bundled software, models, licenses, and integrity verification.
+Camera and microphone are required to start. Audio and code snapshots stay in
+memory unless [recording](#recording) is enabled, which is off by default.
+Candidate video reaches Gemini only with
+`CODETRIAL_GEMINI_CANDIDATE_VIDEO_ENABLED=true`. Face-presence analysis runs in
+the browser and reports itself unavailable rather than guessing.
+
 Jim's avatar model is Seed-san by VirtualCast, Inc.; its required credit and
-license are recorded in that notice.
+license are in [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md), along with
+every other bundled asset and its checksum.
 
 ## Dependencies by lifecycle
 
@@ -52,7 +51,7 @@ license are recorded in that notice.
 | Test time | Build-time tools, Node.js 18+, and Python 3 | Node runs browser and fixture checks; Python verifies generated problem-bank files. `npm ci` adds ESLint and Playwright for the full local browser gate. `ruff`, `shellcheck`, `shfmt`, `commentflow`, `actionlint`, and `cargo-audit` are optional: each gate reports that it skipped rather than failing without them. CI installs all of them except `actionlint`, whose lane skips there too. |
 | Runtime | The compiled `codetrial` binary and a config file | No Node.js, Python, or `node_modules` is required. Rust dependencies are compiled into the binary; browser dependencies are vendored, checksum-pinned, and embedded, so a `web/` directory is optional and only overrides what is already inside. |
 
-Running an interview also requires a LiveKit Cloud project and a Google AI Studio
+Running an interview also needs a LiveKit Cloud project and a Google AI Studio
 API key. C, C++, and Java test runs additionally use the remote Compiler
 Explorer service.
 
@@ -79,94 +78,13 @@ a Setup page instead and prints the URL to open — you can skip steps 2–3 abo
 fill in your keys there, and it writes them to `config/codetrial.env.local` for you. That page
 serves on a loopback address only; a start that would put it on any other
 address refuses instead, and writing the file yourself is the way to deploy for
-other people. See [Prebuilt binaries](#prebuilt-binaries).
-
-## Prebuilt binaries
-
-Every successful build of `main` replaces the `latest` release under
-<https://github.com/sysprog21/codetrial/releases>, unless a newer commit landed
-while it was running. The binaries go to a draft first, and their sizes are
-checked against the files the build produced before that draft takes the name,
-so a truncated upload never reaches the download page. Two things that tag will not
-give you: replacing a release is not atomic, so each publish has a short window
-where `latest` resolves to nothing, and the tag moves, so a link does not keep
-serving the bytes it served last week. Pin a commit and keep your own checksum
-if you need the same binary twice. Nothing is required at runtime beyond the
-binary itself: the browser application, its vendored assets, and the WASM are
-compiled in, so there is no Node.js, no `node_modules`, and no `web/` directory
-to unpack alongside it. The avatar
-model is not in there either: the browser downloads it once from a pinned
-upstream URL, checks it against a pinned SHA-256, and keeps it in its own cache.
-Without that reachable, the interview falls back to Jim's voice-only panel and
-nothing else changes.
-
-```bash
-# Linux
-tar -xzf codetrial-x86_64-unknown-linux-gnu.tar.gz
-mv codetrial-x86_64-unknown-linux-gnu codetrial
-
-# macOS
-unzip codetrial-aarch64-apple-darwin.zip
-xattr -d com.apple.quarantine codetrial-aarch64-apple-darwin
-mv codetrial-aarch64-apple-darwin codetrial
-```
-
-Run `./codetrial` with no config file nearby, and `web` mode serves a Setup
-page at <http://127.0.0.1:3000> instead of refusing to start, printing that
-address for you to open.
-Loopback is the only place it will serve: `--web-addr 0.0.0.0:3000` or
-`CODETRIAL_WEB_ADDR` pointing anywhere else is refused, because the page takes
-credentials over plain HTTP from anyone who can reach it.
-Enter your LiveKit keys there, and your Google key if you want this process to
-host interviewers (see below). Saving writes them **in plain text** to
-`config/codetrial.env.local` beside the executable, creating that directory —
-the same file you would otherwise write yourself:
-
-```bash
-mkdir -p config
-cat >config/codetrial.env.local <<'EOF'
-LIVEKIT_URL=wss://YOUR-PROJECT.livekit.cloud
-LIVEKIT_API_KEY=...
-LIVEKIT_API_SECRET=...
-GOOGLE_API_KEY=...
-EOF
-./codetrial web   # http://127.0.0.1:3000
-```
-
-That `config/` is your data: the keys above and, once the server has run,
-`codetrial.db` with your accounts and reports. To take a newer build, replace
-the executable in place and leave `config/` alone. Unpacking into a fresh
-directory starts over, and deleting the directory removes everything this
-program kept.
-
-`GOOGLE_API_KEY` is the optional one, and it decides which of two things this
-process is. With it, the server hosts interviewers itself. Without it, it serves
-the web side only and every room waits for an agent to join from elsewhere, and
-it says so on startup. There is no matching line for the hosting case, so a
-silent start is the one that hosts interviewers. `--config PATH` names the file
-if you would rather keep it somewhere else; see
-[Configuration](#configuration) for the rest.
-
-Platform notes:
-
-- macOS binaries carry only the ad-hoc signature the linker applies, which is
-  what lets an arm64 binary run at all. They are not Developer ID signed and not
-  notarized, because that needs a paid Apple Developer Program membership this
-  project does not have. A downloaded `.zip` carries the quarantine attribute
-  and Gatekeeper refuses it, so clear the attribute as above or build from
-  source.
-- Windows binaries are unsigned. SmartScreen warns on first run. Put the exe in
-  a folder of its own before double-clicking it: with no config file nearby it
-  opens the Setup page above, and everything it writes lands in that folder —
-  the `config/` that page fills in, and, if the start fails, a
-  `codetrial-error.log` beside the executable that is the only place the reason
-  appears when there is no terminal to read one from.
-- Only `x86_64` Linux, `arm64` macOS, and `x86_64` Windows are published. Build
-  from source for anything else.
+other people. See [docs/install.md](docs/install.md).
 
 ## Run
 
-Building from a checkout instead:
+Prebuilt binaries for Linux, macOS, and Windows are published for every build of
+`main`. What they carry, the config file each needs beside it, and the platform
+notes are in [docs/install.md](docs/install.md). From a checkout instead:
 
 ```bash
 INTERVIEW_ROOM_NAME=interview-local make web
@@ -197,41 +115,19 @@ editors available while disabling their remote test runs.
 
 Jim asks short, targeted questions between logical blocks, offers progressive
 conceptual hints, and uses the latest test run in the final assessment. Voice
-responses stop when the candidate interrupts. Say “can I get a hint?” when
+responses stop when the candidate interrupts. Say "can I get a hint?" when
 needed; hints affect the communication score.
 
-Candidates can present the interview in Google Meet by sharing the CodeTrial
-tab with tab audio enabled. Meet owns the shared tab after that point, and
-face-presence analysis is disabled for the session. See the
+Candidates can present the interview in Google Meet by sharing the CodeTrial tab
+with tab audio enabled. Meet owns the shared tab after that, and face-presence
+analysis is disabled for the session. See the
 [manual check](docs/meet-tab-audio-manual-check.md) for the supported flow.
 
-### Interview length
-
-The lobby offers 30, 45, and 60 minutes, and the candidate picks one before
-starting. `CODETRIAL_DURATION_MIN` is only the length preselected for a
-candidate who does not choose; the endpoint accepts 10 to 90 either way, so a
-deployment that lowers the default has not lowered the ceiling.
-
-Recording lowers it. `CODETRIAL_RECORDING_MAX_MINUTES` bounds a single
-recording, and the sweeper fails one still running five minutes past it, so an
-interview longer than the cap loses exactly the stretch past it and the artifact
-is failed rather than delivered. Where recording is on, the longest interview
-this deployment will start is that cap, clamped into the 10–90 the endpoint
-offers; where it is off, the ceiling is 90.
-
-The lobby is told the ceiling rather than left to discover it. `/api/session`
-reports `maxDurationMin`, and the duration row disables the lengths above it
-with the reason beside them — a length this deployment cannot record is never
-offered and then quietly shortened. `/api/token` clamps to the same ceiling, so
-a request that skips the lobby is bounded too, and both endpoints read it from
-one function so the length that is offered and the length that is enforced
-cannot drift apart.
-
-Startup refuses a cap below `CODETRIAL_DURATION_MIN`, so the length this
-deployment preselects is always one it can record; the pairing is a
-configuration error rather than a quietly shortened interview. Should a cap ever
-sit below every length the row offers, the lobby leaves the row alone rather
-than rendering a page with nothing to press.
+The lobby offers 30, 45, and 60 minutes and the endpoints accept 10 to 90.
+Recording lowers that ceiling to `CODETRIAL_RECORDING_MAX_MINUTES`, and the
+lobby is told the ceiling rather than left to discover it. The rules, and why
+the offered length and the enforced length come from one function, are in
+[docs/interview-length.md](docs/interview-length.md).
 
 ## Development
 
@@ -247,97 +143,21 @@ make hooks           # install the git hooks; uninstall-hooks removes them
 ./scripts/test.sh    # credential-free CI gate
 ```
 
-`scripts/indent.sh` holds the formatter chain: comment reflow with
-`commentflow`, then `cargo fmt`, `ruff format` and `shfmt`, in that order
-because the formatters have to have the last word over the reflow. `make
-indent` runs it with `--write` and the gate runs it with `--check`, against a
-copy of the tree so a check never rewrites what it is judging. `shfmt` takes
-its style from `.editorconfig` and is passed no style flags anywhere.
-
-`scripts/test-git-hooks.sh` drives all four hooks against a scratch repository
-and runs in the gate, so a hook that stops rejecting fails here rather than on
-somebody's next commit.
-
-`make hooks` installs wrappers in `.git/hooks` that resolve the active
-worktree's `scripts/git-*.sh`. The pre-commit hook
-runs `rustfmt`, ESLint, `ruff`, `shellcheck`, `shfmt` and `commentflow` over a
-checkout of the index, so an unstaged edit neither fails a commit nor passes
-one; the commit-msg hook
-holds the subject to 50 characters and the body to 72, imperative and ASCII.
-Whatever is missing locally reports itself as skipped. The pre-push hook
-replays the same message rules over commits a rebase or an amend rewrote after
-the fact, and CI runs them over a pull request's own commits.
-
-The [prerelease](#prebuilt-binaries) is published by the `build` and `release`
-jobs in `.github/workflows/check.yml`, which run only on a push to `main`. No
-repository secrets are involved: the macOS binary ships with the linker's ad-hoc
-signature and nothing else, so a fork builds the same artifacts this repository
-does. Developer ID signing and notarization would need a paid Apple Developer
-Program membership, and the download instructions clear quarantine instead.
-
-The embed falls back per file rather than wholesale, so a partially populated
-web tree is filled in from the built-in copy rather than 404ing. Assets on disk
-win where they exist. That root is `web/` relative to the working directory
-unless `CODETRIAL_WEB_DIR` names another, so running the binary from a checkout
-picks up edits with no environment variable set.
-
-`web/problems/`, `web/judges/`, and the problem cards in `web/index.html` are
-generated from `problem-bank/`. Regenerate them after editing that source, or
-the gate fails on the drift:
-
-```bash
-python3 scripts/gen-problems.py
-python3 scripts/gen-problem-cards.py
-```
-
-`scripts/top-interview-150.json` records which problems the study plan asks
-for. Refresh it from LeetCode with:
-
-```bash
-python3 scripts/gen-problems.py --sync-study-plan
-```
-
-The sync refuses to write when the plan and `problem-bank/` disagree, naming
-the problems each side is missing. Port those first. `--check` holds the
-committed manifest to the same rule, so drift fails the gate offline.
-
-Two commands cover the porting. `--plan-drift` asks LeetCode what changed
-without writing anything, and `--scaffold SLUG` prints the `problems.json` and
-`judges.json` entries for one problem, filled in as far as LeetCode's metadata
-reaches:
-
-```bash
-python3 scripts/gen-problems.py --plan-drift
-python3 scripts/gen-problems.py --scaffold reverse-linked-list-ii
-```
-
-It stops where it has to. The statement, examples and constraints stay empty
-because the fetcher never asks LeetCode for problem prose, and each judge case
-carries its input without an expected value, because `exampleTestcases` is
-inputs only. Both are written by someone who has read the problem.
-
-The end-to-end browser check additionally needs Playwright and Chromium:
-
-```bash
-npm ci && npx playwright install chromium
-scripts/browser-check.sh
-```
-
-Checks that need credentials or a running service stay out of the gate and are
-run on their own: `scripts/server-check.sh`, `gemini-check.sh`,
-`parity-check.sh`, `report-parity-check.sh`, `visual-parity-check.sh`,
-`recording-integration.sh`, and `recording-provision-check.sh`.
+The gate ends by printing what it did not check, because several lanes are
+optional and a run that skips them still exits 0. That summary, the formatter
+chain, the git hooks, the generated problem files, and where a slow run's time
+actually goes are in [docs/development.md](docs/development.md).
 
 ## Configuration
 
 `config/codetrial.env.example` documents the variables that belong in a config
-file. `NODE_ENV` and `INTERVIEW_ROOM_NAME` are set in
-the environment instead. The common ones are:
+file; `NODE_ENV` and `INTERVIEW_ROOM_NAME` are set in the environment instead.
+The common ones:
 
 | Variable | Default | Purpose |
 |---|---|---|
 | `CODETRIAL_WEB_ADDR` | `127.0.0.1:3000` | Listen address |
-| `CODETRIAL_DURATION_MIN` | `45` | Interview length preselected in the lobby (10–90); see [Interview length](#interview-length) |
+| `CODETRIAL_DURATION_MIN` | `45` | Interview length preselected in the lobby (10–90); see [interview length](docs/interview-length.md) |
 | `GEMINI_LIVE_MODEL` | `gemini-3.1-flash-live-preview` | Realtime interviewer model |
 | `GEMINI_REPORT_MODEL` | `gemini-3.1-flash-lite` | Report model |
 | `CODETRIAL_GEMINI_CANDIDATE_VIDEO_ENABLED` | `false` | Forward candidate video to Gemini |
@@ -370,9 +190,9 @@ Recording is off by default. Enabling it requires a separate LiveKit project,
 private GCS staging bucket, Shared Drive, service account, GitHub OAuth, and
 candidate consent. It also caps how long an interview can run:
 `CODETRIAL_RECORDING_MAX_MINUTES` (45 by default) becomes the longest length the
-lobby offers, described under [Interview length](#interview-length). The full
-configuration, lifecycle, retention policy, and credentialed acceptance check
-are in [docs/recording-contract.md](docs/recording-contract.md).
+lobby offers, described in [docs/interview-length.md](docs/interview-length.md).
+The full configuration, lifecycle, retention policy, and credentialed acceptance
+check are in [docs/recording-contract.md](docs/recording-contract.md).
 
 The credentialed recording acceptance records frame dimensions, rate, bitrate,
 and duration from `ffprobe`. Candidate-visible seconds, audio-source count, and
@@ -383,12 +203,19 @@ telemetry exists; they are not presented as measurements.
 
 | Document | Covers |
 |---|---|
-| [Third-party notices](THIRD-PARTY-NOTICES.md) | Bundled software, model attribution, licenses, and checksum verification |
-| [Avatar contract](docs/avatar-contract.md) | Renderer behavior, asset limits, privacy, and accessibility |
+| [Development](docs/development.md) | The gate, formatters, hooks, generated files, releases |
+| [Installing a binary](docs/install.md) | Published binaries, platform notes, the config beside them |
+| [Interview length](docs/interview-length.md) | What the lobby offers and what the endpoints enforce |
+| [Third-party notices](THIRD-PARTY-NOTICES.md) | Bundled software, model attribution, licenses, checksums |
+| [Avatar contract](docs/avatar-contract.md) | Renderer behavior, asset limits, privacy, accessibility |
 | [Provider pooling](docs/providers.md) | Spreading rooms over several LiveKit projects |
-| [Recording contract](docs/recording-contract.md) | Provisioning, consent, delivery, retention, and operations |
+| [Recording contract](docs/recording-contract.md) | Provisioning, consent, delivery, retention, operations |
 | [Google Meet manual check](docs/meet-tab-audio-manual-check.md) | Verifying tab-audio presentation |
-| [LiveKit connection troubleshooting](docs/livekit-connection-troubleshooting.md) | Telling four connection failures apart, and checking credentials without the browser |
+| [LiveKit troubleshooting](docs/livekit-connection-troubleshooting.md) | Telling four connection failures apart |
+| [Observable delivery policy](docs/observable-delivery-policy.md) | What a report may and may not assess |
+| [Interview contract versions](docs/interview-contract-versions.md) | The five versions every report carries |
+| [Rubric calibration](docs/rubric-calibration.md) | Calibration status of the framework scores |
+| [Provider cost and degradation](docs/provider-cost-and-degradation.md) | Gemini budgets, restarts, concurrency |
 
 ## Repository layout
 
@@ -405,7 +232,8 @@ tests/          Rust and browser tests
 ## Troubleshooting
 
 - Waiting for interviewer: start the agent in the same LiveKit room and project.
-- No audio: check browser and system output devices, then the microphone mute state.
+- No audio: check browser and system output devices, then the microphone
+  mute state.
 - Report error: verify `GOOGLE_API_KEY`; the agent log contains the exact cause.
 - Gemini model not found: set `GEMINI_LIVE_MODEL` to a current model from
   <https://ai.google.dev/gemini-api/docs/live>.

--- a/docs/development.md
+++ b/docs/development.md
@@ -49,6 +49,24 @@ indent` runs it with `--write` and the gate runs it with `--check`, against a
 copy of the tree so a check never rewrites what it is judging. `shfmt` takes
 its style from `.editorconfig` and is passed no style flags anywhere.
 
+## Comments that count things
+
+Comments here carry the reasoning, deliberately, and that is not the part worth
+economising on. What has gone wrong repeatedly is narrower: a comment that
+states a count of code, "all three routes", "written out twice", "five
+caveats". Nothing checks those, the code moves, and the comment is then a
+confident false statement sitting next to what it describes. One recent branch
+spent twelve of its eighteen commits correcting claims an earlier commit's
+prose had made.
+
+Two shapes are safe and are the ones to reach for. A count in the past tense is
+history and cannot go stale: "seven modules were each restating this" stays
+true after an eighth arrives. A count a test already pins is checked by that
+test, so `ReplayKind::ALL` being `[Self; 6]` makes "six kinds" safe to write.
+
+A present-tense count of anything else is a liability. Either drop the number,
+naming the things instead, or move it somewhere a run can fail on it.
+
 ## Git hooks
 
 `scripts/test-git-hooks.sh` drives all four hooks against a scratch repository

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,9 +1,44 @@
 # Development
 
-The formatters, the hooks, the generated files, and the checks that stay out of
-the gate. `make` targets and the one-line summary of each are in
+The gate, the formatters, the hooks, the generated files, and where a slow run's
+time actually goes. `make` targets and the one-line summary of each are in
 [README.md](../README.md#development); everything here is the detail behind
 them.
+
+## What the gate checks, and what it will not
+
+`./scripts/test.sh` finishes by printing what it did not check, because several
+lanes are optional and a run that skips them still exits 0. A checkout with none
+of the tools below is a green gate over roughly a tenth of the browser suite and
+no static analysis of the shell, the workflows, the Python, or the dependency
+tree. The summary names each one; these are what they need.
+
+```bash
+npx playwright install chromium   # ~30 browser tests, the whole lobby flow
+npm install                       # eslint
+cargo install cargo-audit         # the dependency advisory scan
+```
+
+`shellcheck`, `ruff` and `actionlint` come from the system package manager. CI
+installs all of them, so what is optional locally is enforced on a pull request
+— the summary exists so that a contributor knows which of the two they are
+looking at. One lane needs `javac` 16 or newer and is skipped on an older JDK;
+that is the Java class-harness fixture and nothing else depends on it.
+
+Where the time goes, measured on this repo rather than guessed, because the
+answer is not the one a first look gives. Warm, the two Rust lanes are seconds:
+`cargo clippy --all-targets` takes about five and building and linking the
+eleven test binaries about nine, and the whole browser suite runs in under
+twenty. What costs minutes is any change that invalidates the dependency graph,
+a lockfile bump, a toolchain bump, a profile edit or a fresh checkout, because
+rebuilding it means building the LiveKit SDK and libwebrtc from source. That is
+why CI caches `target` keyed on the lockfile and links with mold, and it is why
+a local run that suddenly takes twenty minutes has usually just had its cache
+invalidated rather than got slower.
+
+Trimming debug info, which is what buys CI 40% per relink, was measured here
+and buys nothing: 7.5s against 8.1s on macOS, where the system linker rather
+than mold does the work. It stays a CI setting for that reason.
 
 ## Formatting
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,97 @@
+# Development
+
+The formatters, the hooks, the generated files, and the checks that stay out of
+the gate. `make` targets and the one-line summary of each are in
+[README.md](../README.md#development); everything here is the detail behind
+them.
+
+## Formatting
+
+`scripts/indent.sh` holds the formatter chain: comment reflow with
+`commentflow`, then `cargo fmt`, `ruff format` and `shfmt`, in that order
+because the formatters have to have the last word over the reflow. `make
+indent` runs it with `--write` and the gate runs it with `--check`, against a
+copy of the tree so a check never rewrites what it is judging. `shfmt` takes
+its style from `.editorconfig` and is passed no style flags anywhere.
+
+## Git hooks
+
+`scripts/test-git-hooks.sh` drives all four hooks against a scratch repository
+and runs in the gate, so a hook that stops rejecting fails here rather than on
+somebody's next commit.
+
+`make hooks` installs wrappers in `.git/hooks` that resolve the active
+worktree's `scripts/git-*.sh`. The pre-commit hook
+runs `rustfmt`, ESLint, `ruff`, `shellcheck`, `shfmt` and `commentflow` over a
+checkout of the index, so an unstaged edit neither fails a commit nor passes
+one; the commit-msg hook
+holds the subject to 50 characters and the body to 72, imperative and ASCII.
+Whatever is missing locally reports itself as skipped. The pre-push hook
+replays the same message rules over commits a rebase or an amend rewrote after
+the fact, and CI runs them over a pull request's own commits.
+
+## Releases and the embedded web tree
+
+The [prerelease](install.md) is published by the `build` and `release`
+jobs in `.github/workflows/check.yml`, which run only on a push to `main`. No
+repository secrets are involved: the macOS binary ships with the linker's ad-hoc
+signature and nothing else, so a fork builds the same artifacts this repository
+does. Developer ID signing and notarization would need a paid Apple Developer
+Program membership, and the download instructions clear quarantine instead.
+
+The embed falls back per file rather than wholesale, so a partially populated
+web tree is filled in from the built-in copy rather than 404ing. Assets on disk
+win where they exist. That root is `web/` relative to the working directory
+unless `CODETRIAL_WEB_DIR` names another, so running the binary from a checkout
+picks up edits with no environment variable set.
+
+## Generated files
+
+`web/problems/`, `web/judges/`, and the problem cards in `web/index.html` are
+generated from `problem-bank/`. Regenerate them after editing that source, or
+the gate fails on the drift:
+
+```bash
+python3 scripts/gen-problems.py
+python3 scripts/gen-problem-cards.py
+```
+
+`scripts/top-interview-150.json` records which problems the study plan asks
+for. Refresh it from LeetCode with:
+
+```bash
+python3 scripts/gen-problems.py --sync-study-plan
+```
+
+The sync refuses to write when the plan and `problem-bank/` disagree, naming
+the problems each side is missing. Port those first. `--check` holds the
+committed manifest to the same rule, so drift fails the gate offline.
+
+Two commands cover the porting. `--plan-drift` asks LeetCode what changed
+without writing anything, and `--scaffold SLUG` prints the `problems.json` and
+`judges.json` entries for one problem, filled in as far as LeetCode's metadata
+reaches:
+
+```bash
+python3 scripts/gen-problems.py --plan-drift
+python3 scripts/gen-problems.py --scaffold reverse-linked-list-ii
+```
+
+It stops where it has to. The statement, examples and constraints stay empty
+because the fetcher never asks LeetCode for problem prose, and each judge case
+carries its input without an expected value, because `exampleTestcases` is
+inputs only. Both are written by someone who has read the problem.
+
+## Checks outside the gate
+
+The end-to-end browser check additionally needs Playwright and Chromium:
+
+```bash
+npm ci && npx playwright install chromium
+scripts/browser-check.sh
+```
+
+Checks that need credentials or a running service stay out of the gate and are
+run on their own: `scripts/server-check.sh`, `gemini-check.sh`,
+`parity-check.sh`, `report-parity-check.sh`, `visual-parity-check.sh`,
+`recording-integration.sh`, and `recording-provision-check.sh`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,88 @@
+# Installing a prebuilt binary
+
+Where the published binaries come from, what they do and do not carry, and what
+each platform asks of you before it will run one. Building from a checkout is in
+[README.md](../README.md#run) and needs none of this.
+
+Every successful build of `main` replaces the `latest` release under
+<https://github.com/sysprog21/codetrial/releases>, unless a newer commit landed
+while it was running. The binaries go to a draft first, and their sizes are
+checked against the files the build produced before that draft takes the name,
+so a truncated upload never reaches the download page. Two things that tag will
+not
+give you: replacing a release is not atomic, so each publish has a short window
+where `latest` resolves to nothing, and the tag moves, so a link does not keep
+serving the bytes it served last week. Pin a commit and keep your own checksum
+if you need the same binary twice. Nothing is required at runtime beyond the
+binary itself: the browser application, its vendored assets, and the WASM are
+compiled in, so there is no Node.js, no `node_modules`, and no `web/` directory
+to unpack alongside it. The avatar
+model is not in there either: the browser downloads it once from a pinned
+upstream URL, checks it against a pinned SHA-256, and keeps it in its own cache.
+Without that reachable, the interview falls back to Jim's voice-only panel and
+nothing else changes.
+
+```bash
+# Linux
+tar -xzf codetrial-x86_64-unknown-linux-gnu.tar.gz
+mv codetrial-x86_64-unknown-linux-gnu codetrial
+
+# macOS
+unzip codetrial-aarch64-apple-darwin.zip
+xattr -d com.apple.quarantine codetrial-aarch64-apple-darwin
+mv codetrial-aarch64-apple-darwin codetrial
+```
+
+Run `./codetrial` with no config file nearby, and `web` mode serves a Setup
+page at <http://127.0.0.1:3000> instead of refusing to start, printing that
+address for you to open. Loopback is the only place it will serve:
+`--web-addr 0.0.0.0:3000` or `CODETRIAL_WEB_ADDR` pointing anywhere else is
+refused, because the page takes credentials over plain HTTP from anyone who can
+reach it.
+
+Enter your LiveKit keys there, and your Google key if you want this process to
+host interviewers (see below). Saving writes them **in plain text** to
+`config/codetrial.env.local` beside the executable, creating that directory: the
+same file you would otherwise write yourself.
+
+```bash
+mkdir -p config
+cat >config/codetrial.env.local <<'EOF'
+LIVEKIT_URL=wss://YOUR-PROJECT.livekit.cloud
+LIVEKIT_API_KEY=...
+LIVEKIT_API_SECRET=...
+GOOGLE_API_KEY=...
+EOF
+./codetrial web   # http://127.0.0.1:3000
+```
+
+That `config/` is your data: the keys above and, once the server has run,
+`codetrial.db` with your accounts and reports. To take a newer build, replace
+the executable in place and leave `config/` alone. Unpacking into a fresh
+directory starts over, and deleting the directory removes everything this
+program kept.
+
+`GOOGLE_API_KEY` is the optional one, and it decides which of two things this
+process is. With it, the server hosts interviewers itself. Without it, it serves
+the web side only and every room waits for an agent to join from elsewhere, and
+it says so on startup. There is no matching line for the hosting case, so a
+silent start is the one that hosts interviewers. `--config PATH` names the file
+if you would rather keep it somewhere else; see
+[Configuration](../README.md#configuration) for the rest.
+
+Platform notes:
+
+- macOS binaries carry only the ad-hoc signature the linker applies, which is
+  what lets an arm64 binary run at all. They are not Developer ID signed and not
+  notarized, because that needs a paid Apple Developer Program membership this
+  project does not have. A downloaded `.zip` carries the quarantine attribute
+  and Gatekeeper refuses it, so clear the attribute as above or build from
+  source.
+- Windows binaries are unsigned. SmartScreen warns on first run. Put the exe in
+  a folder of its own before double-clicking it: with no config file nearby it
+  opens the Setup page above, and everything it writes lands in that folder, the
+  `config/` that page fills in, and, if the start fails, a
+  `codetrial-error.log` beside the executable that is the only place the reason
+  appears when there is no terminal to read one from.
+- Only `x86_64` Linux, `arm64` macOS, and `x86_64` Windows are published. Build
+  from source for anything else.

--- a/docs/integrity-evidence.md
+++ b/docs/integrity-evidence.md
@@ -1,0 +1,120 @@
+# Integrity evidence
+
+Integrity features produce evidence for a person to review. Nothing here scores
+a candidate, and nothing here is a claim that anybody cheated. That rule is
+what shapes everything below: what the replay page shows, what it says beside
+it, and what CodeTrial declines to look for at all.
+
+Integrity features produce evidence for a person to review. Nothing here scores
+a candidate, and nothing here is a claim that anybody cheated.
+
+## Response windows
+
+The replay page lists a *response window* for each turn the interviewer took:
+the time between the interviewer finishing that turn and the interviewer
+speaking again, taken from the `avatar` state rows the browser recorded. A
+window no candidate transcript turn was attributed to says so; the turn itself
+is read in the transcript beside the timeline, not on the window.
+
+Attribution is recorded rather than inferred. The browser numbers each window
+as it opens, stamps that number on the row opening it, and stamps the number
+that was current when a transcript stream started on the turn that stream
+produced. A turn therefore lands on the question it began answering, even
+though the row carrying it is written when the stream finishes, which is
+routinely after the interviewer has moved on.
+
+No window opens before the interviewer has been heard speaking, and none opens
+on a `listening` that did not follow one. The browser records a state on first
+sight of the interviewer, before there is a question to leave a gap after, and
+a window opened there would report the greeting as elapsed response time.
+
+What a long window can mean is bounded by the interviewer itself, and this is
+the first thing to know about the number. `timing_decision` in `src/agent.rs`
+nudges a candidate who has been silent for 25 seconds and waits 30 between
+nudges, so the interruption lands in that range; the nudge makes the
+interviewer speak, which closes the window. Neither talking nor typing counts
+as silence there, so a window runs long only while the candidate is working: a
+long window means they were busy, which is the innocent reading. A candidate
+silently reading an answer off a second screen is interrupted within half a
+minute and produces a run of short windows holding no transcript, and that run
+is the shape worth opening, not the length of any one of them. In the
+behavioral round, where the editor is disabled, the nudge fires more reliably
+still.
+
+These things belong beside every one of those numbers, and the page says them
+where it shows them, alongside the bound above:
+
+- It is measured from the clock of the browser that recorded the interview. That
+  is the candidate's own clock, the server never trusts it for ordering, and it
+  can jump in either direction: a window can read longer than it lasted as
+  easily as it can read as unmeasurable.
+- It includes the time CodeTrial took to prepare the reply, not only the time
+  the candidate took to give one. The interviewer publishes two states,
+  `listening` and `speaking`, so a window closes when the interviewer starts
+  talking, which is after the model round trip rather than after the candidate
+  stops. That round trip is not the same on every turn — the server logs it per
+  turn precisely because it varies — so it is not a constant a reader can
+  subtract, and no window is a candidate's response time on its own.
+- A window opens whenever the interviewer stops speaking, which is often not the
+  end of a question. The interviewer's own silence nudge, proactive review, test
+  reaction, time warning, round transition and wrap-up all end in speech, and so
+  does a candidate interrupting; a window also follows a moment when the
+  interviewer published no state at all, and one where it dropped out and came
+  back, and one where the candidate paused the interview. That last one is the
+  only cause the replay can name, because the browser records a `paused` event
+  for it, and a window overlapping one says so on itself.
+- A window with no duration is one the recording ended inside, or one where that
+  clock ran backwards between the two rows.
+- Everything above describes a browser reporting honestly. The replay is
+  produced by the candidate's own page, so a modified one can stamp a turn with
+  another window's number and make a silent window read as answered. Nothing
+  here detects that, and nothing about the earlier scheme did either: it placed
+  a turn by row order, which the same page chose. It is disclosed rather than
+  defended because the reviewer's evidence is the recording, and the panel is a
+  place to look in it rather than a thing to read instead of it.
+- A recording made before the browser stamped those numbers cannot place its
+  turns, and says so on each window rather than reporting a question nobody
+  answered. The distinction is the whole of it: "no candidate transcript
+  recorded" is a claim about the candidate, and it is the only one this panel
+  makes, so it is never made on a recording that cannot support it. Past the
+  first window there is no way to place an unstamped turn without guessing at
+  timing, and guessing is what the earlier version of this did.
+- A lost batch is invisible, and it distorts windows five ways. The replay feed
+  splices a batch of up to 32 consecutive events off its queue before sending,
+  and only a `429` puts it back, so any other failure — the network, an
+  oversized batch, a proxy, a `5xx` — drops it. A lost closing row merges two
+  windows and doubles the duration; a lost `listening` row omits a question
+  entirely; a lost `transcript` row makes an answered question look unanswered;
+  a lost `resumed` row would mark the rest of the interview as paused, except
+  that the interviewer speaking proves it is not, which bounds that one to the
+  window it happened in; and a lost `ended` row brings back the phantom window
+  the interviewer's goodbye would otherwise open, on an interview where nothing
+  else went wrong. All five are disclosed rather than corrected, because the
+  sequence numbers are allocated server-side and a batch that never arrived
+  leaves no gap to notice. Each loss costs the windows it touches and no more:
+  a window opens on the `avatar` row before it rather than on anything
+  cumulative, so the rest of the interview still renders.
+
+A window is a place in the recording to go and watch. It is not a finding: a
+candidate who is thinking is slow too, and the number cannot tell the two
+apart. It also cannot separate the silence before an answer from the answer
+itself, because a transcript turn is recorded when it ends.
+
+## What CodeTrial does not look for
+
+CodeTrial does not attempt to detect interview-assistant overlays, and this is
+a decision rather than a gap. The shipped tools exclude themselves from screen
+capture at the operating-system level — `WDA_EXCLUDEFROMCAPTURE` on Windows and
+the equivalent content-protection flag elsewhere — and at least one turns it on
+at launch before any window is shown. There is nothing for a browser or a
+recording to see, so a capture that shows nothing is evidence of nothing, not
+evidence of absence. Reading gaze direction is refused for the same kind of
+reason and one more: those tools tell their users to place the overlay directly
+below the webcam, so the reading angle is designed around, and CodeTrial does
+not infer intent from a candidate's face at all. What the camera is for here is
+presence, which `web/face-presence.js` reports as a count, and reading a
+direction off it would be a different kind of claim about a person than
+anything this product makes.
+
+What survives both is timing, which is what the response window renders, and a
+person watching the replay.

--- a/docs/interview-contract-versions.md
+++ b/docs/interview-contract-versions.md
@@ -1,38 +1,48 @@
 # Interview contract versioning
 
-Every agent-produced report carries one `interviewContract` bundle with five
-positive integer versions: the bundle, live prompt, report prompt, scoring rubric,
-and public report schema. The server owns this value and stamps it after model
-generation; model or candidate output cannot select it.
+Every agent-produced report carries one `interviewContract` bundle of five
+positive integer versions: the bundle, the live prompt, the report prompt, the
+scoring rubric, and the public report schema. The server owns that value and
+stamps it after model generation, so neither model output nor candidate input
+can select it.
 
-The active bundle is version 4: live prompt 1, report prompt 4, rubric 1, and
-report schema 1. Bundle 4 makes the observable-delivery policy explicit in the
-report prompt and server validator without changing the rubric or public shape.
-Bundle 3 explicitly keeps framework phase scores formative and
-prohibits using them mechanically for hiring decisions while calibration remains
-incomplete. Bundle 2 introduced provider-enforced structured report output and
-strict validation without changing rubric semantics or the public schema. A change to prompt behavior,
-score anchors, or report shape must update the relevant component and create a new
-bundle version in the same change. Update Rust and browser constants, prompt/report
-goldens, migration fixtures, and replay fixtures together. Never reuse a released
-bundle number for different behavior.
+## The active bundle
 
-Compatibility rules:
+Bundle 4: live prompt 1, report prompt 4, rubric 1, report schema 1.
 
-- Reports without `interviewContract` predate this contract. They remain readable
-  and are labeled `legacy/unversioned`; they are never assigned the current rubric.
-- The browser renders the active report schema normally. Additive fields may be
-  ignored by an older renderer only after the bundle/schema migration explicitly
-  permits them.
+| Bundle | Introduced |
+|---|---|
+| 4 | The observable-delivery policy, made explicit in the report prompt and the server validator, with no change to the rubric or the public shape |
+| 3 | Framework phase scores kept explicitly formative, and prohibited from mechanical use in a hiring decision while calibration remains incomplete |
+| 2 | Provider-enforced structured report output and strict validation, with no change to rubric semantics or the public schema |
+
+## Changing it
+
+A change to prompt behavior, score anchors, or report shape updates the relevant
+component and creates a new bundle version in the same change. Rust and browser
+constants, prompt and report goldens, migration fixtures, and replay fixtures
+move together. A released bundle number is never reused for different behavior.
+
+## Compatibility rules
+
+- Reports without `interviewContract` predate this contract. They stay readable
+  and are labeled `legacy/unversioned`; they are never assigned the current
+  rubric.
+- The browser renders the active report schema normally. An older renderer may
+  ignore additive fields only after the bundle and schema migration explicitly
+  permits it.
 - A malformed, unknown, or future bundle becomes an incomplete but renderable
-  report. Scores are not coerced or displayed under a rubric the renderer does not
-  understand.
-- Breaking field semantics, required-field changes, rubric-anchor changes, or
-  prompt-policy changes require a new bundle and the corresponding component bump.
-- Migration belongs at the browser report-sanitization boundary. It must be pure,
-  deterministic, fixture-backed, and preserve the original rubric provenance.
+  report. Scores are not coerced, and not displayed under a rubric the renderer
+  does not understand.
+- Breaking field semantics, required-field changes, rubric-anchor changes, and
+  prompt-policy changes each require a new bundle and the corresponding
+  component bump.
+- Migration belongs at the browser report-sanitization boundary. It is pure,
+  deterministic, fixture-backed, and preserves the original rubric provenance.
 
-Release checklist: update the active server bundle; add the browser migration;
-refresh prompt and report goldens; cover successful, incomplete, legacy, malformed,
-and future reports; verify HTML, Markdown, history/progress, and replay provenance;
+## Release checklist
+
+Update the active server bundle; add the browser migration; refresh the prompt
+and report goldens; cover successful, incomplete, legacy, malformed, and future
+reports; verify HTML, Markdown, history and progress, and replay provenance;
 then run the complete local test suite.

--- a/docs/interview-length.md
+++ b/docs/interview-length.md
@@ -1,0 +1,31 @@
+# Interview length
+
+What the lobby offers, what the endpoints enforce, and how recording lowers
+both. One rule matters more than the rest: the length offered and the length
+enforced come from one function, so they cannot drift apart.
+
+The lobby offers 30, 45, and 60 minutes, and the candidate picks one before
+starting. `CODETRIAL_DURATION_MIN` is only the length preselected for a
+candidate who does not choose; the endpoint accepts 10 to 90 either way, so a
+deployment that lowers the default has not lowered the ceiling.
+
+Recording lowers it. `CODETRIAL_RECORDING_MAX_MINUTES` bounds a single
+recording, and the sweeper fails one still running five minutes past it, so an
+interview longer than the cap loses exactly the stretch past it and the artifact
+is failed rather than delivered. Where recording is on, the longest interview
+this deployment will start is that cap, clamped into the 10–90 the endpoint
+offers; where it is off, the ceiling is 90.
+
+The lobby is told the ceiling rather than left to discover it. `/api/session`
+reports `maxDurationMin`, and the duration row disables the lengths above it
+with the reason beside them — a length this deployment cannot record is never
+offered and then quietly shortened. `/api/token` clamps to the same ceiling, so
+a request that skips the lobby is bounded too, and both endpoints read it from
+one function so the length that is offered and the length that is enforced
+cannot drift apart.
+
+Startup refuses a cap below `CODETRIAL_DURATION_MIN`, so the length this
+deployment preselects is always one it can record; the pairing is a
+configuration error rather than a quietly shortened interview. Should a cap ever
+sit below every length the row offers, the lobby leaves the row alone rather
+than rendering a page with nothing to press.

--- a/docs/observable-delivery-policy.md
+++ b/docs/observable-delivery-policy.md
@@ -1,21 +1,34 @@
 # Observable delivery policy
 
-CodeTrial assesses engineering content that is present in candidate speech, code,
-and test reasoning. It does not assess accent or dialect, typing speed, filler
-words or disfluencies, posture, eye contact, facial expression, body language,
-voice tone, attractiveness, presentation-derived nervousness or confidence, or
-personality and psychological traits. Camera/audio presence and integrity events
-describe session conditions, not candidate performance.
+What a CodeTrial report may say about a candidate, what it may not, and what
+enforces the line.
 
-The report prompt states this boundary and the server independently scans every
+## What is assessed
+
+Engineering content present in candidate speech, code, and test reasoning.
+
+Not assessed: accent or dialect, typing speed, filler words or disfluencies,
+posture, eye contact, facial expression, body language, voice tone,
+attractiveness, presentation-derived nervousness or confidence, and personality
+or psychological traits. Camera and audio presence and integrity events describe
+session conditions, not candidate performance.
+
+## What enforces it
+
+The report prompt states the boundary, and the server independently scans every
 provider-authored narrative field before accepting a report. A prohibited claim
-gets a path-specific semantic validation error and the provider has one bounded
+gets a path-specific semantic validation error, and the provider has one bounded
 repair opportunity. If it remains, the report is incomplete and carries no score
-or verdict. Technical uses such as a confidence interval or an evidence record's
-explicit confidence value are not presentation judgments and remain allowed.
+or verdict.
+
+Technical uses such as a confidence interval, or an evidence record's explicit
+confidence value, are not presentation judgments and remain allowed.
+
+## Adding a delivery signal later
 
 Any future delivery signal requires an explicit opt-in separate from interview
 recording consent, independent validation for reliability and subgroup effects,
 clear `observed` versus `inferred` provenance, purpose-limited retention and
-withdrawal, accessible non-participation, and a new prompt/rubric/report contract.
-It cannot silently reuse camera, microphone, avatar, or integrity telemetry.
+withdrawal, accessible non-participation, and a new prompt, rubric, and report
+contract. It cannot silently reuse camera, microphone, avatar, or integrity
+telemetry.

--- a/docs/provider-cost-and-degradation.md
+++ b/docs/provider-cost-and-degradation.md
@@ -1,49 +1,72 @@
 # Provider cost and degradation controls
 
-Each admitted interview spends one LiveKit/Gemini live-session open, plus one
-open per Gemini socket close it survives. Gemini caps a single connection at
-around ten minutes, so a long interview spends several of these on its normal
-path; a close is resumed onto the same conversation when the server issued a
-handle and started cold when it did not. `GEMINI_RESTART_LIMIT` bounds a failing
-endpoint rather than a long interview: it allows 8 opens in a row, and any socket
-that lived past a minute clears the run. Final reporting has a separate hard
-budget of six Gemini HTTP calls: initial generation plus one semantic repair,
-with each generation allowing its first call and at most two transient retries.
-The counter is consumed immediately before the network request, so no future loop
-change can exceed the budget accidentally. Authentication, bad models, malformed
-responses, and other permanent failures do not receive transport retries.
+What one interview costs upstream, what bounds it when a provider misbehaves,
+and what the candidate sees when it does.
 
-The server admits at most `CODETRIAL_MAX_CONCURRENT_INTERVIEWS` live local agents
-(default 16). A reload of an already-live room reuses its slot; completion and
-panic release it. Provider projects are rotated and their LiveKit connection-minute
-quota is refreshed in the background; known-exhausted projects are skipped. The
-token endpoint allows 30 starts per 60-second bucket. Signed-in buckets are keyed
-by account, anonymous buckets by client address, so anonymous traffic cannot spend
-an authenticated candidate's allowance. Candidate-facing failures use bounded
-machine-owned categories such as `at_capacity`, `livekit_quota_exhausted`, rate
-limit/retry-after, report schema failure, or report timeout; logs must never include
-provider bodies, API keys, prompts, transcripts, code, or grounding text.
+## What an interview spends
 
-Only checked-in/static problem-bank, schema, and vendored runtime metadata may be
-cached. Never cache candidate prompts, transcript, code, profile/JD/resume
-grounding, provider output, repair output, framework evidence, or personalized
-feedback. Report requests are constructed from the current session and each retry
-uses that same session's immutable prompt; there is no cross-session response
-cache.
+Each admitted interview spends one LiveKit and Gemini live-session open, plus
+one open per Gemini socket close it survives. Gemini caps a single connection at
+around ten minutes, so a long interview spends several on its normal path: a
+close is resumed onto the same conversation when the server issued a handle, and
+started cold when it did not.
+
+`GEMINI_RESTART_LIMIT` bounds a failing endpoint rather than a long interview.
+It allows 8 opens in a row, and any socket that lived past a minute clears the
+run.
+
+Final reporting has its own hard budget of six Gemini HTTP calls: initial
+generation plus one semantic repair, each generation allowing its first call and
+at most two transient retries. The counter is consumed immediately before the
+network request, so no future loop change can exceed the budget by accident.
+Authentication failures, bad models, malformed responses, and other permanent
+failures get no transport retry.
+
+## What bounds concurrency
+
+The server admits at most `CODETRIAL_MAX_CONCURRENT_INTERVIEWS` live local
+agents, 16 by default. A reload of an already-live room reuses its slot;
+completion and panic release it. Provider projects are rotated and their LiveKit
+connection-minute quota is refreshed in the background, and known-exhausted
+projects are skipped.
+
+The token endpoint allows 30 starts per 60-second bucket. Signed-in buckets are
+keyed by account and anonymous buckets by client address, so anonymous traffic
+cannot spend an authenticated candidate's allowance.
+
+Candidate-facing failures use bounded machine-owned categories such as
+`at_capacity`, `livekit_quota_exhausted`, rate limit with retry-after, report
+schema failure, and report timeout. Logs never include provider bodies, API
+keys, prompts, transcripts, code, or grounding text.
+
+## What may be cached
+
+Checked-in and static problem-bank data, schemas, and vendored runtime metadata,
+and nothing else. Never candidate prompts, transcript, code, profile, job
+description or resume grounding, provider output, repair output, framework
+evidence, or personalized feedback. Report requests are built from the current
+session and each retry uses that same session's immutable prompt, so there is no
+cross-session response cache.
+
+## What the candidate sees
 
 The browser exposes distinct accessible states for connecting, live,
 reconnecting, offline practice, report generation, incomplete report, and
 retry-ready. Reconnecting preserves the live session and resends current code.
-Offline practice keeps the editor and local tests usable but explicitly promises
-no personalized evaluation. An invalid/exhausted report says no scores or verdict
-were created. Browser fallback may summarize local test progress only for a
-session that never reached an interviewer; it never masquerades canned feedback as
-an agent evaluation.
+Offline practice keeps the editor and local tests usable while explicitly
+promising no personalized evaluation. An invalid or exhausted report says that
+no scores or verdict were created. Browser fallback may summarize local test
+progress only for a session that never reached an interviewer, and never
+presents canned feedback as an agent evaluation.
 
-Operational checks: watch `codetrial dispatch_refused ... reason=at_capacity`,
-`livekit quota:` transitions, token HTTP 429 plus `Retry-After`,
-`gemini report transport_failed call=... retry=...`, and bounded incomplete-report
-categories. Raise concurrency only after checking provider minutes, Gemini limits,
-CPU/audio capacity, and the token burst policy. The deterministic dispatcher,
+## Operating it
+
+Watch `codetrial dispatch_refused ... reason=at_capacity`, `livekit quota:`
+transitions, token HTTP 429 with `Retry-After`, `gemini report
+transport_failed call=... retry=...`, and the bounded incomplete-report
+categories.
+
+Raise concurrency only after checking provider minutes, Gemini limits, CPU and
+audio capacity, and the token burst policy. The deterministic dispatcher,
 rate-isolation, resume-limit, report-budget, request-isolation, and browser-state
-tests run under `./scripts/test.sh`.
+tests all run under `./scripts/test.sh`.

--- a/docs/recording-contract.md
+++ b/docs/recording-contract.md
@@ -102,7 +102,7 @@ because a later task has to recognize a wrong one:
 
 ## Fixed paths
 
-These values have exactly one owner in code, `src/recording.rs`, and
+These values have exactly one owner in code, `src/recording/contract.rs`, and
 `tests/recording_contract.rs` fails if this document stops naming them. Do not
 respell them in a later task.
 
@@ -268,8 +268,9 @@ Events this pipeline reacts to: `egress_started`, `egress_updated`,
 
 ## The lifecycle
 
-Eight states. `RecordingState::may_become` in `src/recording.rs` is the only
-implementation of this table, and any transition absent from both is a bug.
+Eight states. `RecordingState::may_become` in `src/recording/provider.rs` is
+the only implementation of this table, and any transition absent from both is a
+bug.
 
 | From | May become | Because |
 |---|---|---|

--- a/docs/recording-contract.md
+++ b/docs/recording-contract.md
@@ -1027,7 +1027,32 @@ three scoped to the account.
 |---|---|
 | `GET /api/recordings` | one page, newest first, plus `nextCursor` |
 | `GET /api/recordings/{id}` | one recording's state, dates and recovery |
-| `GET /api/recordings/{id}/events` | its replay, snapshot or tail |
+| `GET /api/recordings/{id}/events` | its replay: snapshot, review or tail |
+
+The events route has three shapes and two query parameters. Absent or negative
+`after` is the snapshot, which keeps the newest row of each replaceable kind and
+drops what it replaced. A sequence number is the tail, which drops nothing.
+`avatar=history` on the snapshot selects the review read: the snapshot with the
+collapse narrowed to the kinds that restate a whole value, `editor` and `stage`,
+so the `avatar` and `lifecycle` transition histories survive. The replay page
+needs the first to compute the response window described under Integrity
+evidence in `docs/integrity-evidence.md`, and the second to say that a window
+overlapped a pause;
+without the pause rows a break renders as thinking time, which is what
+`applyPause` records them to prevent. It is the one
+parameter the recording template's own read does not accept, because a template
+joining late wants Jim's current state and not the history of it. It applies to
+the snapshot only: the tail collapses nothing already, so a request carrying
+both is answered as the tail it asked for.
+
+The review read costs one row per `avatar` or `lifecycle` transition more than
+the snapshot does, which a 45-minute interview keeps to a few hundred short
+rows. The browser writes an `avatar` row only on a change and the server
+deduplicates the state it publishes, so a turn the interviewer takes is two
+rows, one for the speaking and one for the listening after it. How often it can
+take one unprompted is bounded by whichever of `SILENCE_COOLDOWN_S`,
+`REVIEW_INTERVAL_S` and `TEST_REACTION_COOLDOWN_S` applies, the last being the
+tightest at 20 seconds.
 
 Paged by cursor, `<created_at>.<id>`, rather than by offset. A cursor that does
 not parse is `400 cursor_invalid` rather than a silent first page, which would
@@ -1045,6 +1070,10 @@ reason: it is a credential's subject.
 A deleted or expired recording is `410` on both the detail and the events, with
 `recording_deleted` and `replay_expired` respectively: one was taken away and
 the other waited too long, and they are different things to the person asking.
+That holds for all three shapes of the events read, including the review read:
+`gone_response` runs before any of them and `replay_view` checks the deadline
+again inside its own transaction, so a widened read is not a way past a deadline
+that closed the route beside it.
 Cross-account is `404` on all three, because an account that does not own a
 recording should not learn it exists.
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,6 +9,23 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 
 failed=""
 
+# What this run did not check, collected as it goes and printed at the end.
+#
+# Every optional lane already said so where it was skipped, several hundred
+# lines above the verdict, which is not where anyone looks. A gate that is
+# quieter about what it skipped than about what it ran reports a green tree to
+# somebody whose checkout cannot run a tenth of it: the browser suite alone
+# skips thirty-odd tests without Chromium, and the shell lane covers the scripts
+# that delete cloud artifacts.
+skipped=""
+
+skip()
+{
+    echo "skipping $1" >&2
+    skipped="$skipped
+  $1"
+}
+
 gate()
 {
     name=$1
@@ -30,7 +47,49 @@ browser_tests()
         echo "no browser tests matched $ROOT/tests/browser/*.test.js" >&2
         return 1
     fi
-    node --test "$@"
+
+    # Two reporters: `spec` to the terminal for whoever is watching, and `tap`
+    # to a file for the summary below. A skip reads as "unverified", not as
+    # "fine", and both the reason and the total scroll past long before the
+    # verdict, so they are counted and repeated where the reader is looking.
+    #
+    # The parsing reads TAP rather than the human output for one reason: TAP
+    # says which lines are directives. `spec` writes the reason in place of the
+    # word, so a skip is `# javac 11 is older...` and cannot be told apart from
+    # a passing test titled `works (1ms) # example`, which is a test that ran
+    # being reported as one that did not. TAP escapes `#` inside a title and
+    # spells the directive `# SKIP` or `# TODO`, so there is nothing to guess.
+    #
+    # Anchored on the assertion record all the same, because the YAML block
+    # under a failure quotes the error verbatim: a test whose message happened
+    # to contain the word counted itself as a skip from inside its own
+    # diagnostic.
+    #
+    # No pipeline either, which is why the exit status no longer travels through
+    # a second file: `tee` loses it in POSIX sh and asking node for a file does
+    # not.
+    tap=$(mktemp)
+    node --test \
+        --test-reporter=spec --test-reporter-destination=stdout \
+        --test-reporter=tap --test-reporter-destination="$tap" "$@"
+    status=$?
+
+    # A heredoc rather than a pipe, so the loop runs in this shell and what it
+    # appends to `skipped` survives it. A todo is counted beside the skips on
+    # purpose: it checked nothing either.
+    while IFS= read -r reason; do
+        [ -n "$reason" ] || continue
+        skipped="$skipped
+  browser tests, $reason"
+    done << REASONS
+$(sed -n -e 's/^ *\(not \)\{0,1\}ok [0-9][0-9]* .* # SKIP */skipped: /p' \
+        -e 's/^ *\(not \)\{0,1\}ok [0-9][0-9]* .* # TODO */todo: /p' "$tap" \
+        | sed 's/: $/: no reason given/' \
+        | sort | uniq -c | sed 's/^ *\([0-9]*\) /\1 /')
+REASONS
+
+    rm -f "$tap"
+    return "$status"
 }
 
 # The Rust half of this repo runs clippy at `-D warnings`; this is the other
@@ -41,7 +100,7 @@ browser_tests()
 eslint_gate()
 {
     if [ ! -x "$ROOT/node_modules/.bin/eslint" ]; then
-        echo "skipping eslint: run \`npm install\` to enable it locally" >&2
+        skip "eslint: \`npm install\` enables it"
         return 0
     fi
 
@@ -66,7 +125,7 @@ eslint_gate()
 actionlint_gate()
 {
     if ! command -v actionlint > /dev/null 2>&1; then
-        echo "skipping actionlint: install it to check .github/workflows locally" >&2
+        skip "actionlint: installing it checks .github/workflows, which is code too"
         return 0
     fi
 
@@ -76,7 +135,7 @@ actionlint_gate()
 cargo_audit_gate()
 {
     if ! command -v cargo-audit > /dev/null 2>&1; then
-        echo "skipping cargo-audit: run \`cargo install cargo-audit\` to enable it locally" >&2
+        skip "cargo-audit: \`cargo install cargo-audit\` audits the dependency tree"
         return 0
     fi
 
@@ -90,7 +149,7 @@ cargo_audit_gate()
 ruff_gate()
 {
     if ! command -v ruff > /dev/null 2>&1; then
-        echo "skipping ruff: install it to lint the Python locally" >&2
+        skip "ruff: installing it lints the Python under scripts/ and tests/"
         return 0
     fi
 
@@ -114,7 +173,7 @@ shell_syntax()
     if command -v shellcheck > /dev/null 2>&1; then
         (cd "$ROOT" && shellcheck scripts/*.sh) || status=1
     else
-        echo "skipping shellcheck: install it to enable the rest of this gate locally" >&2
+        skip "shellcheck: installing it checks what 21 shell scripts mean, not just that they parse"
     fi
 
     return "$status"
@@ -169,6 +228,12 @@ gate browser-check-env env BROWSER_CHECK_VALIDATE_ENV_ONLY=1 sh "$ROOT/scripts/b
 # running this, so a stale tests/golden/report-python.json would only have
 # surfaced the next time somebody ran the whole thing by hand.
 gate report-parity-fixtures env REPORT_PARITY_CHECK_VALIDATE_FIXTURES_ONLY=1 sh "$ROOT/scripts/report-parity-check.sh"
+
+[ -z "$skipped" ] || {
+    echo "" >&2
+    echo "not checked by this run:$skipped" >&2
+    echo "" >&2
+}
 
 [ -z "$failed" ] || {
     echo "failed gates:$failed" >&2

--- a/src/agent/events.rs
+++ b/src/agent/events.rs
@@ -172,45 +172,7 @@ fn apply_test_results(
 
 fn apply_control(state: &mut RuntimeState, payload: &serde_json::Value) -> DataEventResult {
     match payload.get("type").and_then(serde_json::Value::as_str) {
-        // Pause used to be a practice-only affordance, and practice is gone.
-        // Left working for everyone rather than deleted with the mode: a
-        // candidate whose machine or network interrupts them mid-interview can
-        // at least stop the interviewer talking into an empty room. It stops
-        // the conversation, not the deadline, which runs on wall clock either
-        // way. It is recorded, so a paused stretch is visible in the report.
-        Some("pause_interview") if !state.ended => {
-            let paused = payload
-                .get("paused")
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(false);
-            if paused == state.paused {
-                return DataEventResult::default();
-            }
-            state.paused = paused;
-
-            // A resumed interview whose interviewer was replaced mid-pause has
-            // to be re-grounded before it is told to carry on: the fixed line
-            // below assumes a Jim who remembers the conversation, and after a
-            // cold restart there is none to continue from.
-            let cold_brief = !paused && std::mem::take(&mut state.needs_cold_brief);
-            DataEventResult {
-                pause_changed: Some(paused),
-                generate_reply: (!paused).then(|| {
-                    if cold_brief {
-                        cold_restart(state)
-                    } else {
-                        "The interview has resumed. Continue with your REACTO step.".to_string()
-                    }
-                }),
-
-                // Resuming makes Jim speak, so it starts the interjection
-                // cooldown like every other reply here. Without this the timing
-                // loop could follow the resume line straight into a proactive
-                // review, talking twice over a candidate who just came back.
-                update_last_interjection: !paused,
-                ..DataEventResult::default()
-            }
-        }
+        Some("pause_interview") if !state.ended => control_pause(state, payload),
         Some("round_transition")
             if !state.ended
                 && !state.paused
@@ -221,79 +183,135 @@ fn apply_control(state: &mut RuntimeState, payload: &serde_json::Value) -> DataE
                 && state.started_at.elapsed() + ROUND_TRANSITION_SKEW
                     >= std::time::Duration::from_secs(u64::from(state.coding_minutes) * 60) =>
         {
-            state.round_transition_seen = true;
-            let completed = |phase| {
-                state
-                    .framework_evidence
-                    .iter()
-                    .any(|item| item.phase == phase && item.kind != EvidenceKind::Skipped)
-            };
-            if completed(FrameworkPhase::Test) && completed(FrameworkPhase::Optimizations) {
-                state.behavioral_round_started = true;
-                DataEventResult {
-                    round_changed: Some("started"),
-                    generate_reply: Some("[SYSTEM EVENT] The trusted coding completion gate passed: Test and Optimizations both have candidate evidence. The coding round is closed. Begin the reserved behavioral round now with exactly one concise question under the private STAR, profile, and document-grounding policies. Use prior candidate answers only to deepen the follow-up; do not repeat them and do not return to coding.".to_string()),
-                    ..DataEventResult::default()
-                }
-            } else {
-                DataEventResult {
-                    round_changed: Some("skipped"),
-                    generate_reply: Some("[SYSTEM EVENT] The behavioral reserve began, but the trusted coding completion gate did not pass because Test or Optimizations evidence is absent. Do not start STAR. Keep the candidate focused on a testable solution, highest-value tests, and justified complexity until the session ends; missing STAR phases will be marked skipped.".to_string()),
-                    ..DataEventResult::default()
-                }
-            }
+            control_round_transition(state)
         }
         Some("time_warning") if !state.ended && !state.paused => {
-            let remaining_seconds = payload
-                .get("remainingSeconds")
-                .and_then(json_int)
-                .unwrap_or(300);
-            let minutes = spoken_minutes_from_remaining_seconds(remaining_seconds) as u32;
-            DataEventResult {
-                generate_reply: Some(if state.behavioral_round_started {
-                    format!(
-                        "[SYSTEM EVENT] Exactly {minutes} minutes remain in the active behavioral round. Do not return to coding or ask a new question. Let the candidate finish the current answer, ask at most the one permitted neutral missing-STAR follow-up, then close naturally."
-                    )
-                } else {
-                    time_warning(minutes)
-                }),
-                ..DataEventResult::default()
-            }
+            control_time_warning(state, payload)
         }
-        Some("end_interview") if !state.ended => {
-            if !state.behavioral_round_started
-                && !payload.get("code").is_some_and(serde_json::Value::is_null)
-                && let Some(code) = payload.get("code").and_then(serde_json::Value::as_str)
-            {
-                state.code = code.to_string();
-            }
-
-            // Read independently of the code. Nesting it meant a payload whose
-            // code was absent or null also discarded the language, and the
-            // report prompt was then written against whatever language the
-            // session last happened to record. Validated for the same reason as
-            // the code path: this string reaches the report prompt.
-            if !state.behavioral_round_started
-                && let Some((id, _)) = payload
-                    .get("language")
-                    .and_then(serde_json::Value::as_str)
-                    .and_then(offered_language)
-            {
-                state.language = id.to_string();
-            }
-            state.ended = true;
-            DataEventResult {
-                finish_interview: Some(
-                    payload
-                        .get("reason")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or("candidate_ended")
-                        .to_string(),
-                ),
-                ..DataEventResult::default()
-            }
-        }
+        Some("end_interview") if !state.ended => control_end_interview(state, payload),
         _ => DataEventResult::default(),
+    }
+}
+
+/// Pause used to be a practice-only affordance, and practice is gone. Left
+/// working for everyone rather than deleted with the mode: a candidate whose
+/// machine or network interrupts them mid-interview can at least stop the
+/// interviewer talking into an empty room. It stops the conversation, not the
+/// deadline, which runs on wall clock either way. It is recorded, so a paused
+/// stretch is visible in the report.
+fn control_pause(state: &mut RuntimeState, payload: &serde_json::Value) -> DataEventResult {
+    let paused = payload
+        .get("paused")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if paused == state.paused {
+        return DataEventResult::default();
+    }
+    state.paused = paused;
+
+    // A resumed interview whose interviewer was replaced mid-pause has to be
+    // re-grounded before it is told to carry on: the fixed line below assumes a
+    // Jim who remembers the conversation, and after a cold restart there is
+    // none to continue from.
+    let cold_brief = !paused && std::mem::take(&mut state.needs_cold_brief);
+    DataEventResult {
+        pause_changed: Some(paused),
+        generate_reply: (!paused).then(|| {
+            if cold_brief {
+                cold_restart(state)
+            } else {
+                "The interview has resumed. Continue with your REACTO step.".to_string()
+            }
+        }),
+
+        // Resuming makes Jim speak, so it starts the interjection cooldown like
+        // every other reply here. Without this the timing loop could follow the
+        // resume line straight into a proactive review, talking twice over a
+        // candidate who just came back.
+        update_last_interjection: !paused,
+        ..DataEventResult::default()
+    }
+}
+
+/// The reserved behavioral round, opened or refused, once.
+fn control_round_transition(state: &mut RuntimeState) -> DataEventResult {
+    state.round_transition_seen = true;
+    let completed = |phase| {
+        state
+            .framework_evidence
+            .iter()
+            .any(|item| item.phase == phase && item.kind != EvidenceKind::Skipped)
+    };
+    if completed(FrameworkPhase::Test) && completed(FrameworkPhase::Optimizations) {
+        state.behavioral_round_started = true;
+        DataEventResult {
+            round_changed: Some("started"),
+            generate_reply: Some("[SYSTEM EVENT] The trusted coding completion gate passed: Test and Optimizations both have candidate evidence. The coding round is closed. Begin the reserved behavioral round now with exactly one concise question under the private STAR, profile, and document-grounding policies. Use prior candidate answers only to deepen the follow-up; do not repeat them and do not return to coding.".to_string()),
+            ..DataEventResult::default()
+        }
+    } else {
+        DataEventResult {
+            round_changed: Some("skipped"),
+            generate_reply: Some("[SYSTEM EVENT] The behavioral reserve began, but the trusted coding completion gate did not pass because Test or Optimizations evidence is absent. Do not start STAR. Keep the candidate focused on a testable solution, highest-value tests, and justified complexity until the session ends; missing STAR phases will be marked skipped.".to_string()),
+            ..DataEventResult::default()
+        }
+    }
+}
+
+/// The clock crossing the warning threshold.
+///
+/// The one control message that reads the state without writing any, which is
+/// what the shared reference says.
+fn control_time_warning(state: &RuntimeState, payload: &serde_json::Value) -> DataEventResult {
+    let remaining_seconds = payload
+        .get("remainingSeconds")
+        .and_then(json_int)
+        .unwrap_or(300);
+    let minutes = spoken_minutes_from_remaining_seconds(remaining_seconds) as u32;
+    DataEventResult {
+        generate_reply: Some(if state.behavioral_round_started {
+            format!(
+                "[SYSTEM EVENT] Exactly {minutes} minutes remain in the active behavioral round. Do not return to coding or ask a new question. Let the candidate finish the current answer, ask at most the one permitted neutral missing-STAR follow-up, then close naturally."
+            )
+        } else {
+            time_warning(minutes)
+        }),
+        ..DataEventResult::default()
+    }
+}
+
+/// The candidate leaving, however they left.
+fn control_end_interview(state: &mut RuntimeState, payload: &serde_json::Value) -> DataEventResult {
+    if !state.behavioral_round_started
+        && !payload.get("code").is_some_and(serde_json::Value::is_null)
+        && let Some(code) = payload.get("code").and_then(serde_json::Value::as_str)
+    {
+        state.code = code.to_string();
+    }
+
+    // Read independently of the code. Nesting it meant a payload whose code was
+    // absent or null also discarded the language, and the report prompt was
+    // then written against whatever language the session last happened to
+    // record. Validated for the same reason as the code path: this string
+    // reaches the report prompt.
+    if !state.behavioral_round_started
+        && let Some((id, _)) = payload
+            .get("language")
+            .and_then(serde_json::Value::as_str)
+            .and_then(offered_language)
+    {
+        state.language = id.to_string();
+    }
+    state.ended = true;
+    DataEventResult {
+        finish_interview: Some(
+            payload
+                .get("reason")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("candidate_ended")
+                .to_string(),
+        ),
+        ..DataEventResult::default()
     }
 }
 

--- a/src/agent/prompts.rs
+++ b/src/agent/prompts.rs
@@ -456,8 +456,13 @@ pub struct ReportPromptInput<'a> {
     pub test_summary: &'a str,
 }
 
-pub fn report_prompt(input: ReportPromptInput<'_>) -> String {
-    let rubric_version = RUBRIC_VERSION;
+/// What happened in this interview: the brief the reviewer reads before the
+/// rules, and the only half of the prompt that interpolates anything.
+///
+/// The four values that can be absent get the words the prompt uses for
+/// absence here, rather than in the caller, because "the editor was left empty"
+/// is prompt text and belongs with the rest of it.
+fn report_brief(input: &ReportPromptInput<'_>) -> String {
     let metadata = input.problem.question_metadata();
     let competencies = metadata.competencies.join(", ");
     let [statement_point, optimal_point, pitfalls_point] = metadata.expected_discussion_points;
@@ -520,9 +525,33 @@ Score two independent dimensions from 0 to 100:
    of Situation, Task, personal Action, and Result only if the interviewer actually
    asked a behavioral question. If none was asked, say behavioral communication
    was not assessed and do not deduct for it. Consider independence too: each hint
-   should meaningfully reduce this score; {} hint(s) were given.
+   should meaningfully reduce this score; {} hint(s) were given."#,
+        input.duration_min,
+        input.elapsed_min,
+        input.problem.title,
+        input.problem.difficulty,
+        statement_point,
+        optimal_point,
+        pitfalls_point,
+        input.language,
+        final_code,
+        transcript,
+        input.hints_used,
+        test_summary,
+        input.hints_used
+    )
+}
 
-Decision rule: "HIRE" only if the performance would clear a real mid-level SWE
+/// The schema, and the rules for filling it in. The same document every time.
+///
+/// Split from the brief where the last interpolated value ends, so this half
+/// interpolates nothing but the rubric version. It stays one string rather than
+/// being assembled from fragments: a reviewer reads it end to end, and a rule
+/// that arrives in pieces is one somebody has to reassemble to check.
+fn report_rules() -> String {
+    let rubric_version = RUBRIC_VERSION;
+    format!(
+        r#"Decision rule: "HIRE" only if the performance would clear a real mid-level SWE
 onsite bar — a working, reasonably optimal solution AND clear communication.
 Otherwise "NO_HIRE".
 The ten `frameworkAssessment` phase scores are formative coaching signals and
@@ -622,21 +651,12 @@ clear opportunity. A zero is observed performance, never a substitute for `null`
 Weakness tags must be copied character for character from the `weakness` of an
 `improvementPlan` item whose `phase` is this phase; where no plan item names this
 phase, the list is empty. Evidence confidence is not
-performance and must never become a phase score."#,
-        input.duration_min,
-        input.elapsed_min,
-        input.problem.title,
-        input.problem.difficulty,
-        statement_point,
-        optimal_point,
-        pitfalls_point,
-        input.language,
-        final_code,
-        transcript,
-        input.hints_used,
-        test_summary,
-        input.hints_used
+performance and must never become a phase score."#
     )
+}
+
+pub fn report_prompt(input: ReportPromptInput<'_>) -> String {
+    format!("{}\n\n{}", report_brief(&input), report_rules())
 }
 
 pub fn test_results_reaction(summary_text: &str, all_passed: bool) -> String {

--- a/src/livekit.rs
+++ b/src/livekit.rs
@@ -2,23 +2,34 @@
 //! Gemini, publish Gemini's audio back, and produce the report when the
 //! interview ends.
 //!
-//! Still the largest module in the tree, so here is its shape. The regions
-//! below are cohesive and appear in this order; a further split should follow
-//! these lines rather than a line count.
+//! Still the largest module in the tree, so here is its shape.
 //!
-//! Two are already out: `media` holds the buffers, pumps and codecs that carry
+//! Four regions are out. `media` holds the buffers, pumps and codecs that carry
 //! audio and video in both directions, and `turn` holds the state a turn is
-//! made of, which explains what stayed behind with the loop.
+//! made of, which explains what stayed behind with the loop. `rooms` is the
+//! only region that talks to LiveKit over HTTP rather than over the room's
+//! event stream, and `report` is the packet an ending interview produces.
+//!
+//! What is left is the loop and the things it is made of:
 //!
 //! - `run_room` and `join_room`: the lifecycle, and the only entry point.
-//! - Room admin over the LiveKit REST API (`isolate_local_agent` through
-//!   `evict_duplicate_agent`): finding and removing a duplicate agent left
-//!   behind by a previous run.
+//! - Session setup and restart (`take_restart_attempt` through `open_session`):
+//!   what runs once before the loop, and what the loop calls when the Gemini
+//!   socket dies under it.
 //! - Event handling (`handle_data_packet`, `handle_gemini_event`): the sources
 //!   that drive the session. The third, `handle_media_event`, is in `media`.
 //! - Turn procedures (`send_wrap_up_and_wait` through `close_turn`): what ends
 //!   a turn, operating on the context above.
-//! - Report building (`publish_report` through `report_data_packet`).
+//!
+//! Session setup is the region that looks separable and is not, which is worth
+//! writing down so the next reader does not spend the afternoon finding out.
+//! `open_session` and `restart_after_close` name `InterviewContext`,
+//! `GeminiEventContext`, `OutputAudio`, `CandidateMedia` and `TurnState`, and
+//! call `join_room`, `close_turns`, `cut_off_turn`, `set_agent_state`,
+//! `publish_interviewer_state` and `candidate_bootstrap`. Moving it out moves
+//! the loop's own vocabulary with it, and what is gained is a file boundary
+//! rather than a seam. The three that did come out each named four parent items
+//! or fewer.
 
 use std::collections::HashMap;
 use std::ops::ControlFlow;
@@ -30,10 +41,9 @@ use ::livekit::data_stream::api::StreamTextOptions;
 use ::livekit::prelude::{DataPacket, RemoteParticipant, Room, RoomEvent, RoomOptions};
 
 use crate::agent::{
-    ReportPromptInput, RuntimeState, SpeakerTurn, WATCH_TICK_S, apply_data_event, final_report,
-    format_test_run, framework_evidence_json, framework_progress, interview_contract_json,
-    parse_participant_metadata, read_editor_text, record_framework_evidence, report_prompt,
-    transcript_for_report, wrap_up,
+    RuntimeState, SpeakerTurn, WATCH_TICK_S, apply_data_event, framework_evidence_json,
+    framework_progress, parse_participant_metadata, read_editor_text, record_framework_evidence,
+    wrap_up,
 };
 use crate::config::AgentConfig;
 use crate::runtime::TOPIC_CONTROL;
@@ -57,19 +67,25 @@ const CANDIDATE_JOIN_LIMIT: Duration = Duration::from_secs(300);
 const CANDIDATE_ABSENCE_LIMIT: Duration = Duration::from_secs(90);
 
 use crate::gemini::{
-    GeminiEvent, GeminiFunctionCall, GeminiLiveSession, generate_report, open_live_session,
-    redact_api_key, resume_live_session,
+    GeminiEvent, GeminiFunctionCall, GeminiLiveSession, open_live_session, resume_live_session,
 };
-#[cfg(test)]
-use crate::runtime::bootstrap;
 use crate::runtime::{
     AGENT_NAME, RuntimeBootstrap, TOOL_LOG_HINT, TOOL_READ_EDITOR, TOOL_RECORD_FRAMEWORK_EVIDENCE,
-    TOPIC_REPORT, TOPIC_TRANSCRIPTION, agent_identity,
+    TOPIC_TRANSCRIPTION, agent_identity,
 };
-use crate::token::{LivekitTokenInput, livekit_room_admin_token, livekit_token};
+use crate::token::{LivekitTokenInput, livekit_token};
 
 mod media;
+mod report;
+mod rooms;
 mod turn;
+
+use report::publish_report;
+use rooms::{evict_duplicate_agent, isolate_local_agent};
+
+// Re-exported rather than merely used: `web::setup` calls this to check the
+// credentials a Setup form was given, and it names it through this module.
+pub(crate) use rooms::validate_livekit_credentials;
 
 use media::*;
 use turn::*;
@@ -109,7 +125,7 @@ const NOTABLE_PLAYOUT_BACKLOG: Duration = Duration::from_millis(500);
 /// Covers the normal report attempt, one schema repair, and bounded transient
 /// retries. The candidate is watching a spinner, so this is the point where
 /// waiting stops being worth more than an honest incomplete report.
-const REPORT_TIMEOUT: Duration = Duration::from_secs(45);
+pub(super) const REPORT_TIMEOUT: Duration = Duration::from_secs(45);
 /// Whether the candidate is in the room, and since when they have not been.
 ///
 /// The departure, the return and the grace check happen in three different
@@ -797,241 +813,6 @@ async fn join_room(
     Ok((room, events))
 }
 
-async fn isolate_local_agent(
-    config: &AgentConfig,
-    room_name: &str,
-    local_identity: &str,
-    now_seconds: u64,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // One list pass more than removal rounds: the last pass only confirms the
-    // final removal landed.
-    let mut rounds_left = DUPLICATE_AGENT_ISOLATION_ATTEMPTS;
-    loop {
-        let participants = list_room_participants(config, room_name, now_seconds).await?;
-        let duplicate_agents = duplicate_agent_identities(&participants, local_identity);
-        if duplicate_agents.is_empty() {
-            return Ok(());
-        }
-        if rounds_left == 0 {
-            // Loud, not fatal. This used to return Err, and in `serve` an agent
-            // error aborts the web task and exits the process, so one stubborn
-            // auto-dispatched agent took the whole server down mid-interview.
-            // Two interviewers talking over each other is bad; no interviewer,
-            // no editor and no report is worse, and the operator can see this
-            // line and act on it while the candidate finishes.
-            eprintln!(
-                "WARNING: duplicate LiveKit agent participants remained after \
-                 {DUPLICATE_AGENT_ISOLATION_ATTEMPTS} attempts, continuing anyway: \
-                 {duplicate_agents:?}"
-            );
-            return Ok(());
-        }
-        rounds_left -= 1;
-        for identity in &duplicate_agents {
-            eprintln!("removing duplicate LiveKit agent participant identity={identity}");
-            remove_room_participant(config, room_name, identity, now_seconds).await?;
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
-}
-
-async fn list_room_participants(
-    config: &AgentConfig,
-    room_name: &str,
-    now_seconds: u64,
-) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
-    livekit_room_service_request(
-        config,
-        room_name,
-        "ListParticipants",
-        serde_json::json!({ "room": room_name }),
-        now_seconds,
-    )
-    .await
-}
-
-/// A removal that finds nothing to remove has achieved what it was asked to do.
-///
-/// This used to propagate the 404 and kill the interview. The duplicate agents
-/// being evicted here are the ones that leave on their own, so losing the race
-/// with them is the common case, not the exceptional one: the agent greeted the
-/// candidate, tried to evict a participant that had already gone, took the
-/// `not_found` as fatal, and exited. The candidate was left in a room with no
-/// interviewer, talking to nobody, with the status pill correctly reading
-/// "Waiting" and nothing on screen explaining why.
-async fn remove_room_participant(
-    config: &AgentConfig,
-    room_name: &str,
-    identity: &str,
-    now_seconds: u64,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    match livekit_room_service_request(
-        config,
-        room_name,
-        "RemoveParticipant",
-        serde_json::json!({ "room": room_name, "identity": identity }),
-        now_seconds,
-    )
-    .await
-    {
-        Ok(_) => Ok(()),
-        Err(error) if is_participant_gone(&error.to_string()) => {
-            eprintln!("duplicate LiveKit agent participant already gone identity={identity}");
-            Ok(())
-        }
-        Err(error) => Err(error),
-    }
-}
-
-/// Matches on the wire response rather than on a status code alone, because
-/// LiveKit answers Twirp over HTTP and a bare 404 could also mean the route is
-/// wrong. All three parts are required: the method, so a 404 from any other
-/// RoomService call stays fatal; the status; and `not_found` in the body, which
-/// is the participant-specific Twirp code rather than an HTML error page.
-fn is_participant_gone(error: &str) -> bool {
-    error.contains("RemoveParticipant") && error.contains("404") && error.contains("not_found")
-}
-
-/// The Twirp POST both RoomService callers make. Only the token and the base
-/// differ, and both are strings; the body comes back with the status because a
-/// refusal explains itself there and not in the code.
-async fn post_room_service(
-    base: &str,
-    token: &str,
-    method: &str,
-    body: &serde_json::Value,
-) -> Result<(reqwest::StatusCode, String), Box<dyn std::error::Error + Send + Sync>> {
-    let response = crate::http_client()
-        .post(format!("{base}/twirp/livekit.RoomService/{method}"))
-        .bearer_auth(token)
-        .json(body)
-        .send()
-        .await?;
-    let status = response.status();
-    Ok((status, response.text().await?))
-}
-
-async fn livekit_room_service_request(
-    config: &AgentConfig,
-    room_name: &str,
-    method: &str,
-    body: serde_json::Value,
-    now_seconds: u64,
-) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
-    let token = livekit_room_admin_token(
-        &config.livekit_api_key,
-        &config.livekit_api_secret,
-        room_name,
-        now_seconds,
-    )?;
-    let (status, text) = post_room_service(
-        &livekit_http_base(&config.livekit_url),
-        &token,
-        method,
-        &body,
-    )
-    .await?;
-    if !status.is_success() {
-        return Err(format!("LiveKit RoomService {method} failed: {status} {text}").into());
-    }
-    parse_room_service_response(method, &text)
-}
-
-/// Proves credentials like `check-gemini` proves a Google key: the server
-/// must accept a signed request. `ListRooms` needs no room to exist.
-pub(crate) async fn validate_livekit_credentials(
-    url: &str,
-    api_key: &str,
-    api_secret: &str,
-    now_seconds: u64,
-) -> Result<(), String> {
-    let token = crate::token::livekit_room_list_token(api_key, api_secret, now_seconds)
-        .map_err(|error| error.to_string())?;
-    let (status, text) = post_room_service(
-        &livekit_http_base(url),
-        &token,
-        "ListRooms",
-        &serde_json::json!({}),
-    )
-    .await
-    .map_err(|error| error.to_string())?;
-    if status.is_success() {
-        return Ok(());
-    }
-
-    // The body, because it is LiveKit's own account of the refusal and the
-    // Setup form is the one place a reader can act on it: a status alone says
-    // "did not work" to someone who already knows that. Bounded, because a
-    // wrong host answers with an HTML page and the form is one line.
-    const REASON_LIMIT: usize = 200;
-    let reason: String = text.chars().take(REASON_LIMIT).collect();
-    let ellipsis = if text.chars().count() > REASON_LIMIT {
-        "..."
-    } else {
-        ""
-    };
-    Err(format!(
-        "LiveKit ListRooms failed: {status} {reason}{ellipsis}"
-    ))
-}
-
-/// The RoomService origin for a LiveKit URL: the same host, over the scheme an
-/// HTTP client will send.
-///
-/// The rewrite goes through `livekit_scheme` rather than matching the two
-/// websocket schemes here, because `validate_livekit_url` accepts a scheme in
-/// any case and this has to rewrite every spelling that accepts. A pasted
-/// `WSS://` used to survive unchanged, and reqwest refuses any scheme but http
-/// and https before the request leaves the process, so credentials that were
-/// good came back as credentials that did not work.
-fn livekit_http_base(url: &str) -> String {
-    let trimmed = url.trim_end_matches('/');
-    match crate::config::livekit_scheme(trimmed) {
-        Some((scheme, _, http)) => format!("{http}{}", &trimmed[scheme.len()..]),
-        None => trimmed.to_string(),
-    }
-}
-
-fn parse_room_service_response(
-    method: &str,
-    text: &str,
-) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
-    serde_json::from_str(text).map_err(|error| {
-        format!("LiveKit RoomService {method} returned invalid JSON: {error}").into()
-    })
-}
-
-fn duplicate_agent_identities(
-    participants: &serde_json::Value,
-    local_identity: &str,
-) -> Vec<String> {
-    participants
-        .get("participants")
-        .and_then(serde_json::Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter(|participant| is_agent_participant(participant))
-        .filter_map(|participant| {
-            participant
-                .get("identity")
-                .and_then(serde_json::Value::as_str)
-        })
-        .filter(|identity| *identity != local_identity)
-        .map(ToString::to_string)
-        .collect()
-}
-
-fn is_agent_participant(participant: &serde_json::Value) -> bool {
-    participant
-        .pointer("/permission/agent")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
-        || participant
-            .get("kind")
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|kind| kind == "AGENT")
-}
-
 fn is_candidate(participant: &RemoteParticipant) -> bool {
     participant.kind() == ParticipantKind::Standard
         && candidate_identity_matches(&participant.identity().0, &participant.metadata())
@@ -1047,19 +828,6 @@ pub fn candidate_identity_matches(identity: &str, metadata: &str) -> bool {
                 .map(str::to_owned)
         })
         .is_some_and(|minted| minted == identity && minted.starts_with("candidate-"))
-}
-
-/// A second agent in the room would answer over the top of this one, so the
-/// late joiner is removed rather than tolerated.
-async fn evict_duplicate_agent(
-    config: &AgentConfig,
-    room_name: &str,
-    participant: &RemoteParticipant,
-    now_seconds: u64,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let identity = participant.identity().0;
-    eprintln!("removing late duplicate LiveKit agent participant identity={identity}");
-    remove_room_participant(config, room_name, &identity, now_seconds).await
 }
 
 /// Only the candidate this interview bootstrapped from may drive the runtime.
@@ -1232,7 +1000,7 @@ fn initial_runtime_state(boot: &RuntimeBootstrap<'_>, started_at: Instant) -> Ru
 /// an unreliable one may be dropped on a bad network, and one with no topic
 /// lands on a channel nothing reads. Built in one place because it was written
 /// out at four call sites, where each field was free to go missing on its own.
-fn browser_packet(
+pub(super) fn browser_packet(
     topic: &str,
     message: &serde_json::Value,
 ) -> Result<DataPacket, serde_json::Error> {
@@ -1636,193 +1404,6 @@ fn transcript_text(text: &str) -> Option<&str> {
     (!text.is_empty()).then_some(text)
 }
 
-async fn publish_report(
-    room: &Room,
-    boot: &RuntimeBootstrap<'_>,
-    state: &RuntimeState,
-    reason: &str,
-    elapsed_min: f64,
-    api_key: &str,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    room.local_participant()
-        .publish_data(report_packet(boot, state, reason, elapsed_min, api_key).await?)
-        .await?;
-    Ok(())
-}
-
-async fn report_packet(
-    boot: &RuntimeBootstrap<'_>,
-    state: &RuntimeState,
-    reason: &str,
-    elapsed_min: f64,
-    api_key: &str,
-) -> Result<DataPacket, Box<dyn std::error::Error + Send + Sync>> {
-    let mut report = match tokio::time::timeout(
-        REPORT_TIMEOUT,
-        generate_report(
-            api_key,
-            boot.report_model,
-            &report_prompt_text(boot, state, elapsed_min),
-        ),
-    )
-    .await
-    {
-        Ok(Ok(raw)) => final_report(Some(&raw), state.hints_used, None),
-        Ok(Err(error)) => final_report(
-            None,
-            state.hints_used,
-            Some(&report_error_note(
-                boot,
-                state,
-                reason,
-                error.as_ref(),
-                api_key,
-            )),
-        ),
-        Err(error) => final_report(
-            None,
-            state.hints_used,
-            Some(&report_error_note(boot, state, reason, &error, api_key)),
-        ),
-    };
-    stamp_report_contract(&mut report);
-    Ok(report_data_packet(report_with_integrity_events(
-        report, state,
-    ))?)
-}
-
-fn stamp_report_contract(report: &mut serde_json::Value) {
-    if let Some(object) = report.as_object_mut() {
-        object.insert("interviewContract".to_string(), interview_contract_json());
-    }
-}
-
-fn report_with_integrity_events(
-    mut report: serde_json::Value,
-    state: &RuntimeState,
-) -> serde_json::Value {
-    if let Some(object) = report.as_object_mut() {
-        // The evidence, plus the heartbeats that bookend it, merged by sequence
-        // rather than appended: a reader goes down this list in the order the
-        // interview happened, and a device-state sample out of place reads as a
-        // fault rather than as a bookend.
-        let kept = state.integrity_events.len() as u64;
-        let liveness = state.integrity_first_heartbeat.iter();
-        let liveness = liveness.chain(state.integrity_last_heartbeat.iter());
-        let samples = liveness.clone().count() as u64;
-        let mut events = state.integrity_events.clone();
-        events.extend(liveness.cloned());
-        events.sort_by_key(|event| event["seq"].as_u64().unwrap_or(0));
-        object.insert(
-            "integrityEvents".to_string(),
-            serde_json::Value::Array(events),
-        );
-
-        // How far verification got, and how much of it this report is not
-        // showing. The array above is a subsequence, so its links cannot be
-        // recomputed by whoever holds the report; without these a reader cannot
-        // tell a retention gap from a deleted row, which is the distinction the
-        // chain exists to make visible.
-        //
-        // The dropped count is derived rather than tallied. Every accepted
-        // event is in the evidence, held as a sample, or gone, and the cursor
-        // counts acceptances, so a counter would have been a fourth place for
-        // the same fact to be wrong.
-        let verified = state.integrity_chain.as_ref().map(|(seq, _)| *seq);
-        object.insert("integrityChainSeq".to_string(), serde_json::json!(verified));
-        object.insert(
-            "integrityDropped".to_string(),
-            serde_json::json!(verified.map(|seq| seq.saturating_sub(kept + samples))),
-        );
-        object.insert(
-            "frameworkEvidence".to_string(),
-            serde_json::Value::Array(
-                state
-                    .framework_evidence
-                    .iter()
-                    .map(framework_evidence_json)
-                    .collect(),
-            ),
-        );
-        let coding_gate = [
-            crate::agent::FrameworkPhase::Test,
-            crate::agent::FrameworkPhase::Optimizations,
-        ]
-        .iter()
-        .all(|phase| {
-            state.framework_evidence.iter().any(|item| {
-                item.phase == *phase && item.kind != crate::agent::EvidenceKind::Skipped
-            })
-        });
-        object.insert(
-            "interviewLoop".to_string(),
-            serde_json::json!(state.interview_loop.as_str()),
-        );
-        let star_complete = state.behavioral_round_started
-            && [
-                crate::agent::FrameworkPhase::Situation,
-                crate::agent::FrameworkPhase::Task,
-                crate::agent::FrameworkPhase::Action,
-                crate::agent::FrameworkPhase::Result,
-            ]
-            .iter()
-            .all(|phase| {
-                state.framework_evidence.iter().any(|item| {
-                    item.phase == *phase && item.kind != crate::agent::EvidenceKind::Skipped
-                })
-            });
-        object.insert("rounds".to_string(), serde_json::json!([
-            {"kind":"coding","budgetMin": state.coding_minutes, "status": if coding_gate { "complete" } else { "incomplete" }},
-            {"kind":"behavioral","budgetMin": state.behavioral_minutes, "status": if state.interview_loop == crate::agent::InterviewLoop::CodingOnly { "not_configured" } else if star_complete { "complete" } else if state.behavioral_round_started { "started" } else { "skipped" }}
-        ]));
-    }
-    report
-}
-
-fn report_prompt_text(
-    boot: &RuntimeBootstrap<'_>,
-    state: &RuntimeState,
-    elapsed_min: f64,
-) -> String {
-    let transcript = transcript_for_report(&state.transcript);
-    let test_summary = format_test_run(state.last_test_run.as_ref(), state.test_runs);
-    report_prompt(ReportPromptInput {
-        problem: boot.problem,
-        transcript: &transcript,
-        final_code: &state.code,
-        language: &state.language,
-        hints_used: state.hints_used,
-        duration_min: boot.duration_min,
-        elapsed_min,
-        test_summary: &test_summary,
-    })
-}
-
-/// This note is published to the candidate's browser and rendered in the report
-/// card, so `api_key` is not decoration: an error carrying a credentialed URL
-/// would otherwise hand the server's Google key to whoever is taking the
-/// interview.
-fn report_error_note(
-    boot: &RuntimeBootstrap<'_>,
-    state: &RuntimeState,
-    reason: &str,
-    error: &(dyn std::error::Error + 'static),
-    api_key: &str,
-) -> String {
-    let detail = redact_api_key(&error.to_string(), api_key);
-    format!(
-        "Rust LiveKit runner ended ({reason}) but Gemini report generation failed for model {} on {}. Final editor state: {} bytes of {}. Error: {detail}",
-        boot.report_model,
-        boot.problem.id,
-        state.code.len(),
-        state.language
-    )
-}
-
-fn report_data_packet(report: serde_json::Value) -> Result<DataPacket, serde_json::Error> {
-    browser_packet(TOPIC_REPORT, &report)
-}
-
 async fn send_wrap_up_and_wait(
     room: &Room,
     context: &mut GeminiEventContext<'_>,
@@ -1995,6 +1576,11 @@ impl TurnState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Only the tests below reach for it now: the report packet that carries
+    // this topic is built in `report.rs`, and what is left here asserts which
+    // topics the loop refuses from a browser.
+    use crate::runtime::TOPIC_REPORT;
     use ::livekit::webrtc::audio_frame::AudioFrame;
     use ::livekit::webrtc::audio_source::AudioSourceOptions;
     use ::livekit::webrtc::audio_source::native::NativeAudioSource;
@@ -2099,102 +1685,6 @@ mod tests {
             close_turn(&mut turn, "Candidate").is_none(),
             "a closed turn closes once; publishing it again repeats the line"
         );
-    }
-
-    /// The report says which rounds actually completed, from banked evidence.
-    ///
-    /// Two gates, and both are the same shape: every phase of the round needs
-    /// evidence that is not a skip. Loosened to "any phase" or to "including
-    /// skips", a candidate who ran out of time reads as one who finished.
-    #[test]
-    fn the_rounds_a_report_calls_complete_are_the_ones_with_evidence() {
-        let rounds = |state: &RuntimeState| {
-            report_with_integrity_events(serde_json::json!({}), state)["rounds"].clone()
-        };
-        let bank = |state: &mut RuntimeState, phase: &str, kind: &str| {
-            crate::agent::record_framework_evidence(
-                state,
-                &serde_json::json!({
-                    "phase": phase, "source": if kind == "skipped" { "session_timing" }
-                        else { "candidate_speech" },
-                    "kind": kind, "confidence": 90,
-                    "summary": format!("candidate {kind} {phase}"),
-                }),
-            )
-            .expect("evidence should record");
-        };
-
-        // Nothing banked: neither round is claimed.
-        let bare = RuntimeState {
-            interview_loop: crate::agent::InterviewLoop::CodingBehavioral,
-            ..RuntimeState::default()
-        };
-        assert_eq!(rounds(&bare)[0]["status"], "incomplete");
-        assert_eq!(rounds(&bare)[1]["status"], "skipped");
-
-        // Evidence for some other phase is evidence for neither of these.
-        // Asking whether any banked phase is not Test answers yes for a
-        // candidate who only restated the problem, and calls the round done.
-        let mut elsewhere = bare.clone();
-        bank(&mut elsewhere, "repeat", "observed");
-        assert_eq!(
-            rounds(&elsewhere)[0]["status"],
-            "incomplete",
-            "restating the problem is not having tested or optimized it"
-        );
-
-        // One of the two coding phases is not both of them.
-        let mut half = bare.clone();
-        bank(&mut half, "test", "observed");
-        assert_eq!(
-            rounds(&half)[0]["status"],
-            "incomplete",
-            "one phase is not the gate"
-        );
-
-        // A skip is the record of not reaching it, so it cannot complete it.
-        let mut skipped = half.clone();
-        bank(&mut skipped, "optimizations", "skipped");
-        assert_eq!(
-            rounds(&skipped)[0]["status"],
-            "incomplete",
-            "running out of time is not finishing"
-        );
-
-        let mut coding_done = half.clone();
-        bank(&mut coding_done, "optimizations", "observed");
-        assert_eq!(rounds(&coding_done)[0]["status"], "complete");
-
-        // STAR needs the round to have started and all four phases banked.
-        let mut star = coding_done.clone();
-        for phase in ["situation", "task", "action", "result"] {
-            bank(&mut star, phase, "observed");
-        }
-        assert_eq!(
-            rounds(&star)[1]["status"],
-            "skipped",
-            "four phases without the round beginning is not a behavioral round"
-        );
-        star.behavioral_round_started = true;
-        assert_eq!(rounds(&star)[1]["status"], "complete");
-
-        // Begun but not finished. Evidence for one STAR phase is not evidence
-        // for the other three, and asking whether any banked phase is not Task
-        // answers yes as soon as anything else was said, which reports a
-        // behavioral round the candidate barely entered as one they completed.
-        let mut begun = coding_done.clone();
-        begun.behavioral_round_started = true;
-        bank(&mut begun, "situation", "observed");
-        assert_eq!(
-            rounds(&begun)[1]["status"],
-            "started",
-            "one STAR phase in is started, not complete"
-        );
-
-        // A coding-only interview reserves no behavioral round at all.
-        let mut coding_only = coding_done.clone();
-        coding_only.interview_loop = crate::agent::InterviewLoop::CodingOnly;
-        assert_eq!(rounds(&coding_only)[1]["status"], "not_configured");
     }
 
     /// A packet the browser never receives is the same as one never sent.
@@ -2403,41 +1893,6 @@ mod tests {
         );
     }
 
-    /// The note goes over the data channel into the candidate's report card. A
-    /// `reqwest` error Displays the URL it was built from, so a credentialed
-    /// URL
-    /// anywhere in that chain hands the server's Google key to the candidate.
-    #[test]
-    fn report_error_note_never_carries_the_google_api_key() {
-        let config = load_from_pairs([
-            ("LIVEKIT_URL", "wss://example.livekit.cloud"),
-            ("LIVEKIT_API_KEY", "devkey"),
-            ("LIVEKIT_API_SECRET", "devsecret"),
-            ("GOOGLE_API_KEY", "AQ.Ab8RN6secret"),
-        ])
-        .unwrap();
-        let boot = bootstrap(&config, "interview-fixed", Some("two-sum"), 45);
-        let leaky = std::io::Error::other(
-            "HTTP status server error (503 Service Unavailable) for url \
-             (https://generativelanguage.googleapis.com/v1beta/models/x:generateContent?key=AQ.Ab8RN6secret)",
-        );
-
-        let note = report_error_note(
-            &boot,
-            &RuntimeState::default(),
-            "candidate_ended",
-            &leaky,
-            "AQ.Ab8RN6secret",
-        );
-
-        assert!(!note.contains("AQ.Ab8RN6secret"), "{note}");
-        assert!(note.contains("[REDACTED]"), "{note}");
-        assert!(
-            note.contains("503 Service Unavailable"),
-            "the reason still has to be readable: {note}"
-        );
-    }
-
     #[test]
     fn candidate_bootstrap_uses_participant_metadata() {
         let config = load_from_pairs([
@@ -2463,279 +1918,6 @@ mod tests {
         assert_eq!(boot.profile.role, "Platform engineer");
         assert_eq!(boot.profile.target_company, "Example Co");
         assert!(boot.instructions.contains("candidate selected staff"));
-    }
-
-    /// Losing the race with a duplicate agent that left on its own must not end
-    /// the interview. This shipped as a fatal error: the agent greeted the
-    /// candidate, tried to evict a participant that was already gone, and
-    /// exited on the `not_found`, leaving the candidate talking to an empty
-    /// room. Every other RoomService failure stays fatal.
-    #[test]
-    fn a_removal_that_finds_nobody_is_not_a_failure() {
-        assert!(is_participant_gone(
-            "LiveKit RoomService RemoveParticipant failed: 404 Not Found {\"code\":\"not_found\",\"msg\":\"participant does not exist\"}"
-        ));
-
-        for still_fatal in [
-            "LiveKit RoomService RemoveParticipant failed: 401 Unauthorized {\"code\":\"unauthenticated\"}",
-            "LiveKit RoomService RemoveParticipant failed: 503 Service Unavailable {}",
-            "LiveKit RoomService ListParticipants failed: 404 Not Found <html>no such route</html>",
-        ] {
-            assert!(!is_participant_gone(still_fatal), "{still_fatal}");
-        }
-    }
-
-    #[test]
-    fn duplicate_agent_identities_ignores_candidate_and_local_agent() {
-        let participants = serde_json::json!({
-            "participants": [
-                {
-                    "identity": "candidate-fixed",
-                    "kind": "STANDARD",
-                    "permission": { "agent": false }
-                },
-                {
-                    "identity": "interviewer-interview-fixed",
-                    "kind": "AGENT",
-                    "permission": { "agent": true }
-                },
-                {
-                    "identity": "hosted-agent",
-                    "kind": "AGENT",
-                    "permission": { "agent": true }
-                },
-                {
-                    "identity": "legacy-agent",
-                    "permission": { "agent": true }
-                }
-            ]
-        });
-
-        assert_eq!(
-            duplicate_agent_identities(&participants, "interviewer-interview-fixed"),
-            vec!["hosted-agent".to_string(), "legacy-agent".to_string()]
-        );
-    }
-
-    #[test]
-    fn livekit_http_base_maps_websocket_urls_to_room_service_host() {
-        assert_eq!(
-            livekit_http_base("wss://example.livekit.cloud/"),
-            "https://example.livekit.cloud"
-        );
-        assert_eq!(
-            livekit_http_base("ws://localhost:7880"),
-            "http://localhost:7880"
-        );
-    }
-
-    /// `validate_livekit_url` compares the scheme without regard to case, so
-    /// every spelling it accepts reaches here. The host keeps the case it was
-    /// given: DNS does not care, and a path might.
-    #[test]
-    fn livekit_http_base_rewrites_a_scheme_in_any_case() {
-        assert_eq!(
-            livekit_http_base("WSS://Example.LiveKit.Cloud"),
-            "https://Example.LiveKit.Cloud"
-        );
-        assert_eq!(
-            livekit_http_base("Ws://localhost:7880/"),
-            "http://localhost:7880"
-        );
-        assert_eq!(
-            livekit_http_base("HTTPS://example.livekit.cloud"),
-            "https://example.livekit.cloud"
-        );
-    }
-
-    #[test]
-    fn room_service_response_rejects_malformed_success_json() {
-        let error = parse_room_service_response("ListParticipants", "not json")
-            .unwrap_err()
-            .to_string();
-
-        assert!(error.contains("ListParticipants returned invalid JSON"));
-    }
-
-    #[test]
-    fn report_helpers_use_report_topic_prompt_state_and_error_note() {
-        let config = load_from_pairs([
-            ("LIVEKIT_URL", "wss://example.livekit.cloud"),
-            ("LIVEKIT_API_KEY", "devkey"),
-            ("LIVEKIT_API_SECRET", "devsecret"),
-            ("GOOGLE_API_KEY", "google"),
-        ])
-        .unwrap();
-        let boot = bootstrap(&config, "interview-fixed", Some("two-sum"), 45);
-        let state = RuntimeState {
-            code: "return [0, 1]".to_string(),
-            language: "python".to_string(),
-            transcript: vec![
-                "Interviewer: Welcome.".to_string(),
-                "Candidate: I will use a hash map.".to_string(),
-            ],
-            last_test_run: Some(serde_json::json!({
-                "language": "python",
-                "passed": 1,
-                "total": 2,
-                "failures": [],
-            })),
-            test_runs: 1,
-            hints_used: 2,
-            ..RuntimeState::default()
-        };
-        let error = std::io::Error::other("model unavailable");
-        let report = final_report(
-            None,
-            state.hints_used,
-            Some(&report_error_note(
-                &boot,
-                &state,
-                "candidate_ended",
-                &error,
-                "google",
-            )),
-        );
-        let packet = report_data_packet(report).unwrap();
-        let payload: serde_json::Value = serde_json::from_slice(&packet.payload).unwrap();
-        let report = report_with_integrity_events(
-            payload.clone(),
-            &RuntimeState {
-                integrity_events: vec![serde_json::json!({
-                    "type": "SESSION_START",
-                    "at": "now",
-                    "severity": "info",
-                    "source": "media",
-                    "durationMs": 0,
-                    "seq": 1,
-                    "prevHash": "",
-                    "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                    "detail": null,
-                })],
-                ..RuntimeState::default()
-            },
-        );
-        let prompt = report_prompt_text(&boot, &state, 12.4);
-
-        assert!(prompt.contains("Candidate: I will use a hash map."));
-        assert!(prompt.contains("Latest test run (run #1, python): 1/2 cases passed."));
-        assert!(packet.reliable);
-        assert_eq!(packet.topic.as_deref(), Some(TOPIC_REPORT));
-        assert!(
-            payload["summary"]
-                .as_str()
-                .unwrap()
-                .contains("Final editor state: 13 bytes of python")
-        );
-        assert_eq!(payload["hintsUsed"], 2);
-        assert_eq!(report["integrityEvents"][0]["type"], "SESSION_START");
-    }
-
-    #[test]
-    fn the_server_overwrites_model_selected_contract_provenance() {
-        let mut report = serde_json::json!({
-            "decision": "HIRE",
-            "interviewContract": {"bundleVersion": 999}
-        });
-        stamp_report_contract(&mut report);
-        assert_eq!(report["interviewContract"], interview_contract_json());
-
-        let mut incomplete = serde_json::json!({"incomplete": true});
-        stamp_report_contract(&mut incomplete);
-        assert_eq!(incomplete["interviewContract"], interview_contract_json());
-    }
-
-    /// The liveness pair bookends the evidence, and the closing sample is the
-    /// one that says how the interview ended. Nothing covered this merge, so
-    /// dropping it, duplicating it, or emitting it out of order was invisible.
-    #[test]
-    fn the_report_packet_bookends_the_evidence_with_the_liveness_pair() {
-        let event = |seq: u64, kind: &str| {
-            serde_json::json!({
-                "type": kind,
-                "at": "now",
-                "severity": "info",
-                "source": "media",
-                "durationMs": 0,
-                "seq": seq,
-                "prevHash": "",
-                "hash": "a".repeat(64),
-                "detail": null,
-            })
-        };
-        let packet = |first, last| {
-            report_with_integrity_events(
-                serde_json::json!({}),
-                &RuntimeState {
-                    integrity_events: vec![event(5, "CAMERA_STOPPED")],
-                    integrity_first_heartbeat: first,
-                    integrity_last_heartbeat: last,
-                    integrity_chain: Some((9, "b".repeat(64))),
-                    ..RuntimeState::default()
-                },
-            )
-        };
-
-        let both = packet(
-            Some(event(2, "INTEGRITY_HEARTBEAT")),
-            Some(event(9, "INTEGRITY_HEARTBEAT")),
-        );
-        let seqs: Vec<u64> = both["integrityEvents"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|event| event["seq"].as_u64().unwrap())
-            .collect();
-        assert_eq!(seqs, vec![2, 5, 9], "merged in the order the interview ran");
-        assert_eq!(both["integrityChainSeq"], 9);
-
-        // Derived, not tallied: nine accepted, one kept as evidence and two
-        // held as samples, so six went for space.
-        assert_eq!(both["integrityDropped"], 6);
-
-        // A run of one has an opening sample and no closing one.
-        let single = packet(Some(event(2, "INTEGRITY_HEARTBEAT")), None);
-        let seqs: Vec<u64> = single["integrityEvents"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|event| event["seq"].as_u64().unwrap())
-            .collect();
-        assert_eq!(seqs, vec![2, 5], "one sample is one row");
-        assert_eq!(single["integrityDropped"], 7);
-
-        // And an interview that produced no heartbeat at all carries neither.
-        let none = packet(None, None);
-        assert_eq!(none["integrityEvents"].as_array().unwrap().len(), 1);
-        assert_eq!(none["integrityDropped"], 8);
-    }
-
-    #[test]
-    fn complete_and_incomplete_reports_carry_agent_owned_framework_evidence() {
-        let mut state = RuntimeState::default();
-        record_framework_evidence(
-            &mut state,
-            &serde_json::json!({
-                "phase":"result", "source":"session_timing", "kind":"skipped",
-                "confidence":100, "summary":"The cutoff prevented STAR assessment."
-            }),
-        )
-        .unwrap();
-        for report in [
-            serde_json::json!({"decision":"HIRE"}),
-            serde_json::json!({"incomplete":true}),
-        ] {
-            let report = report_with_integrity_events(report, &state);
-            assert_eq!(report["frameworkEvidence"][0]["phase"], "result");
-            assert_eq!(report["frameworkEvidence"][0]["kind"], "skipped");
-            assert_eq!(report["interviewLoop"], "coding_behavioral");
-            assert_eq!(report["rounds"][0]["budgetMin"], 37);
-            assert_eq!(report["rounds"][1]["status"], "skipped");
-            assert_eq!(
-                report["frameworkEvidence"][0]["frameworkVersion"],
-                crate::agent::FRAMEWORK_VERSION
-            );
-        }
     }
 
     #[test]

--- a/src/livekit.rs
+++ b/src/livekit.rs
@@ -765,7 +765,8 @@ async fn handle_room_event(
         RoomEvent::ParticipantConnected(participant)
             if is_duplicate_agent(&participant, agent_identity) =>
         {
-            evict_duplicate_agent(config, room_name, &participant, now_seconds).await?;
+            evict_duplicate_agent(config, room_name, &participant.identity().0, now_seconds)
+                .await?;
         }
         RoomEvent::ParticipantDisconnected(participant)
             if participant.identity().0 == candidate_identity =>

--- a/src/livekit/report.rs
+++ b/src/livekit/report.rs
@@ -1,0 +1,527 @@
+//! Building the report packet the browser receives when an interview ends.
+//!
+//! One region because it is one output. `publish_report` is the only thing the
+//! interview loop calls; everything below it is how the packet is assembled,
+//! and the pieces are separated so that a failure in one of them is a note in
+//! the report rather than no report at all.
+//!
+//! Split out of `livekit.rs` along the line its module doc already drew.
+
+use ::livekit::prelude::{DataPacket, Room};
+
+use crate::agent::{
+    ReportPromptInput, RuntimeState, final_report, format_test_run, framework_evidence_json,
+    interview_contract_json, report_prompt, transcript_for_report,
+};
+use crate::gemini::{generate_report, redact_api_key};
+use crate::runtime::{RuntimeBootstrap, TOPIC_REPORT};
+
+use super::{REPORT_TIMEOUT, browser_packet};
+
+pub(super) async fn publish_report(
+    room: &Room,
+    boot: &RuntimeBootstrap<'_>,
+    state: &RuntimeState,
+    reason: &str,
+    elapsed_min: f64,
+    api_key: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    room.local_participant()
+        .publish_data(report_packet(boot, state, reason, elapsed_min, api_key).await?)
+        .await?;
+    Ok(())
+}
+
+async fn report_packet(
+    boot: &RuntimeBootstrap<'_>,
+    state: &RuntimeState,
+    reason: &str,
+    elapsed_min: f64,
+    api_key: &str,
+) -> Result<DataPacket, Box<dyn std::error::Error + Send + Sync>> {
+    let mut report = match tokio::time::timeout(
+        REPORT_TIMEOUT,
+        generate_report(
+            api_key,
+            boot.report_model,
+            &report_prompt_text(boot, state, elapsed_min),
+        ),
+    )
+    .await
+    {
+        Ok(Ok(raw)) => final_report(Some(&raw), state.hints_used, None),
+        Ok(Err(error)) => final_report(
+            None,
+            state.hints_used,
+            Some(&report_error_note(
+                boot,
+                state,
+                reason,
+                error.as_ref(),
+                api_key,
+            )),
+        ),
+        Err(error) => final_report(
+            None,
+            state.hints_used,
+            Some(&report_error_note(boot, state, reason, &error, api_key)),
+        ),
+    };
+    stamp_report_contract(&mut report);
+    Ok(report_data_packet(report_with_integrity_events(
+        report, state,
+    ))?)
+}
+
+fn stamp_report_contract(report: &mut serde_json::Value) {
+    if let Some(object) = report.as_object_mut() {
+        object.insert("interviewContract".to_string(), interview_contract_json());
+    }
+}
+
+fn report_with_integrity_events(
+    mut report: serde_json::Value,
+    state: &RuntimeState,
+) -> serde_json::Value {
+    if let Some(object) = report.as_object_mut() {
+        // The evidence, plus the heartbeats that bookend it, merged by sequence
+        // rather than appended: a reader goes down this list in the order the
+        // interview happened, and a device-state sample out of place reads as a
+        // fault rather than as a bookend.
+        let kept = state.integrity_events.len() as u64;
+        let liveness = state.integrity_first_heartbeat.iter();
+        let liveness = liveness.chain(state.integrity_last_heartbeat.iter());
+        let samples = liveness.clone().count() as u64;
+        let mut events = state.integrity_events.clone();
+        events.extend(liveness.cloned());
+        events.sort_by_key(|event| event["seq"].as_u64().unwrap_or(0));
+        object.insert(
+            "integrityEvents".to_string(),
+            serde_json::Value::Array(events),
+        );
+
+        // How far verification got, and how much of it this report is not
+        // showing. The array above is a subsequence, so its links cannot be
+        // recomputed by whoever holds the report; without these a reader cannot
+        // tell a retention gap from a deleted row, which is the distinction the
+        // chain exists to make visible.
+        //
+        // The dropped count is derived rather than tallied. Every accepted
+        // event is in the evidence, held as a sample, or gone, and the cursor
+        // counts acceptances, so a counter would have been a fourth place for
+        // the same fact to be wrong.
+        let verified = state.integrity_chain.as_ref().map(|(seq, _)| *seq);
+        object.insert("integrityChainSeq".to_string(), serde_json::json!(verified));
+        object.insert(
+            "integrityDropped".to_string(),
+            serde_json::json!(verified.map(|seq| seq.saturating_sub(kept + samples))),
+        );
+        object.insert(
+            "frameworkEvidence".to_string(),
+            serde_json::Value::Array(
+                state
+                    .framework_evidence
+                    .iter()
+                    .map(framework_evidence_json)
+                    .collect(),
+            ),
+        );
+        let coding_gate = [
+            crate::agent::FrameworkPhase::Test,
+            crate::agent::FrameworkPhase::Optimizations,
+        ]
+        .iter()
+        .all(|phase| {
+            state.framework_evidence.iter().any(|item| {
+                item.phase == *phase && item.kind != crate::agent::EvidenceKind::Skipped
+            })
+        });
+        object.insert(
+            "interviewLoop".to_string(),
+            serde_json::json!(state.interview_loop.as_str()),
+        );
+        let star_complete = state.behavioral_round_started
+            && [
+                crate::agent::FrameworkPhase::Situation,
+                crate::agent::FrameworkPhase::Task,
+                crate::agent::FrameworkPhase::Action,
+                crate::agent::FrameworkPhase::Result,
+            ]
+            .iter()
+            .all(|phase| {
+                state.framework_evidence.iter().any(|item| {
+                    item.phase == *phase && item.kind != crate::agent::EvidenceKind::Skipped
+                })
+            });
+        object.insert("rounds".to_string(), serde_json::json!([
+            {"kind":"coding","budgetMin": state.coding_minutes, "status": if coding_gate { "complete" } else { "incomplete" }},
+            {"kind":"behavioral","budgetMin": state.behavioral_minutes, "status": if state.interview_loop == crate::agent::InterviewLoop::CodingOnly { "not_configured" } else if star_complete { "complete" } else if state.behavioral_round_started { "started" } else { "skipped" }}
+        ]));
+    }
+    report
+}
+
+fn report_prompt_text(
+    boot: &RuntimeBootstrap<'_>,
+    state: &RuntimeState,
+    elapsed_min: f64,
+) -> String {
+    let transcript = transcript_for_report(&state.transcript);
+    let test_summary = format_test_run(state.last_test_run.as_ref(), state.test_runs);
+    report_prompt(ReportPromptInput {
+        problem: boot.problem,
+        transcript: &transcript,
+        final_code: &state.code,
+        language: &state.language,
+        hints_used: state.hints_used,
+        duration_min: boot.duration_min,
+        elapsed_min,
+        test_summary: &test_summary,
+    })
+}
+
+/// This note is published to the candidate's browser and rendered in the report
+/// card, so `api_key` is not decoration: an error carrying a credentialed URL
+/// would otherwise hand the server's Google key to whoever is taking the
+/// interview.
+fn report_error_note(
+    boot: &RuntimeBootstrap<'_>,
+    state: &RuntimeState,
+    reason: &str,
+    error: &(dyn std::error::Error + 'static),
+    api_key: &str,
+) -> String {
+    let detail = redact_api_key(&error.to_string(), api_key);
+    format!(
+        "Rust LiveKit runner ended ({reason}) but Gemini report generation failed for model {} on {}. Final editor state: {} bytes of {}. Error: {detail}",
+        boot.report_model,
+        boot.problem.id,
+        state.code.len(),
+        state.language
+    )
+}
+
+fn report_data_packet(report: serde_json::Value) -> Result<DataPacket, serde_json::Error> {
+    browser_packet(TOPIC_REPORT, &report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::agent::record_framework_evidence;
+    use crate::config::load_from_pairs;
+    use crate::runtime::bootstrap;
+
+    /// The report says which rounds actually completed, from banked evidence.
+    ///
+    /// Two gates, and both are the same shape: every phase of the round needs
+    /// evidence that is not a skip. Loosened to "any phase" or to "including
+    /// skips", a candidate who ran out of time reads as one who finished.
+    #[test]
+    fn the_rounds_a_report_calls_complete_are_the_ones_with_evidence() {
+        let rounds = |state: &RuntimeState| {
+            report_with_integrity_events(serde_json::json!({}), state)["rounds"].clone()
+        };
+        let bank = |state: &mut RuntimeState, phase: &str, kind: &str| {
+            crate::agent::record_framework_evidence(
+                state,
+                &serde_json::json!({
+                    "phase": phase, "source": if kind == "skipped" { "session_timing" }
+                        else { "candidate_speech" },
+                    "kind": kind, "confidence": 90,
+                    "summary": format!("candidate {kind} {phase}"),
+                }),
+            )
+            .expect("evidence should record");
+        };
+
+        // Nothing banked: neither round is claimed.
+        let bare = RuntimeState {
+            interview_loop: crate::agent::InterviewLoop::CodingBehavioral,
+            ..RuntimeState::default()
+        };
+        assert_eq!(rounds(&bare)[0]["status"], "incomplete");
+        assert_eq!(rounds(&bare)[1]["status"], "skipped");
+
+        // Evidence for some other phase is evidence for neither of these.
+        // Asking whether any banked phase is not Test answers yes for a
+        // candidate who only restated the problem, and calls the round done.
+        let mut elsewhere = bare.clone();
+        bank(&mut elsewhere, "repeat", "observed");
+        assert_eq!(
+            rounds(&elsewhere)[0]["status"],
+            "incomplete",
+            "restating the problem is not having tested or optimized it"
+        );
+
+        // One of the two coding phases is not both of them.
+        let mut half = bare.clone();
+        bank(&mut half, "test", "observed");
+        assert_eq!(
+            rounds(&half)[0]["status"],
+            "incomplete",
+            "one phase is not the gate"
+        );
+
+        // A skip is the record of not reaching it, so it cannot complete it.
+        let mut skipped = half.clone();
+        bank(&mut skipped, "optimizations", "skipped");
+        assert_eq!(
+            rounds(&skipped)[0]["status"],
+            "incomplete",
+            "running out of time is not finishing"
+        );
+
+        let mut coding_done = half.clone();
+        bank(&mut coding_done, "optimizations", "observed");
+        assert_eq!(rounds(&coding_done)[0]["status"], "complete");
+
+        // STAR needs the round to have started and all four phases banked.
+        let mut star = coding_done.clone();
+        for phase in ["situation", "task", "action", "result"] {
+            bank(&mut star, phase, "observed");
+        }
+        assert_eq!(
+            rounds(&star)[1]["status"],
+            "skipped",
+            "four phases without the round beginning is not a behavioral round"
+        );
+        star.behavioral_round_started = true;
+        assert_eq!(rounds(&star)[1]["status"], "complete");
+
+        // Begun but not finished. Evidence for one STAR phase is not evidence
+        // for the other three, and asking whether any banked phase is not Task
+        // answers yes as soon as anything else was said, which reports a
+        // behavioral round the candidate barely entered as one they completed.
+        let mut begun = coding_done.clone();
+        begun.behavioral_round_started = true;
+        bank(&mut begun, "situation", "observed");
+        assert_eq!(
+            rounds(&begun)[1]["status"],
+            "started",
+            "one STAR phase in is started, not complete"
+        );
+
+        // A coding-only interview reserves no behavioral round at all.
+        let mut coding_only = coding_done.clone();
+        coding_only.interview_loop = crate::agent::InterviewLoop::CodingOnly;
+        assert_eq!(rounds(&coding_only)[1]["status"], "not_configured");
+    }
+
+    /// The note goes over the data channel into the candidate's report card. A
+    /// `reqwest` error Displays the URL it was built from, so a credentialed
+    /// URL
+    /// anywhere in that chain hands the server's Google key to the candidate.
+    #[test]
+    fn report_error_note_never_carries_the_google_api_key() {
+        let config = load_from_pairs([
+            ("LIVEKIT_URL", "wss://example.livekit.cloud"),
+            ("LIVEKIT_API_KEY", "devkey"),
+            ("LIVEKIT_API_SECRET", "devsecret"),
+            ("GOOGLE_API_KEY", "AQ.Ab8RN6secret"),
+        ])
+        .unwrap();
+        let boot = bootstrap(&config, "interview-fixed", Some("two-sum"), 45);
+        let leaky = std::io::Error::other(
+            "HTTP status server error (503 Service Unavailable) for url \
+             (https://generativelanguage.googleapis.com/v1beta/models/x:generateContent?key=AQ.Ab8RN6secret)",
+        );
+
+        let note = report_error_note(
+            &boot,
+            &RuntimeState::default(),
+            "candidate_ended",
+            &leaky,
+            "AQ.Ab8RN6secret",
+        );
+
+        assert!(!note.contains("AQ.Ab8RN6secret"), "{note}");
+        assert!(note.contains("[REDACTED]"), "{note}");
+        assert!(
+            note.contains("503 Service Unavailable"),
+            "the reason still has to be readable: {note}"
+        );
+    }
+
+    #[test]
+    fn report_helpers_use_report_topic_prompt_state_and_error_note() {
+        let config = load_from_pairs([
+            ("LIVEKIT_URL", "wss://example.livekit.cloud"),
+            ("LIVEKIT_API_KEY", "devkey"),
+            ("LIVEKIT_API_SECRET", "devsecret"),
+            ("GOOGLE_API_KEY", "google"),
+        ])
+        .unwrap();
+        let boot = bootstrap(&config, "interview-fixed", Some("two-sum"), 45);
+        let state = RuntimeState {
+            code: "return [0, 1]".to_string(),
+            language: "python".to_string(),
+            transcript: vec![
+                "Interviewer: Welcome.".to_string(),
+                "Candidate: I will use a hash map.".to_string(),
+            ],
+            last_test_run: Some(serde_json::json!({
+                "language": "python",
+                "passed": 1,
+                "total": 2,
+                "failures": [],
+            })),
+            test_runs: 1,
+            hints_used: 2,
+            ..RuntimeState::default()
+        };
+        let error = std::io::Error::other("model unavailable");
+        let report = final_report(
+            None,
+            state.hints_used,
+            Some(&report_error_note(
+                &boot,
+                &state,
+                "candidate_ended",
+                &error,
+                "google",
+            )),
+        );
+        let packet = report_data_packet(report).unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&packet.payload).unwrap();
+        let report = report_with_integrity_events(
+            payload.clone(),
+            &RuntimeState {
+                integrity_events: vec![serde_json::json!({
+                    "type": "SESSION_START",
+                    "at": "now",
+                    "severity": "info",
+                    "source": "media",
+                    "durationMs": 0,
+                    "seq": 1,
+                    "prevHash": "",
+                    "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "detail": null,
+                })],
+                ..RuntimeState::default()
+            },
+        );
+        let prompt = report_prompt_text(&boot, &state, 12.4);
+
+        assert!(prompt.contains("Candidate: I will use a hash map."));
+        assert!(prompt.contains("Latest test run (run #1, python): 1/2 cases passed."));
+        assert!(packet.reliable);
+        assert_eq!(packet.topic.as_deref(), Some(TOPIC_REPORT));
+        assert!(
+            payload["summary"]
+                .as_str()
+                .unwrap()
+                .contains("Final editor state: 13 bytes of python")
+        );
+        assert_eq!(payload["hintsUsed"], 2);
+        assert_eq!(report["integrityEvents"][0]["type"], "SESSION_START");
+    }
+
+    #[test]
+    fn the_server_overwrites_model_selected_contract_provenance() {
+        let mut report = serde_json::json!({
+            "decision": "HIRE",
+            "interviewContract": {"bundleVersion": 999}
+        });
+        stamp_report_contract(&mut report);
+        assert_eq!(report["interviewContract"], interview_contract_json());
+
+        let mut incomplete = serde_json::json!({"incomplete": true});
+        stamp_report_contract(&mut incomplete);
+        assert_eq!(incomplete["interviewContract"], interview_contract_json());
+    }
+
+    /// The liveness pair bookends the evidence, and the closing sample is the
+    /// one that says how the interview ended. Nothing covered this merge, so
+    /// dropping it, duplicating it, or emitting it out of order was invisible.
+    #[test]
+    fn the_report_packet_bookends_the_evidence_with_the_liveness_pair() {
+        let event = |seq: u64, kind: &str| {
+            serde_json::json!({
+                "type": kind,
+                "at": "now",
+                "severity": "info",
+                "source": "media",
+                "durationMs": 0,
+                "seq": seq,
+                "prevHash": "",
+                "hash": "a".repeat(64),
+                "detail": null,
+            })
+        };
+        let packet = |first, last| {
+            report_with_integrity_events(
+                serde_json::json!({}),
+                &RuntimeState {
+                    integrity_events: vec![event(5, "CAMERA_STOPPED")],
+                    integrity_first_heartbeat: first,
+                    integrity_last_heartbeat: last,
+                    integrity_chain: Some((9, "b".repeat(64))),
+                    ..RuntimeState::default()
+                },
+            )
+        };
+
+        let both = packet(
+            Some(event(2, "INTEGRITY_HEARTBEAT")),
+            Some(event(9, "INTEGRITY_HEARTBEAT")),
+        );
+        let seqs: Vec<u64> = both["integrityEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|event| event["seq"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![2, 5, 9], "merged in the order the interview ran");
+        assert_eq!(both["integrityChainSeq"], 9);
+
+        // Derived, not tallied: nine accepted, one kept as evidence and two
+        // held as samples, so six went for space.
+        assert_eq!(both["integrityDropped"], 6);
+
+        // A run of one has an opening sample and no closing one.
+        let single = packet(Some(event(2, "INTEGRITY_HEARTBEAT")), None);
+        let seqs: Vec<u64> = single["integrityEvents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|event| event["seq"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![2, 5], "one sample is one row");
+        assert_eq!(single["integrityDropped"], 7);
+
+        // And an interview that produced no heartbeat at all carries neither.
+        let none = packet(None, None);
+        assert_eq!(none["integrityEvents"].as_array().unwrap().len(), 1);
+        assert_eq!(none["integrityDropped"], 8);
+    }
+
+    #[test]
+    fn complete_and_incomplete_reports_carry_agent_owned_framework_evidence() {
+        let mut state = RuntimeState::default();
+        record_framework_evidence(
+            &mut state,
+            &serde_json::json!({
+                "phase":"result", "source":"session_timing", "kind":"skipped",
+                "confidence":100, "summary":"The cutoff prevented STAR assessment."
+            }),
+        )
+        .unwrap();
+        for report in [
+            serde_json::json!({"decision":"HIRE"}),
+            serde_json::json!({"incomplete":true}),
+        ] {
+            let report = report_with_integrity_events(report, &state);
+            assert_eq!(report["frameworkEvidence"][0]["phase"], "result");
+            assert_eq!(report["frameworkEvidence"][0]["kind"], "skipped");
+            assert_eq!(report["interviewLoop"], "coding_behavioral");
+            assert_eq!(report["rounds"][0]["budgetMin"], 37);
+            assert_eq!(report["rounds"][1]["status"], "skipped");
+            assert_eq!(
+                report["frameworkEvidence"][0]["frameworkVersion"],
+                crate::agent::FRAMEWORK_VERSION
+            );
+        }
+    }
+}

--- a/src/livekit/rooms.rs
+++ b/src/livekit/rooms.rs
@@ -277,6 +277,284 @@ pub(super) async fn evict_duplicate_agent(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// A RoomService that answers what the test tells it to and remembers what
+    /// it was asked.
+    ///
+    /// A real socket rather than an injected transport, because what these
+    /// functions do with a reply is bound up with how they make the request:
+    /// the Twirp path, the bearer token and the status handling are the parts
+    /// worth pinning, and none of them survives being stubbed out one layer up.
+    /// Replies are answered in order and the last one repeats, so a caller that
+    /// polls needs one entry rather than twenty.
+    struct RoomService {
+        url: String,
+        seen: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    impl RoomService {
+        async fn start(replies: Vec<(u16, &'static str)>) -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let url = format!("http://{}", listener.local_addr().unwrap());
+            let seen = Arc::new(Mutex::new(Vec::new()));
+            let recorded = seen.clone();
+            tokio::spawn(async move {
+                let mut replies = replies.into_iter().peekable();
+                let mut last = (200, "{}");
+                loop {
+                    let Ok((mut socket, _)) = listener.accept().await else {
+                        return;
+                    };
+                    if replies.peek().is_some() {
+                        last = replies.next().unwrap();
+                    }
+
+                    // Headers to the blank line, then exactly the declared
+                    // body.
+                    let mut raw = Vec::new();
+                    let mut byte = [0u8; 1];
+                    while !raw.ends_with(b"\r\n\r\n") {
+                        match socket.read(&mut byte).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(_) => raw.push(byte[0]),
+                        }
+                    }
+                    let head = String::from_utf8_lossy(&raw).to_string();
+                    let path = head
+                        .lines()
+                        .next()
+                        .and_then(|line| line.split_whitespace().nth(1))
+                        .unwrap_or_default()
+                        .to_string();
+                    let length: usize = head
+                        .to_ascii_lowercase()
+                        .lines()
+                        .find_map(|line| line.strip_prefix("content-length:"))
+                        .and_then(|value| value.trim().parse().ok())
+                        .unwrap_or(0);
+                    let mut body = vec![0u8; length];
+                    if length > 0 && socket.read_exact(&mut body).await.is_err() {
+                        return;
+                    }
+                    recorded
+                        .lock()
+                        .unwrap()
+                        .push((path, String::from_utf8_lossy(&body).to_string()));
+
+                    let (status, reply) = last;
+                    let response = format!(
+                        "HTTP/1.1 {status} X\r\ncontent-type: application/json\r\n\
+                         content-length: {}\r\nconnection: close\r\n\r\n{reply}",
+                        reply.len()
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.flush().await;
+                }
+            });
+            Self { url, seen }
+        }
+
+        fn config(&self) -> AgentConfig {
+            crate::config::load_from_pairs([
+                ("LIVEKIT_URL", self.url.as_str()),
+                ("LIVEKIT_API_KEY", "devkey"),
+                ("LIVEKIT_API_SECRET", "devsecret"),
+                ("GOOGLE_API_KEY", "google"),
+            ])
+            .unwrap()
+        }
+
+        fn requests(&self) -> Vec<(String, String)> {
+            self.seen.lock().unwrap().clone()
+        }
+    }
+
+    /// The request this makes, and what it does with each kind of answer.
+    ///
+    /// The Twirp path is a contract with LiveKit that no test named: a wrong
+    /// method segment reaches a real server and 404s, which
+    /// `is_participant_gone` then has to be careful not to read as a departed
+    /// participant. The success path returned the parsed body and the failure
+    /// path had to keep the method, the status and the body, because that
+    /// string is the only thing the caller can tell them apart by.
+    #[tokio::test]
+    async fn a_room_service_call_names_its_method_and_carries_the_answer() {
+        let service =
+            RoomService::start(vec![(200, r#"{"participants":[{"identity":"a"}]}"#)]).await;
+        let config = service.config();
+
+        let participants = list_room_participants(&config, "interview-abc12345", 1_700_000_000)
+            .await
+            .unwrap();
+        assert_eq!(participants["participants"][0]["identity"], "a");
+
+        let (path, body) = service.requests().into_iter().next().unwrap();
+        assert_eq!(path, "/twirp/livekit.RoomService/ListParticipants");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&body).unwrap()["room"],
+            "interview-abc12345"
+        );
+
+        // A refusal is an error, and the message carries all three parts the
+        // caller reads it for.
+        let refusing = RoomService::start(vec![(503, r#"{"msg":"busy"}"#)]).await;
+        let error = list_room_participants(&refusing.config(), "interview-abc12345", 1_700_000_000)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("ListParticipants"), "{error}");
+        assert!(error.contains("503"), "{error}");
+        assert!(error.contains("busy"), "{error}");
+    }
+
+    /// The Setup form's credential check, and the sentence it hands back.
+    ///
+    /// This is what a reader acts on: the form shows LiveKit's own account of
+    /// the refusal, because a status alone says "did not work" to somebody who
+    /// already knows that. It is bounded because a wrong host answers with an
+    /// HTML page and the form is one line, and the boundary is the part worth
+    /// pinning: an off-by-one there either truncates a reason that fit or lets
+    /// a whole page through.
+    #[tokio::test]
+    async fn a_credential_check_reports_what_livekit_said() {
+        let accepted = RoomService::start(vec![(200, "{}")]).await;
+        validate_livekit_credentials(&accepted.url, "devkey", "devsecret", 1_700_000_000)
+            .await
+            .expect("a project that answers ListRooms has usable credentials");
+        let (path, _) = accepted.requests().into_iter().next().unwrap();
+        assert_eq!(path, "/twirp/livekit.RoomService/ListRooms");
+
+        let refused = RoomService::start(vec![(401, r#"{"msg":"invalid api key"}"#)]).await;
+        let error = validate_livekit_credentials(&refused.url, "devkey", "wrong", 1_700_000_000)
+            .await
+            .unwrap_err();
+        assert!(error.contains("401"), "{error}");
+        assert!(error.contains("invalid api key"), "{error}");
+        assert!(
+            !error.ends_with("..."),
+            "a reason that fits is not truncated"
+        );
+    }
+
+    /// A wrong host answers with a page, and the form takes one line of it.
+    #[tokio::test]
+    async fn a_credential_check_bounds_the_reason_it_repeats() {
+        // Longer than the limit by one, which is the only length that tells the
+        // boundary apart from its neighbours.
+        const OVER: &str = concat!(
+            "0123456789012345678901234567890123456789012345678901234567890123456789",
+            "0123456789012345678901234567890123456789012345678901234567890123456789",
+            "0123456789012345678901234567890123456789012345678901234567890123456789",
+        );
+        assert_eq!(OVER.len(), 210);
+
+        let wordy = RoomService::start(vec![(500, OVER)]).await;
+        let error = validate_livekit_credentials(&wordy.url, "devkey", "devsecret", 1_700_000_000)
+            .await
+            .unwrap_err();
+        assert!(
+            error.ends_with("..."),
+            "an over-long reason is cut and marked"
+        );
+        assert!(
+            error.contains(&OVER[..200]) && !error.contains(&OVER[..201]),
+            "exactly the limit is repeated: {error}"
+        );
+
+        // Exactly the limit, which is the length that tells `>` from `>=`: a
+        // reason that fits to the last character is whole, not cut.
+        let exact = &OVER[..200];
+        let fitting = RoomService::start(vec![(500, exact)]).await;
+        let error =
+            validate_livekit_credentials(&fitting.url, "devkey", "devsecret", 1_700_000_000)
+                .await
+                .unwrap_err();
+        assert!(
+            error.ends_with(exact),
+            "a reason of exactly the limit is not marked as cut: {error}"
+        );
+    }
+
+    /// A removal that finds nobody is done, and every other refusal is not.
+    ///
+    /// The predicate is unit tested above; this is the path that consults it,
+    /// which is where losing the race with a departing agent used to end the
+    /// interview.
+    #[tokio::test]
+    async fn a_removal_consults_the_predicate_before_giving_up() {
+        let gone = RoomService::start(vec![(
+            404,
+            r#"{"code":"not_found","msg":"participant does not exist"}"#,
+        )])
+        .await;
+        remove_room_participant(
+            &gone.config(),
+            "interview-abc12345",
+            "agent-old",
+            1_700_000_000,
+        )
+        .await
+        .expect("a participant that already left is not a failure");
+        let (path, _) = gone.requests().into_iter().next().unwrap();
+        assert_eq!(path, "/twirp/livekit.RoomService/RemoveParticipant");
+
+        let refused = RoomService::start(vec![(401, r#"{"code":"unauthenticated"}"#)]).await;
+        remove_room_participant(
+            &refused.config(),
+            "interview-abc12345",
+            "agent-old",
+            1_700_000_000,
+        )
+        .await
+        .expect_err("a refusal that is not a departed participant stays fatal");
+    }
+
+    /// Isolation lists, removes what it finds, and stops.
+    ///
+    /// The loop is the part worth pinning: it re-lists after removing, so the
+    /// last pass is the one that confirms the room is clear, and it gives up
+    /// loudly rather than spinning forever. Nothing asserted that it removed
+    /// anything at all.
+    #[tokio::test]
+    async fn isolation_removes_a_duplicate_and_confirms_the_room_is_clear() {
+        // Crowded once, then empty, which is the ordinary case: list, remove,
+        // list again and find nothing.
+        let service = RoomService::start(vec![
+            (
+                200,
+                r#"{"participants":[{"identity":"agent-old","kind":"AGENT"},{"identity":"agent-me","kind":"AGENT"}]}"#,
+            ),
+            (200, r#"{}"#),
+            (200, r#"{"participants":[]}"#),
+        ])
+        .await;
+
+        isolate_local_agent(
+            &service.config(),
+            "interview-abc12345",
+            "agent-me",
+            1_700_000_000,
+        )
+        .await
+        .unwrap();
+
+        let methods: Vec<String> = service
+            .requests()
+            .into_iter()
+            .map(|(path, _)| path.rsplit('/').next().unwrap_or_default().to_string())
+            .collect();
+        assert_eq!(
+            methods,
+            vec![
+                "ListParticipants".to_string(),
+                "RemoveParticipant".to_string(),
+                "ListParticipants".to_string(),
+            ],
+            "it lists, removes what it found, and lists again to confirm"
+        );
+    }
 
     /// Losing the race with a duplicate agent that left on its own must not end
     /// the interview. This shipped as a fatal error: the agent greeted the

--- a/src/livekit/rooms.rs
+++ b/src/livekit/rooms.rs
@@ -11,8 +11,6 @@
 
 use std::time::Duration;
 
-use ::livekit::prelude::RemoteParticipant;
-
 use crate::config::AgentConfig;
 use crate::token::livekit_room_admin_token;
 
@@ -266,12 +264,11 @@ fn is_agent_participant(participant: &serde_json::Value) -> bool {
 pub(super) async fn evict_duplicate_agent(
     config: &AgentConfig,
     room_name: &str,
-    participant: &RemoteParticipant,
+    identity: &str,
     now_seconds: u64,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let identity = participant.identity().0;
     eprintln!("removing late duplicate LiveKit agent participant identity={identity}");
-    remove_room_participant(config, room_name, &identity, now_seconds).await
+    remove_room_participant(config, room_name, identity, now_seconds).await
 }
 
 #[cfg(test)]
@@ -474,6 +471,34 @@ mod tests {
         assert!(
             error.ends_with(exact),
             "a reason of exactly the limit is not marked as cut: {error}"
+        );
+    }
+
+    /// A late duplicate is evicted by name.
+    ///
+    /// This runs when a second agent joins after isolation has already passed,
+    /// which is the case isolation cannot cover: the room was clear when it
+    /// looked. It takes an identity rather than the participant it came from,
+    /// because the identity is all it needs and a participant cannot be built
+    /// to test with.
+    #[tokio::test]
+    async fn a_late_duplicate_is_evicted_by_name() {
+        let service = RoomService::start(vec![(200, "{}")]).await;
+
+        evict_duplicate_agent(
+            &service.config(),
+            "interview-abc12345",
+            "agent-late",
+            1_700_000_000,
+        )
+        .await
+        .unwrap();
+
+        let (path, body) = service.requests().into_iter().next().unwrap();
+        assert_eq!(path, "/twirp/livekit.RoomService/RemoveParticipant");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&body).unwrap()["identity"],
+            "agent-late"
         );
     }
 

--- a/src/livekit/rooms.rs
+++ b/src/livekit/rooms.rs
@@ -1,0 +1,364 @@
+//! Room administration over the LiveKit server API.
+//!
+//! Named apart from the rest because it is the one region here that talks to
+//! LiveKit over HTTP rather than over the room's own event stream. Everything
+//! in it exists for one problem: a previous run of this agent can leave a
+//! participant behind, and a second agent in a room answers over the top of
+//! the first. `run_room` and `open_session` in the parent call two of these and
+//! nothing outside this module calls any of them.
+//!
+//! Split out of `livekit.rs` along the line its module doc already drew.
+
+use std::time::Duration;
+
+use ::livekit::prelude::RemoteParticipant;
+
+use crate::config::AgentConfig;
+use crate::token::livekit_room_admin_token;
+
+use super::DUPLICATE_AGENT_ISOLATION_ATTEMPTS;
+
+pub(super) async fn isolate_local_agent(
+    config: &AgentConfig,
+    room_name: &str,
+    local_identity: &str,
+    now_seconds: u64,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // One list pass more than removal rounds: the last pass only confirms the
+    // final removal landed.
+    let mut rounds_left = DUPLICATE_AGENT_ISOLATION_ATTEMPTS;
+    loop {
+        let participants = list_room_participants(config, room_name, now_seconds).await?;
+        let duplicate_agents = duplicate_agent_identities(&participants, local_identity);
+        if duplicate_agents.is_empty() {
+            return Ok(());
+        }
+        if rounds_left == 0 {
+            // Loud, not fatal. This used to return Err, and in `serve` an agent
+            // error aborts the web task and exits the process, so one stubborn
+            // auto-dispatched agent took the whole server down mid-interview.
+            // Two interviewers talking over each other is bad; no interviewer,
+            // no editor and no report is worse, and the operator can see this
+            // line and act on it while the candidate finishes.
+            eprintln!(
+                "WARNING: duplicate LiveKit agent participants remained after \
+                 {DUPLICATE_AGENT_ISOLATION_ATTEMPTS} attempts, continuing anyway: \
+                 {duplicate_agents:?}"
+            );
+            return Ok(());
+        }
+        rounds_left -= 1;
+        for identity in &duplicate_agents {
+            eprintln!("removing duplicate LiveKit agent participant identity={identity}");
+            remove_room_participant(config, room_name, identity, now_seconds).await?;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+async fn list_room_participants(
+    config: &AgentConfig,
+    room_name: &str,
+    now_seconds: u64,
+) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+    livekit_room_service_request(
+        config,
+        room_name,
+        "ListParticipants",
+        serde_json::json!({ "room": room_name }),
+        now_seconds,
+    )
+    .await
+}
+
+/// A removal that finds nothing to remove has achieved what it was asked to do.
+///
+/// This used to propagate the 404 and kill the interview. The duplicate agents
+/// being evicted here are the ones that leave on their own, so losing the race
+/// with them is the common case, not the exceptional one: the agent greeted the
+/// candidate, tried to evict a participant that had already gone, took the
+/// `not_found` as fatal, and exited. The candidate was left in a room with no
+/// interviewer, talking to nobody, with the status pill correctly reading
+/// "Waiting" and nothing on screen explaining why.
+async fn remove_room_participant(
+    config: &AgentConfig,
+    room_name: &str,
+    identity: &str,
+    now_seconds: u64,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    match livekit_room_service_request(
+        config,
+        room_name,
+        "RemoveParticipant",
+        serde_json::json!({ "room": room_name, "identity": identity }),
+        now_seconds,
+    )
+    .await
+    {
+        Ok(_) => Ok(()),
+        Err(error) if is_participant_gone(&error.to_string()) => {
+            eprintln!("duplicate LiveKit agent participant already gone identity={identity}");
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Matches on the wire response rather than on a status code alone, because
+/// LiveKit answers Twirp over HTTP and a bare 404 could also mean the route is
+/// wrong. All three parts are required: the method, so a 404 from any other
+/// RoomService call stays fatal; the status; and `not_found` in the body, which
+/// is the participant-specific Twirp code rather than an HTML error page.
+fn is_participant_gone(error: &str) -> bool {
+    error.contains("RemoveParticipant") && error.contains("404") && error.contains("not_found")
+}
+
+/// The Twirp POST both RoomService callers make. Only the token and the base
+/// differ, and both are strings; the body comes back with the status because a
+/// refusal explains itself there and not in the code.
+async fn post_room_service(
+    base: &str,
+    token: &str,
+    method: &str,
+    body: &serde_json::Value,
+) -> Result<(reqwest::StatusCode, String), Box<dyn std::error::Error + Send + Sync>> {
+    let response = crate::http_client()
+        .post(format!("{base}/twirp/livekit.RoomService/{method}"))
+        .bearer_auth(token)
+        .json(body)
+        .send()
+        .await?;
+    let status = response.status();
+    Ok((status, response.text().await?))
+}
+
+async fn livekit_room_service_request(
+    config: &AgentConfig,
+    room_name: &str,
+    method: &str,
+    body: serde_json::Value,
+    now_seconds: u64,
+) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+    let token = livekit_room_admin_token(
+        &config.livekit_api_key,
+        &config.livekit_api_secret,
+        room_name,
+        now_seconds,
+    )?;
+    let (status, text) = post_room_service(
+        &livekit_http_base(&config.livekit_url),
+        &token,
+        method,
+        &body,
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(format!("LiveKit RoomService {method} failed: {status} {text}").into());
+    }
+    parse_room_service_response(method, &text)
+}
+
+/// Proves credentials like `check-gemini` proves a Google key: the server
+/// must accept a signed request. `ListRooms` needs no room to exist.
+pub(crate) async fn validate_livekit_credentials(
+    url: &str,
+    api_key: &str,
+    api_secret: &str,
+    now_seconds: u64,
+) -> Result<(), String> {
+    let token = crate::token::livekit_room_list_token(api_key, api_secret, now_seconds)
+        .map_err(|error| error.to_string())?;
+    let (status, text) = post_room_service(
+        &livekit_http_base(url),
+        &token,
+        "ListRooms",
+        &serde_json::json!({}),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    if status.is_success() {
+        return Ok(());
+    }
+
+    // The body, because it is LiveKit's own account of the refusal and the
+    // Setup form is the one place a reader can act on it: a status alone says
+    // "did not work" to someone who already knows that. Bounded, because a
+    // wrong host answers with an HTML page and the form is one line.
+    const REASON_LIMIT: usize = 200;
+    let reason: String = text.chars().take(REASON_LIMIT).collect();
+    let ellipsis = if text.chars().count() > REASON_LIMIT {
+        "..."
+    } else {
+        ""
+    };
+    Err(format!(
+        "LiveKit ListRooms failed: {status} {reason}{ellipsis}"
+    ))
+}
+
+/// The RoomService origin for a LiveKit URL: the same host, over the scheme an
+/// HTTP client will send.
+///
+/// The rewrite goes through `livekit_scheme` rather than matching the two
+/// websocket schemes here, because `validate_livekit_url` accepts a scheme in
+/// any case and this has to rewrite every spelling that accepts. A pasted
+/// `WSS://` used to survive unchanged, and reqwest refuses any scheme but http
+/// and https before the request leaves the process, so credentials that were
+/// good came back as credentials that did not work.
+fn livekit_http_base(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/');
+    match crate::config::livekit_scheme(trimmed) {
+        Some((scheme, _, http)) => format!("{http}{}", &trimmed[scheme.len()..]),
+        None => trimmed.to_string(),
+    }
+}
+
+fn parse_room_service_response(
+    method: &str,
+    text: &str,
+) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+    serde_json::from_str(text).map_err(|error| {
+        format!("LiveKit RoomService {method} returned invalid JSON: {error}").into()
+    })
+}
+
+fn duplicate_agent_identities(
+    participants: &serde_json::Value,
+    local_identity: &str,
+) -> Vec<String> {
+    participants
+        .get("participants")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|participant| is_agent_participant(participant))
+        .filter_map(|participant| {
+            participant
+                .get("identity")
+                .and_then(serde_json::Value::as_str)
+        })
+        .filter(|identity| *identity != local_identity)
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn is_agent_participant(participant: &serde_json::Value) -> bool {
+    participant
+        .pointer("/permission/agent")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+        || participant
+            .get("kind")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|kind| kind == "AGENT")
+}
+
+/// A second agent in the room would answer over the top of this one, so the
+/// late joiner is removed rather than tolerated.
+pub(super) async fn evict_duplicate_agent(
+    config: &AgentConfig,
+    room_name: &str,
+    participant: &RemoteParticipant,
+    now_seconds: u64,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let identity = participant.identity().0;
+    eprintln!("removing late duplicate LiveKit agent participant identity={identity}");
+    remove_room_participant(config, room_name, &identity, now_seconds).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Losing the race with a duplicate agent that left on its own must not end
+    /// the interview. This shipped as a fatal error: the agent greeted the
+    /// candidate, tried to evict a participant that was already gone, and
+    /// exited on the `not_found`, leaving the candidate talking to an empty
+    /// room. Every other RoomService failure stays fatal.
+    #[test]
+    fn a_removal_that_finds_nobody_is_not_a_failure() {
+        assert!(is_participant_gone(
+            "LiveKit RoomService RemoveParticipant failed: 404 Not Found {\"code\":\"not_found\",\"msg\":\"participant does not exist\"}"
+        ));
+
+        for still_fatal in [
+            "LiveKit RoomService RemoveParticipant failed: 401 Unauthorized {\"code\":\"unauthenticated\"}",
+            "LiveKit RoomService RemoveParticipant failed: 503 Service Unavailable {}",
+            "LiveKit RoomService ListParticipants failed: 404 Not Found <html>no such route</html>",
+        ] {
+            assert!(!is_participant_gone(still_fatal), "{still_fatal}");
+        }
+    }
+
+    #[test]
+    fn duplicate_agent_identities_ignores_candidate_and_local_agent() {
+        let participants = serde_json::json!({
+            "participants": [
+                {
+                    "identity": "candidate-fixed",
+                    "kind": "STANDARD",
+                    "permission": { "agent": false }
+                },
+                {
+                    "identity": "interviewer-interview-fixed",
+                    "kind": "AGENT",
+                    "permission": { "agent": true }
+                },
+                {
+                    "identity": "hosted-agent",
+                    "kind": "AGENT",
+                    "permission": { "agent": true }
+                },
+                {
+                    "identity": "legacy-agent",
+                    "permission": { "agent": true }
+                }
+            ]
+        });
+
+        assert_eq!(
+            duplicate_agent_identities(&participants, "interviewer-interview-fixed"),
+            vec!["hosted-agent".to_string(), "legacy-agent".to_string()]
+        );
+    }
+
+    #[test]
+    fn livekit_http_base_maps_websocket_urls_to_room_service_host() {
+        assert_eq!(
+            livekit_http_base("wss://example.livekit.cloud/"),
+            "https://example.livekit.cloud"
+        );
+        assert_eq!(
+            livekit_http_base("ws://localhost:7880"),
+            "http://localhost:7880"
+        );
+    }
+
+    /// `validate_livekit_url` compares the scheme without regard to case, so
+    /// every spelling it accepts reaches here. The host keeps the case it was
+    /// given: DNS does not care, and a path might.
+    #[test]
+    fn livekit_http_base_rewrites_a_scheme_in_any_case() {
+        assert_eq!(
+            livekit_http_base("WSS://Example.LiveKit.Cloud"),
+            "https://Example.LiveKit.Cloud"
+        );
+        assert_eq!(
+            livekit_http_base("Ws://localhost:7880/"),
+            "http://localhost:7880"
+        );
+        assert_eq!(
+            livekit_http_base("HTTPS://example.livekit.cloud"),
+            "https://example.livekit.cloud"
+        );
+    }
+
+    #[test]
+    fn room_service_response_rejects_malformed_success_json() {
+        let error = parse_room_service_response("ListParticipants", "not json")
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("ListParticipants returned invalid JSON"));
+    }
+}

--- a/src/livekit/rooms.rs
+++ b/src/livekit/rooms.rs
@@ -22,36 +22,41 @@ pub(super) async fn isolate_local_agent(
     local_identity: &str,
     now_seconds: u64,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // One list pass more than removal rounds: the last pass only confirms the
-    // final removal landed.
-    let mut rounds_left = DUPLICATE_AGENT_ISOLATION_ATTEMPTS;
-    loop {
+    // A bounded number of removal rounds, then one more look. The last look is
+    // what confirms the final removal landed, and writing the budget as the
+    // range rather than as a counter is what keeps "one pass more" a property
+    // of the shape instead of an arithmetic accident.
+    for _ in 0..DUPLICATE_AGENT_ISOLATION_ATTEMPTS {
         let participants = list_room_participants(config, room_name, now_seconds).await?;
         let duplicate_agents = duplicate_agent_identities(&participants, local_identity);
         if duplicate_agents.is_empty() {
             return Ok(());
         }
-        if rounds_left == 0 {
-            // Loud, not fatal. This used to return Err, and in `serve` an agent
-            // error aborts the web task and exits the process, so one stubborn
-            // auto-dispatched agent took the whole server down mid-interview.
-            // Two interviewers talking over each other is bad; no interviewer,
-            // no editor and no report is worse, and the operator can see this
-            // line and act on it while the candidate finishes.
-            eprintln!(
-                "WARNING: duplicate LiveKit agent participants remained after \
-                 {DUPLICATE_AGENT_ISOLATION_ATTEMPTS} attempts, continuing anyway: \
-                 {duplicate_agents:?}"
-            );
-            return Ok(());
-        }
-        rounds_left -= 1;
         for identity in &duplicate_agents {
             eprintln!("removing duplicate LiveKit agent participant identity={identity}");
             remove_room_participant(config, room_name, identity, now_seconds).await?;
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
+
+    let participants = list_room_participants(config, room_name, now_seconds).await?;
+    let duplicate_agents = duplicate_agent_identities(&participants, local_identity);
+    if duplicate_agents.is_empty() {
+        return Ok(());
+    }
+
+    // Loud, not fatal. This used to return Err, and in `serve` an agent error
+    // aborts the web task and exits the process, so one stubborn
+    // auto-dispatched agent took the whole server down mid-interview. Two
+    // interviewers talking over each other is bad; no interviewer, no editor
+    // and no report is worse, and the operator can see this line and act on it
+    // while the candidate finishes.
+    eprintln!(
+        "WARNING: duplicate LiveKit agent participants remained after \
+         {DUPLICATE_AGENT_ISOLATION_ATTEMPTS} attempts, continuing anyway: \
+         {duplicate_agents:?}"
+    );
+    Ok(())
 }
 
 async fn list_room_participants(

--- a/src/livekit/rooms.rs
+++ b/src/livekit/rooms.rs
@@ -205,8 +205,16 @@ pub(crate) async fn validate_livekit_credentials(
 /// `WSS://` used to survive unchanged, and reqwest refuses any scheme but http
 /// and https before the request leaves the process, so credentials that were
 /// good came back as credentials that did not work.
+///
+/// The query and the fragment come off, because the Twirp path is appended
+/// to what this returns and validation accepts both. A configured
+/// `?region=eu` took the method name into the query rather than to the
+/// service. The path itself is kept: a LiveKit behind a reverse proxy at
+/// `https://host/livekit` serves RoomService under that prefix.
 fn livekit_http_base(url: &str) -> String {
-    let trimmed = url.trim_end_matches('/');
+    let trimmed = url.trim();
+    let trimmed = trimmed.split(['?', '#']).next().unwrap_or(trimmed);
+    let trimmed = trimmed.trim_end_matches('/');
     match crate::config::livekit_scheme(trimmed) {
         Some((scheme, _, http)) => format!("{http}{}", &trimmed[scheme.len()..]),
         None => trimmed.to_string(),
@@ -332,6 +340,40 @@ mod tests {
             livekit_http_base("ws://localhost:7880"),
             "http://localhost:7880"
         );
+
+        // Everything `validate_livekit_url` lets through. The scheme is matched
+        // case-insensitively there, and a query, a fragment and a path are all
+        // accepted, so each of these is a URL a deployment can be holding.
+        assert_eq!(
+            livekit_http_base("WSS://example.livekit.cloud"),
+            "https://example.livekit.cloud"
+        );
+        assert_eq!(
+            livekit_http_base("Ws://localhost:7880"),
+            "http://localhost:7880"
+        );
+        assert_eq!(
+            livekit_http_base("wss://example.livekit.cloud/?region=eu"),
+            "https://example.livekit.cloud"
+        );
+
+        // The path stays, because a proxy mounts RoomService under it. Only the
+        // query and the fragment come off, and neither can precede a path.
+        assert_eq!(
+            livekit_http_base("wss://example.livekit.cloud/livekit/"),
+            "https://example.livekit.cloud/livekit"
+        );
+        assert_eq!(
+            livekit_http_base("https://example.livekit.cloud/sfu#frag"),
+            "https://example.livekit.cloud/sfu"
+        );
+
+        // Shapes validation also accepts, neither of which this may mangle.
+        assert_eq!(
+            livekit_http_base("wss://user:pass@example.livekit.cloud/sfu"),
+            "https://user:pass@example.livekit.cloud/sfu"
+        );
+        assert_eq!(livekit_http_base("ws://[::1]:7880"), "http://[::1]:7880");
     }
 
     /// `validate_livekit_url` compares the scheme without regard to case, so

--- a/src/livekit/rooms.rs
+++ b/src/livekit/rooms.rs
@@ -395,6 +395,31 @@ mod tests {
         );
     }
 
+    /// All three parts are required, and nothing said so.
+    ///
+    /// Each is load bearing for a different reason the doc comment gives: the
+    /// method keeps a 404 from any other RoomService call fatal, the status
+    /// distinguishes a refusal from a failure, and the Twirp code separates a
+    /// participant that is gone from an HTML error page at the wrong route.
+    /// Dropping any one of them widens this to a participant that is still
+    /// there, and the caller treats that as a successful eviction.
+    #[test]
+    fn a_participant_is_gone_only_when_all_three_parts_say_so() {
+        let gone = "RemoveParticipant failed: 404 {\"code\":\"not_found\"}";
+        assert!(is_participant_gone(gone));
+
+        for missing in [
+            // Another RoomService call answering 404 is still fatal.
+            "ListParticipants failed: 404 {\"code\":\"not_found\"}",
+            // The right call and the right code, but not a refusal.
+            "RemoveParticipant failed: 500 {\"code\":\"not_found\"}",
+            // A 404 from the wrong route, which is an error page and not Twirp.
+            "RemoveParticipant failed: 404 <html>no such route</html>",
+        ] {
+            assert!(!is_participant_gone(missing), "{missing}");
+        }
+    }
+
     #[test]
     fn room_service_response_rejects_malformed_success_json() {
         let error = parse_room_service_response("ListParticipants", "not json")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1600,6 +1600,65 @@ bm90IGEga2V5
         assert!(super::recording_can_deliver(Some(&recording)).is_err());
     }
 
+    /// Half an OAuth app is not an OAuth app.
+    ///
+    /// The rule below is tested on its own; this is the wiring that feeds it,
+    /// and the two lookups have to be joined with "and". Joined with "or", a
+    /// deployment holding only a client id would start recording and then
+    /// refuse every interview at `/api/token`, because the address a recording
+    /// is delivered to is the one GitHub returns and there is no GitHub. Each
+    /// half alone has to be refused, and so does neither.
+    #[test]
+    fn recording_starts_only_with_both_halves_of_the_oauth_app() {
+        let recording_values = |pairs: &[(&str, &str)]| {
+            let mut values: std::collections::BTreeMap<String, String> = [
+                ("CODETRIAL_RECORDING_ENABLED", "true"),
+                ("CODETRIAL_RECORDING_GCS_BUCKET", "codetrial-staging"),
+                ("CODETRIAL_RECORDING_DRIVE_ID", "0AKfixtureDriveId"),
+                (
+                    "CODETRIAL_RECORDING_SERVICE_ACCOUNT_JSON",
+                    r#"{"type":"service_account","client_email":"a@b.iam.gserviceaccount.com","private_key":"KEYMATERIAL-4bd2"}"#,
+                ),
+                (
+                    "CODETRIAL_RECORDING_TEMPLATE_BASE_URL",
+                    "https://recording.codetrial.example",
+                ),
+                ("SESSION_SECRET", "a-real-secret"),
+            ]
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect();
+            for (key, value) in pairs {
+                values.insert(key.to_string(), value.to_string());
+            }
+            values
+        };
+        let pool = codetrial::config::ProviderPool {
+            providers: vec![provider(codetrial::config::PRIMARY_PROVIDER_ID)],
+        };
+
+        for half in [
+            vec![("GITHUB_CLIENT_ID", "id")],
+            vec![("GITHUB_CLIENT_SECRET", "secret")],
+            vec![],
+        ] {
+            let error = super::web_server_config(
+                &recording_values(&half),
+                pool.clone(),
+                false,
+                &super::CliOptions::default(),
+            )
+            .expect_err("recording with half an OAuth app must not start");
+            assert!(error.contains("GITHUB_CLIENT_ID"), "{error}");
+        }
+
+        // The other direction is `recording_needs_verified_identity` below,
+        // which takes the answer rather than the lookups: reaching it from here
+        // means a service account whose key really parses, and the rule it
+        // applies is the same either way.
+        let _ = pool;
+    }
+
     #[test]
     fn recording_needs_both_oauth_credentials_or_it_refuses_to_start() {
         assert!(super::recording_needs_verified_identity(false, false).is_ok());

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,6 +228,55 @@ fn bind_web_listener(addr: &str) -> Result<std::net::TcpListener, String> {
     Ok(listener)
 }
 
+/// The recording block and the server configuration it goes into.
+///
+/// Split from `run_web` because it is one decision made in one place:
+/// everything here is read from the operator's environment, validated, and put
+/// in a struct, and nothing here binds a socket or starts a task. The order
+/// inside it is load bearing and is written where it happens.
+fn web_server_config(
+    values: &std::collections::BTreeMap<String, String>,
+    pool: codetrial::config::ProviderPool,
+    production: bool,
+    options: &CliOptions,
+) -> Result<WebServerConfig, String> {
+    // After the pool is complete, so the "is this project in the pool" check
+    // sees the pool the server will actually serve, and before the listener
+    // does any work: a half-configured recording block is a startup failure,
+    // never a surprise at the moment a candidate's interview ends.
+    let recording = codetrial::config::load_recording(
+        values,
+        &pool,
+        interview_duration_min(values),
+        production,
+    )
+    .map_err(|error| error.to_string())?;
+    recording_needs_verified_identity(
+        recording.is_some(),
+        nonempty(values, "GITHUB_CLIENT_ID").is_some()
+            && nonempty(values, "GITHUB_CLIENT_SECRET").is_some(),
+    )?;
+    recording_can_deliver(recording.as_ref())?;
+
+    Ok(WebServerConfig {
+        web_dir: PathBuf::from(value_or(values, "CODETRIAL_WEB_DIR", DEFAULT_WEB_DIR)),
+        github_client_id: nonempty(values, "GITHUB_CLIENT_ID"),
+        github_client_secret: nonempty(values, "GITHUB_CLIENT_SECRET"),
+        session_secret: Some(value_or(values, "SESSION_SECRET", DEFAULT_SESSION_SECRET)),
+        db_path: Some(account_db_path(values, options)),
+        github_oauth_base_url: None,
+        github_api_base_url: None,
+        room_prefix: value_or(values, "CODETRIAL_ROOM_PREFIX", DEFAULT_ROOM_PREFIX),
+        fixed_room_name: nonempty(values, "INTERVIEW_ROOM_NAME"),
+        production,
+        trusted_proxy_hops: trusted_proxy_hops(values),
+        compiler_explorer_enabled: compiler_explorer_enabled(values),
+        recording,
+        pool,
+        probe_provider_quota: true,
+    })
+}
+
 fn run_web(options: CliOptions) -> Result<(), String> {
     // Falls through: once `serve_setup` returns, the config exists and the rest
     // of this function is an ordinary launch, on the socket Setup served on.
@@ -258,41 +307,7 @@ fn run_web(options: CliOptions) -> Result<(), String> {
     let production = is_production(&values);
     let pool = web_provider_pool(&values, &options, production)?;
 
-    // After the pool is complete, so the "is this project in the pool" check
-    // sees the pool the server will actually serve, and before the listener
-    // does any work: a half-configured recording block is a startup failure,
-    // never a surprise at the moment a candidate's interview ends.
-    let recording = codetrial::config::load_recording(
-        &values,
-        &pool,
-        interview_duration_min(&values),
-        production,
-    )
-    .map_err(|error| error.to_string())?;
-    recording_needs_verified_identity(
-        recording.is_some(),
-        nonempty(&values, "GITHUB_CLIENT_ID").is_some()
-            && nonempty(&values, "GITHUB_CLIENT_SECRET").is_some(),
-    )?;
-    recording_can_deliver(recording.as_ref())?;
-
-    let config = WebServerConfig {
-        web_dir: PathBuf::from(value_or(&values, "CODETRIAL_WEB_DIR", DEFAULT_WEB_DIR)),
-        github_client_id: nonempty(&values, "GITHUB_CLIENT_ID"),
-        github_client_secret: nonempty(&values, "GITHUB_CLIENT_SECRET"),
-        session_secret: Some(value_or(&values, "SESSION_SECRET", DEFAULT_SESSION_SECRET)),
-        db_path: Some(account_db_path(&values, &options)),
-        github_oauth_base_url: None,
-        github_api_base_url: None,
-        room_prefix: value_or(&values, "CODETRIAL_ROOM_PREFIX", DEFAULT_ROOM_PREFIX),
-        fixed_room_name: nonempty(&values, "INTERVIEW_ROOM_NAME"),
-        production: is_production(&values),
-        trusted_proxy_hops: trusted_proxy_hops(&values),
-        compiler_explorer_enabled: compiler_explorer_enabled(&values),
-        recording,
-        pool,
-        probe_provider_quota: true,
-    };
+    let config = web_server_config(&values, pool, production, &options)?;
 
     initialize_accounts(&config)?;
 

--- a/src/recording/replay.rs
+++ b/src/recording/replay.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 
 use crate::accounts::Accounts;
 
-use super::*;
+use super::RecordingState;
 
 /// The replay, which is the interview without the video.
 ///
@@ -79,17 +79,127 @@ impl ReplayKind {
         Self::ALL.into_iter().find(|kind| kind.as_str() == value)
     }
 
+    /// What a row of this kind is to the row before it.
+    ///
+    /// Exhaustive on purpose. Two overlapping `matches!` lists stood here, one
+    /// naming the replaceable kinds and one naming the restated ones, and a
+    /// seventh kind added to `ALL` would have classified silently as
+    /// accumulating in both. A `match` with no wildcard does not compile until
+    /// somebody says which of the three a new kind is.
+    fn class(self) -> ReplayClass {
+        match self {
+            // A transcript line is a line and a test run is a result; neither
+            // replaces what came before it.
+            Self::Transcript | Self::Tests => ReplayClass::Accumulates,
+
+            // A whole value, restated: a code buffer and a heading plus a
+            // clock.
+            Self::Editor | Self::Stage => ReplayClass::Restates,
+            // A transition, whose newest row is the current state.
+            Self::Avatar | Self::Lifecycle => ReplayClass::Transitions,
+        }
+    }
+
     /// Whether the newest event of this kind is the whole story.
     ///
     /// An editor snapshot replaces the last one and a transcript line does not,
     /// which is what lets a late join be one snapshot plus the events after it
     /// rather than every keystroke since the interview began.
     pub fn is_snapshot(self) -> bool {
-        matches!(
-            self,
-            Self::Editor | Self::Stage | Self::Avatar | Self::Lifecycle
-        )
+        !matches!(self.class(), ReplayClass::Accumulates)
     }
+}
+
+/// The three things a replay row can be to the row before it.
+///
+/// Private for the same reason `Collapse` is: nothing outside this module
+/// classifies a kind, and `is_snapshot` is the answer the rest of the crate
+/// asks for.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReplayClass {
+    /// Adds to what came before. Nothing supersedes it.
+    Accumulates,
+    /// Restates a whole value, so only the newest is worth keeping.
+    Restates,
+    /// A change of state, so the newest is the current one and the ones before
+    /// it are the history.
+    Transitions,
+}
+
+/// Which superseded frames a whole-replay read drops.
+///
+/// The two whole reads differ here and nowhere else.
+///
+/// A late join wants the newest row of each replaceable kind, and none of what
+/// it replaced. The review page wants one editor buffer and every `avatar` row,
+/// because what it renders is the shape of Jim's state over time, and what it
+/// cannot afford is a whole code buffer per debounce.
+///
+/// Private, because nothing outside this module chooses one: the reads are
+/// functions, and this is how two of them differ inside.
+#[derive(Clone, Copy)]
+enum Collapse {
+    /// Every snapshot kind, which is what `is_snapshot` names.
+    Snapshots,
+    /// Only the kinds whose rows restate a whole value: the editor buffer and
+    /// the stage heading. The other two, `avatar` and `lifecycle`, are
+    /// transitions rather than restatements, and a history of transitions is
+    /// what the review page is for.
+    ///
+    /// `Avatar` and `Lifecycle` stay snapshot kinds, and for two different
+    /// reasons.
+    ///
+    /// `Avatar` earns it by having a reader. A recording template joining late
+    /// takes the newest row and learns Jim's current state without replaying
+    /// the interview, which is what `web/recording/recording.js` does with it.
+    /// `Lifecycle` earns it by shape alone: its rows replace each other the way
+    /// a state does, but no consumer of the snapshot reads one, and the
+    /// template drops it in a `default:` arm that says so.
+    ///
+    /// `Lifecycle` is out of this collapse because of the pause. `applyPause`
+    /// in `web/interview.js` records a `paused` row precisely so a break is
+    /// visible rather than passing as thinking time, and the response window
+    /// computed from the `avatar` history is exactly what it would otherwise
+    /// pass as. Collapsing to the newest `lifecycle` row leaves a reviewer
+    /// reading a break as a long silence.
+    Restatements,
+}
+
+impl Collapse {
+    /// Whether a superseded row of this kind is dropped from the answer.
+    fn drops(self, kind: ReplayKind) -> bool {
+        match self {
+            Self::Snapshots => kind.is_snapshot(),
+
+            // No `is_snapshot` conjunct: both of these are snapshot kinds, and
+            // an `&&` that is always true reads as a guard somebody checked.
+            Self::Restatements => kind.class() == ReplayClass::Restates,
+        }
+    }
+}
+
+/// What one read of `replay_events` is asking for.
+///
+/// One argument rather than two, and that is the point of it.
+///
+/// Collapsing is correct only from the start of the replay. The subquery that
+/// finds the newest row of a kind is bounded above by the ceiling and not below
+/// by the floor, so a read that both collapsed and began at a sequence number
+/// would drop a kind entirely whenever that kind's newest row sat at or below
+/// the floor.
+///
+/// While collapsing and starting from the beginning were the same `after < 0`
+/// test, the code shape enforced that. Splitting them into two parameters would
+/// have left it to convention, so they are one parameter instead and the bad
+/// pair cannot be written.
+#[derive(Clone, Copy)]
+enum ReplayRead {
+    /// The whole replay, minus what the given collapse drops.
+    Whole(Collapse),
+    /// Everything after a sequence number, dropping nothing. A caller carrying
+    /// on from a snapshot is replaying, and a frame it never saw is not one to
+    /// skip.
+    After(i64),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -498,7 +608,37 @@ pub fn replay_snapshot(
     account_id: i64,
     now: i64,
 ) -> rusqlite::Result<SnapshotView> {
-    replay_view(accounts, interview_id, account_id, -1, now)
+    replay_view(
+        accounts,
+        interview_id,
+        account_id,
+        ReplayRead::Whole(Collapse::Snapshots),
+        now,
+    )
+}
+
+/// The replay a reviewer reads: one editor buffer, every transition.
+///
+/// The same read as `replay_snapshot`, under the same guards, differing only in
+/// what it collapses; `Collapse::Restatements` says what that is for.
+///
+/// `seq` 0 is in the answer. `after` is `-1` here exactly as it is for the
+/// snapshot, so the `seq > ?3` bound is `seq > -1` and the first event of the
+/// interview is included. That is the difference from reaching the same rows
+/// through `replay_tail`, whose `after.max(0)` puts the floor at `seq > 0`.
+pub fn replay_review(
+    accounts: &Accounts,
+    interview_id: &str,
+    account_id: i64,
+    now: i64,
+) -> rusqlite::Result<SnapshotView> {
+    replay_view(
+        accounts,
+        interview_id,
+        account_id,
+        ReplayRead::Whole(Collapse::Restatements),
+        now,
+    )
 }
 
 /// Everything after `seq`, under the same guards.
@@ -513,14 +653,20 @@ pub fn replay_tail(
     after: i64,
     now: i64,
 ) -> rusqlite::Result<SnapshotView> {
-    replay_view(accounts, interview_id, account_id, after.max(0), now)
+    replay_view(
+        accounts,
+        interview_id,
+        account_id,
+        ReplayRead::After(after),
+        now,
+    )
 }
 
 fn replay_view(
     accounts: &Accounts,
     interview_id: &str,
     account_id: i64,
-    after: i64,
+    read: ReplayRead,
     now: i64,
 ) -> rusqlite::Result<SnapshotView> {
     accounts.with(|connection| {
@@ -562,15 +708,28 @@ fn replay_view(
             [interview_id],
             |row| row.get(0),
         )?;
-        let superseded = ReplayKind::ALL
-            .iter()
-            .filter(|kind| kind.is_snapshot())
-            .map(|kind| format!("'{}'", kind.as_str()))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let query = if after < 0 {
-            format!(
-                "
+
+        // The floor and the query are one decision, so they are one match. A
+        // whole read binds `-1`, so `seq > -1` includes `seq` 0; a tail floors
+        // its argument at 0 and collapses nothing, which is why it never has to
+        // build `kind NOT IN ()` out of an empty list, a thing SQLite refuses
+        // to parse.
+        //
+        // The kinds are interpolated rather than bound, because SQLite has no
+        // list parameter and `kind.as_str()` is a `&'static str` from a closed
+        // enum: there is no caller-supplied text anywhere in this list.
+        let (after, query) = match read {
+            ReplayRead::Whole(collapse) => {
+                let superseded = ReplayKind::ALL
+                    .into_iter()
+                    .filter(|kind| collapse.drops(*kind))
+                    .map(|kind| format!("'{}'", kind.as_str()))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                (
+                    -1,
+                    format!(
+                        "
         SELECT seq, kind, at, payload FROM replay_events
         WHERE interview_id = ?1 AND seq <= ?2 AND seq > ?3
           AND (kind NOT IN ({superseded})
@@ -580,14 +739,18 @@ fn replay_view(
                            AND newer.seq <= ?2))
         ORDER BY seq
         "
-            )
-        } else {
-            "
+                    ),
+                )
+            }
+            ReplayRead::After(after) => (
+                after.max(0),
+                "
         SELECT seq, kind, at, payload FROM replay_events
         WHERE interview_id = ?1 AND seq <= ?2 AND seq > ?3
         ORDER BY seq
         "
-            .to_string()
+                .to_string(),
+            ),
         };
         let mut statement = transaction.prepare(&query)?;
         let events = statement
@@ -604,6 +767,12 @@ fn replay_view(
 }
 
 /// Every event of an interview, in the order they were allocated.
+///
+/// Public and called only by tests: the three reads a route takes are
+/// `replay_snapshot`, `replay_review` and `replay_tail`, and this one predates
+/// them. Kept because the tests that assert on ingest want the rows as stored,
+/// with nothing collapsed and no retention guard in the way, which none of the
+/// three will give them.
 pub fn replay_events(
     accounts: &Accounts,
     interview_id: &str,
@@ -611,8 +780,8 @@ pub fn replay_events(
     after: i64,
 ) -> rusqlite::Result<Vec<(i64, ReplayEvent)>> {
     accounts.with(|connection| {
-        // Scoped in the query rather than by the caller. The read routes are a
-        // later task, and an id from a URL is the only thing they will have.
+        // Scoped in the query rather than by the caller, because a caller that
+        // has only an id from a URL cannot scope it itself.
         let mut statement = connection.prepare(
             "
         SELECT seq, kind, at, payload FROM replay_events

--- a/src/recording/store.rs
+++ b/src/recording/store.rs
@@ -245,6 +245,26 @@ pub fn transition(
     next: RecordingState,
     error: Option<&str>,
 ) -> rusqlite::Result<Option<(RecordingState, bool)>> {
+    transition_within(accounts, clock, recording_id, None, next, error)
+}
+
+/// [`transition`], refused unless the row is still in one of `only_from`.
+///
+/// For a caller whose news can arrive late about a row somebody else now owns.
+/// The table cannot express that: it allows `transferring` to `failed` because
+/// the delivery worker needs that move, which also let a provider failure
+/// arriving after a completed egress fail a recording whose file was already
+/// queued and sound. Reading the state first and then moving would leave the
+/// same race in a wider window, so the guard is inside the one closure that
+/// already reads and writes under the same lock.
+pub fn transition_within(
+    accounts: &Accounts,
+    clock: &dyn Clock,
+    recording_id: &str,
+    only_from: Option<&[RecordingState]>,
+    next: RecordingState,
+    error: Option<&str>,
+) -> rusqlite::Result<Option<(RecordingState, bool)>> {
     let now = clock.now();
     accounts.with(|connection| {
         let current: Option<String> = connection
@@ -257,6 +277,11 @@ pub fn transition(
         let Some(current) = current.as_deref().and_then(RecordingState::parse) else {
             return Ok(None);
         };
+        if let Some(only_from) = only_from
+            && !only_from.contains(&current)
+        {
+            return Ok(Some((current, false)));
+        }
 
         // Already there. The transition is allowed, and nothing moved, which is
         // the difference a duplicate stop rides on: the second caller has

--- a/src/web/interviews.rs
+++ b/src/web/interviews.rs
@@ -19,7 +19,8 @@ use crate::current_epoch_seconds;
 use super::auth::Owner;
 use super::recordings::finish_recording;
 use super::{
-    AppState, MAX_BODY_BYTES, MAX_REPORT_BYTES, json_response, rate_limited_response, replay_body,
+    AppState, MAX_BODY_BYTES, MAX_REPORT_BYTES, json_response, rate_limited_response,
+    replay_response,
 };
 
 /// What one account posting replay events may spend in a window.
@@ -360,8 +361,6 @@ pub(crate) async fn replay_snapshot_handler(
     UriPath(interview_id): UriPath<String>,
     Owner { accounts, user }: Owner,
 ) -> Response {
-    use crate::recording::SnapshotView;
-
     let missing = || {
         json_response(
             StatusCode::NOT_FOUND,
@@ -375,26 +374,10 @@ pub(crate) async fn replay_snapshot_handler(
     let view =
         blocking(move || crate::recording::replay_snapshot(&accounts, &interview_id, user.id, now))
             .await;
-    match view {
-        Ok(SnapshotView::Ready(snapshot)) => json_response(StatusCode::OK, replay_body(&snapshot)),
 
-        // Gone rather than not-found: this account owns the interview and is
-        // owed the difference between "never yours" and "not any more".
-        Ok(SnapshotView::Expired) => json_response(
-            StatusCode::GONE,
-            json!({ "code": "replay_expired", "error": "This replay is past its retention deadline." }),
-        ),
-        Ok(SnapshotView::Deleted) => json_response(
-            StatusCode::GONE,
-            json!({ "code": "recording_deleted", "error": "This recording has been deleted." }),
-        ),
-        Ok(SnapshotView::NoInterview) => missing(),
-        Err(error) => {
-            eprintln!("could not read a replay snapshot: {error}");
-            json_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                json!({ "error": "Could not read the replay." }),
-            )
-        }
-    }
+    // Gone rather than not-found on an expired or deleted replay: this account
+    // owns the interview and is owed the difference between "never yours" and
+    // "not any more". That distinction, and the two sentences carrying it, are
+    // `replay_response`'s, shared with the two recording routes.
+    replay_response(view, missing, "could not read a replay snapshot")
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -40,6 +40,7 @@ pub use assets::static_file_meta;
 pub use auth::login_config;
 pub use interviews::REPLAY_RATE_LIMIT;
 use pool::{ProviderQuota, QuotaRefresher, spawn_provider_quota_refresher};
+pub use recordings::READ_RATE_LIMIT;
 pub use setup::setup_service;
 pub use token::{TOKEN_RATE_LIMIT, TokenConfig, TokenResponse, token_response};
 
@@ -197,6 +198,17 @@ pub(crate) struct AppState {
     /// for the length of an interview, so sharing the token bucket would have a
     /// candidate's own replay spend the budget their next token needs.
     replay_limit: TokenRateLimit<i64>,
+
+    /// The read side of the same reasoning, and a separate bucket from the
+    /// write side so that a candidate mid-interview cannot be locked out of
+    /// posting their own replay by a reviewer reading one.
+    ///
+    /// Every route behind it is already `Owner`-scoped and every answer is
+    /// already bounded, by `MAX_REPLAY_EVENTS` and `MAX_REPLAY_BYTES` on a
+    /// replay and by the page size on a listing. So this bounds neither the
+    /// blast radius of one request nor who may ask: it bounds how often, which
+    /// is the one of the three nothing else covered.
+    read_limit: TokenRateLimit<i64>,
 
     /// Which provider the next room goes to. Relaxed because nothing depends on
     /// the order two concurrent requests observe, only that they observe
@@ -371,6 +383,7 @@ pub(crate) fn web_router(
             token_limit: TokenRateLimit::with_limit(token::TOKEN_RATE_LIMIT),
             login_limit: TokenRateLimit::with_limit(token::TOKEN_RATE_LIMIT),
             replay_limit: TokenRateLimit::with_limit(interviews::REPLAY_RATE_LIMIT),
+            read_limit: TokenRateLimit::with_limit(recordings::READ_RATE_LIMIT),
             provider_counter: Arc::new(AtomicUsize::new(0)),
             provider_quota,
             quota_refresher: Arc::new(quota_refresher),

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -613,9 +613,54 @@ pub(crate) fn client_ip(headers: &header::HeaderMap, peer: SocketAddr, hops: u32
         .unwrap_or_else(|| peer.ip())
 }
 
+/// One answer for every replay read, so the three routes that take one cannot
+/// drift apart.
+///
+/// They differ in two things and this takes both: what "no such replay" means
+/// to the caller, which is a recording id to one route and a room to another,
+/// and the sentence a read error is logged under. Everything else was written
+/// out three times, including the two `410` bodies, and those are the retention
+/// promise: a copy that said something slightly different would be a third
+/// answer to a question the product gives one answer to. `gone_response` below
+/// exists for the same reason on the route ahead of this one.
+///
+/// A function pointer rather than a closure, because none of the three captures
+/// anything: what a route answers here is a constant, and a signature that
+/// allowed a captured one would be inviting a fourth thing to differ.
+pub(crate) fn replay_response(
+    view: rusqlite::Result<crate::recording::SnapshotView>,
+    missing: fn() -> Response,
+    context: &str,
+) -> Response {
+    use crate::recording::SnapshotView;
+
+    match view {
+        Ok(SnapshotView::Ready(snapshot)) => json_response(StatusCode::OK, replay_body(&snapshot)),
+        Ok(SnapshotView::Expired) => json_response(
+            StatusCode::GONE,
+            json!({ "code": "replay_expired", "error": "This replay is past its retention deadline." }),
+        ),
+        Ok(SnapshotView::Deleted) => json_response(
+            StatusCode::GONE,
+            json!({ "code": "recording_deleted", "error": "This recording has been deleted." }),
+        ),
+        Ok(SnapshotView::NoInterview) => missing(),
+        Err(error) => {
+            eprintln!("{context}: {error}");
+            json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                json!({ "error": "Could not read the replay." }),
+            )
+        }
+    }
+}
+
 /// One body shape for both replay reads, so a caller that starts with a
 /// snapshot and carries on with the tail parses one thing.
-pub(crate) fn replay_body(snapshot: &crate::recording::Snapshot) -> Value {
+///
+/// Private since the fold: `replay_response` above is the only caller, and the
+/// routes that used to build this themselves now go through it.
+fn replay_body(snapshot: &crate::recording::Snapshot) -> Value {
     json!({
         "seq": snapshot.seq,
         "quotaExceeded": snapshot.quota_exceeded,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -188,6 +188,12 @@ pub(crate) struct AppState {
     #[allow(dead_code)]
     quota_refresher: Arc<QuotaRefresher>,
 
+    /// The same, for the recording sweeper and the delivery worker. Detached,
+    /// these outlived the router that started them and went on scanning a
+    /// database the server they belonged to had finished with.
+    #[allow(dead_code)]
+    recording_workers: Arc<RecordingWorkers>,
+
     // A separate bucket, for the same reason `/api/token` checks the session
     // before spending its own: login is reachable without any credential, so a
     // flood of it must not lock a signed-in candidate out of a token.
@@ -302,10 +308,12 @@ pub(crate) fn web_router(
         );
     }
     let accounts = login.and_then(open_accounts);
-    if let (Some(accounts), Some(recorder)) = (&accounts, &recorder) {
-        spawn_recording_sweeper(accounts.clone(), recorder.clone());
-        spawn_delivery_worker(accounts.clone(), recorder.clone());
-    }
+    let recording_workers = match (&accounts, &recorder) {
+        (Some(accounts), Some(recorder)) => {
+            spawn_recording_workers(accounts.clone(), recorder.clone())
+        }
+        _ => RecordingWorkers::default(),
+    };
 
     // Built here rather than in the state literal below, because the refresher
     // and the request path have to share one cache: a second `default()` would
@@ -387,6 +395,7 @@ pub(crate) fn web_router(
             provider_counter: Arc::new(AtomicUsize::new(0)),
             provider_quota,
             quota_refresher: Arc::new(quota_refresher),
+            recording_workers: Arc::new(recording_workers),
             room_authorizations: Arc::default(),
         })
 }

--- a/src/web/recordings.rs
+++ b/src/web/recordings.rs
@@ -17,7 +17,7 @@ use crate::current_epoch_seconds;
 
 use super::auth::Owner;
 use super::consent::recording_requires_consent;
-use super::{AppState, MAX_WEBHOOK_BODY_BYTES, json_response, replay_body};
+use super::{AppState, MAX_WEBHOOK_BODY_BYTES, json_response, replay_response};
 
 /// How often the sweeper runs. The shortest retry backoff, because a schedule
 /// checked less often than its own first step is a schedule with a different
@@ -297,22 +297,24 @@ pub(crate) async fn recording_status_handler(
 ) -> Response {
     // A server that records nothing answers exactly as one with no such
     // recording does. Three states, one reply: telling them apart is a way to
-    // learn about other people's interviews and about this deployment.
-    let missing = || {
+    // learn about other people's interviews and about this deployment. Its own
+    // sentence: this route is asked about an interview, and the two others
+    // about a recording id, so the words differ where the code does not.
+    let no_recording = || {
         json_response(
             StatusCode::NOT_FOUND,
             json!({ "code": "recording_not_found", "error": "No recording for that interview." }),
         )
     };
     if state.recorder.is_none() {
-        return missing();
+        return no_recording();
     }
     let found = blocking(move || {
         crate::recording::recording_for_interview(&accounts, &interview_id, user.id)
     })
     .await;
     match found {
-        Ok(None) => missing(),
+        Ok(None) => no_recording(),
         Ok(Some(recording)) => {
             // Through `Failure::parse`, so only an enumerated code can reach a
             // client. The column is written by this crate today, and a status
@@ -476,14 +478,8 @@ pub(crate) async fn recording_handler(
     UriPath(recording_id): UriPath<String>,
     Owner { accounts, user }: Owner,
 ) -> Response {
-    let missing = || {
-        json_response(
-            StatusCode::NOT_FOUND,
-            json!({ "code": "recording_not_found", "error": "No such recording." }),
-        )
-    };
     if state.recorder.is_none() {
-        return missing();
+        return recording_missing();
     }
     let found =
         blocking(move || crate::recording::recording_summary(&accounts, &recording_id, user.id))
@@ -495,7 +491,7 @@ pub(crate) async fn recording_handler(
         );
     };
     let Some(summary) = found else {
-        return missing();
+        return recording_missing();
     };
     if let Some(gone) = gone_response(&summary, current_epoch_seconds() as i64) {
         return gone;
@@ -531,23 +527,14 @@ pub(crate) async fn recording_events_handler(
     Query(params): Query<HashMap<String, String>>,
     Owner { accounts, user }: Owner,
 ) -> Response {
-    use crate::recording::SnapshotView;
-
-    let missing = || {
-        json_response(
-            StatusCode::NOT_FOUND,
-            json!({ "code": "recording_not_found", "error": "No such recording." }),
-        )
-    };
     if state.recorder.is_none() {
-        return missing();
+        return recording_missing();
     }
     let now = current_epoch_seconds() as i64;
     let after = params
         .get("after")
         .and_then(|after| after.parse::<i64>().ok())
         .unwrap_or(-1);
-
     let found = {
         let accounts = accounts.clone();
         let recording_id = recording_id.clone();
@@ -556,7 +543,7 @@ pub(crate) async fn recording_events_handler(
     };
     let summary = match found {
         Ok(Some(summary)) => summary,
-        Ok(None) => return missing(),
+        Ok(None) => return recording_missing(),
 
         // A read that failed is not a recording that does not exist. Answering
         // `404` for it tells a person their interview is gone when the database
@@ -581,25 +568,24 @@ pub(crate) async fn recording_events_handler(
         }
     })
     .await;
-    match view {
-        Ok(SnapshotView::Ready(snapshot)) => json_response(StatusCode::OK, replay_body(&snapshot)),
-        Ok(SnapshotView::Expired) => json_response(
-            StatusCode::GONE,
-            json!({ "code": "replay_expired", "error": "This replay is past its retention deadline." }),
-        ),
-        Ok(SnapshotView::Deleted) => json_response(
-            StatusCode::GONE,
-            json!({ "code": "recording_deleted", "error": "This recording has been deleted." }),
-        ),
-        Ok(SnapshotView::NoInterview) => missing(),
-        Err(error) => {
-            eprintln!("could not read a replay: {error}");
-            json_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                json!({ "error": "Could not read the replay." }),
-            )
-        }
-    }
+    replay_response(view, recording_missing, "could not read a replay")
+}
+
+/// No such recording, in the words the detail and the events routes both use.
+///
+/// Written out twice before, which is two chances for one of them to start
+/// saying something a caller can tell apart from the other: an account that
+/// does not own a recording must not learn that it exists, and that only holds
+/// while both routes answer a stranger and an owner of nothing the same way.
+///
+/// The other two routes in this file keep their own wording deliberately, and
+/// each says why where it says it: one is asked about an interview and one
+/// about a room.
+fn recording_missing() -> Response {
+    json_response(
+        StatusCode::NOT_FOUND,
+        json!({ "code": "recording_not_found", "error": "No such recording." }),
+    )
 }
 
 /// `410` for a recording whose media is gone or past its deadline, and nothing
@@ -647,8 +633,6 @@ pub(crate) async fn recording_replay_handler(
     Query(params): Query<HashMap<String, String>>,
     request: Request<Body>,
 ) -> Response {
-    use crate::recording::SnapshotView;
-
     let Some(accounts) = state.accounts.clone() else {
         return state.accounts_error();
     };
@@ -721,28 +705,16 @@ pub(crate) async fn recording_replay_handler(
         }
     })
     .await;
-    match view {
-        Ok(SnapshotView::Ready(snapshot)) => json_response(StatusCode::OK, replay_body(&snapshot)),
-        Ok(SnapshotView::Expired) => json_response(
-            StatusCode::GONE,
-            json!({ "code": "replay_expired", "error": "This replay is past its retention deadline." }),
-        ),
-        Ok(SnapshotView::Deleted) => json_response(
-            StatusCode::GONE,
-            json!({ "code": "recording_deleted", "error": "This recording has been deleted." }),
-        ),
-        Ok(SnapshotView::NoInterview) => json_response(
-            StatusCode::NOT_FOUND,
-            json!({ "code": "recording_not_found", "error": "No replay for that room." }),
-        ),
-        Err(error) => {
-            eprintln!("could not read a replay for a room: {error}");
+    replay_response(
+        view,
+        || {
             json_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                json!({ "error": "Could not read the replay." }),
+                StatusCode::NOT_FOUND,
+                json!({ "code": "recording_not_found", "error": "No replay for that room." }),
             )
-        }
-    }
+        },
+        "could not read a replay for a room",
+    )
 }
 
 /// LiveKit's webhooks.

--- a/src/web/recordings.rs
+++ b/src/web/recordings.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::body::{Body, to_bytes};
 use axum::extract::{Path as UriPath, Query, State};
@@ -17,7 +17,39 @@ use crate::current_epoch_seconds;
 
 use super::auth::Owner;
 use super::consent::recording_requires_consent;
-use super::{AppState, MAX_WEBHOOK_BODY_BYTES, json_response, replay_response};
+use super::{
+    AppState, MAX_WEBHOOK_BODY_BYTES, json_response, rate_limited_response, replay_response,
+};
+
+/// What one account may spend reading its own recordings in a window.
+///
+/// Derived from the first-party caller rather than picked, the way
+/// `REPLAY_RATE_LIMIT` is. `web/replay.js` reads the listing once a page load
+/// and then the detail and the events of whichever recording a person clicks,
+/// so a reviewer working quickly through a history spends single digits a
+/// minute against this budget. A hundred and twenty leaves that untouched with
+/// room to spare.
+///
+/// The reads it bounds are cheap per call and not free per row: the review read
+/// added for the response window returns every `avatar` and `lifecycle`
+/// transition rather than the newest of each, which is what made "nothing
+/// bounds how often" worth closing rather than noting.
+pub const READ_RATE_LIMIT: u32 = 120;
+
+/// Whether this account may spend one more read, in the words the routes behind
+/// it answer with: the listing, the detail and the events.
+///
+/// Keyed on the account, which `Owner` has already resolved, for the reason the
+/// ingest limiter gives: the address would put a whole office behind one budget
+/// and let one looping tab refuse everyone beside it.
+///
+/// Not every read in this file is behind it. The room-token replay route has no
+/// account to charge, and the status route that `web/recording-state.js` polls
+/// is not budgeted.
+fn read_allowed(state: &AppState, account_id: i64) -> Option<Response> {
+    (!state.read_limit.allow(account_id, Instant::now()))
+        .then(|| rate_limited_response("Too many reads at once. Wait a minute."))
+}
 
 /// How often the sweeper runs. The shortest retry backoff, because a schedule
 /// checked less often than its own first step is a schedule with a different
@@ -406,6 +438,9 @@ pub(crate) async fn list_recordings_handler(
             json!({ "recordings": [], "nextCursor": null }),
         );
     }
+    if let Some(refused) = read_allowed(&state, user.id) {
+        return refused;
+    }
 
     // `<created_at>.<id>`, which is the last row of the previous page. Refused
     // rather than ignored when it does not parse: a cursor that quietly became
@@ -481,6 +516,9 @@ pub(crate) async fn recording_handler(
     if state.recorder.is_none() {
         return recording_missing();
     }
+    if let Some(refused) = read_allowed(&state, user.id) {
+        return refused;
+    }
     let found =
         blocking(move || crate::recording::recording_summary(&accounts, &recording_id, user.id))
             .await;
@@ -538,6 +576,9 @@ pub(crate) async fn recording_events_handler(
 ) -> Response {
     if state.recorder.is_none() {
         return recording_missing();
+    }
+    if let Some(refused) = read_allowed(&state, user.id) {
+        return refused;
     }
     let now = current_epoch_seconds() as i64;
     let after = params

--- a/src/web/recordings.rs
+++ b/src/web/recordings.rs
@@ -521,6 +521,15 @@ pub(crate) async fn recording_handler(
 ///
 /// The same shape the recording template reads, and the same rules: absent or
 /// negative `after` is the snapshot, a number is the tail.
+///
+/// `avatar=history` is the one thing this route reads that the template's does
+/// not. It answers the snapshot with the collapse narrowed to `Restates`, so
+/// the transition histories survive; `Collapse` in `src/recording/replay.rs`
+/// carries what each read is for and why the template gets neither history.
+///
+/// It applies to the snapshot only. The tail collapses nothing already, so the
+/// parameter has nothing to lift there, and a request carrying both is answered
+/// as the tail it asked for.
 pub(crate) async fn recording_events_handler(
     State(state): State<AppState>,
     UriPath(recording_id): UriPath<String>,
@@ -535,6 +544,12 @@ pub(crate) async fn recording_events_handler(
         .get("after")
         .and_then(|after| after.parse::<i64>().ok())
         .unwrap_or(-1);
+
+    // Exact, not truthy. An unknown value is the ordinary snapshot rather than
+    // a guess at what the caller meant, so a typo reads one avatar row instead
+    // of quietly widening the answer.
+    let avatar_history = params.get("avatar").map(String::as_str) == Some("history");
+
     let found = {
         let accounts = accounts.clone();
         let recording_id = recording_id.clone();
@@ -560,11 +575,17 @@ pub(crate) async fn recording_events_handler(
         return gone;
     }
 
+    // After `gone_response`, and `replay_view` checks expiry and deletion again
+    // inside its own transaction. Both guards cover the review read for the
+    // same reason they cover the snapshot: it is the same function with one
+    // argument changed, so there is no second path to leave unguarded.
     let view = blocking(move || {
-        if after < 0 {
-            crate::recording::replay_snapshot(&accounts, &summary.interview_id, user.id, now)
-        } else {
+        if after >= 0 {
             crate::recording::replay_tail(&accounts, &summary.interview_id, user.id, after, now)
+        } else if avatar_history {
+            crate::recording::replay_review(&accounts, &summary.interview_id, user.id, now)
+        } else {
+            crate::recording::replay_snapshot(&accounts, &summary.interview_id, user.id, now)
         }
     })
     .await;

--- a/src/web/recordings/mod.rs
+++ b/src/web/recordings/mod.rs
@@ -654,11 +654,26 @@ pub(crate) async fn recording_replay_handler(
         let room_name = room_name.clone();
         blocking(move || crate::recording::recording_for_room(&accounts, &room_name)).await
     };
-    let Ok(Some(recording)) = found else {
-        return json_response(
-            StatusCode::NOT_FOUND,
-            json!({ "code": "recording_not_found", "error": "No recording for that room." }),
-        );
+    let recording = match found {
+        Ok(Some(recording)) => recording,
+        Ok(None) => {
+            return json_response(
+                StatusCode::NOT_FOUND,
+                json!({ "code": "recording_not_found", "error": "No recording for that room." }),
+            );
+        }
+
+        // Separated from the empty read, because the template treats this route
+        // as the answer to whether a replay exists. A database that was busy
+        // for a moment reported the recording gone, which is a permanent answer
+        // to a temporary condition and one no caller retries.
+        Err(error) => {
+            eprintln!("could not read the recording for a room: {error}");
+            return json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                json!({ "error": "Could not read the recording." }),
+            );
+        }
     };
 
     let view = blocking(move || {

--- a/src/web/recordings/mod.rs
+++ b/src/web/recordings/mod.rs
@@ -1,25 +1,42 @@
-//! Everything downstream of a room being recorded: starting and stopping an
-//! Egress job, the webhook that reports on it, the queries that list and serve
-//! the result, and the background workers that sweep and deliver.
+//! An account's own recordings, over HTTP: starting and stopping an Egress
+//! job, and the queries that list and serve the result.
+//!
+//! Two regions are out. `workers` holds the sweeper and the delivery worker,
+//! which no request drives, and `webhook` holds LiveKit's callback, which
+//! authenticates on a signature rather than a session.
+//!
+//! What is left is one caller and one auth model: every route here takes
+//! `Owner`, answers the account that owns the recording, and shares
+//! `recording_missing` and `gone_response`. Starting a recording and reading
+//! one back looked like two regions by line count and are not: splitting them
+//! would put a file boundary through one surface rather than along a seam.
+
+mod webhook;
+mod workers;
+
+pub(crate) use webhook::recording_webhook_handler;
+
+// Not re-exported: the replay route below is the only caller outside `webhook`,
+// so these stay visible to this module and no wider.
+use webhook::{signed_by_the_rooms_project, webhook_credentials};
+pub(crate) use workers::{delivery_provider, spawn_delivery_worker, spawn_recording_sweeper};
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
-use axum::body::{Body, to_bytes};
+use axum::body::Body;
 use axum::extract::{Path as UriPath, Query, State};
 use axum::http::{Request, StatusCode, header};
 use axum::response::{IntoResponse, Response};
-use serde_json::{Value, json};
+use serde_json::json;
 
 use crate::accounts::{Accounts, blocking, random_token};
 use crate::current_epoch_seconds;
 
 use super::auth::Owner;
 use super::consent::recording_requires_consent;
-use super::{
-    AppState, MAX_WEBHOOK_BODY_BYTES, json_response, rate_limited_response, replay_response,
-};
+use super::{AppState, json_response, rate_limited_response, replay_response};
 
 /// What one account may spend reading its own recordings in a window.
 ///
@@ -51,112 +68,17 @@ fn read_allowed(state: &AppState, account_id: i64) -> Option<Response> {
         .then(|| rate_limited_response("Too many reads at once. Wait a minute."))
 }
 
-/// How often the sweeper runs. The shortest retry backoff, because a schedule
-/// checked less often than its own first step is a schedule with a different
-/// first step.
-pub(crate) const SWEEP_INTERVAL: Duration = Duration::from_secs(60);
-
-/// Resolves recordings nobody is looking after, now and then repeatedly.
+/// The `after` query parameter, which chooses the shape of a replay read.
 ///
-/// Now, because a process that died mid-interview left rows no request will
-/// ever touch again. Repeatedly, because the retry schedule is minutes long and
-/// a sweep that only ran at startup would turn every provider hiccup into a
-/// failed recording.
-///
-/// Silent when there is no runtime to spawn on. `web_router` is public and can
-/// be built outside one; a router that serves without a sweeper is degraded,
-/// and a panic at construction is worse.
-pub(crate) fn spawn_recording_sweeper(
-    accounts: Arc<Accounts>,
-    recorder: crate::recording::Recorder,
-) {
-    let Ok(handle) = tokio::runtime::Handle::try_current() else {
-        eprintln!("recording is configured but there is no runtime to sweep on");
-        return;
-    };
-    handle.spawn(async move {
-        loop {
-            let outcome = crate::recording::sweep_recordings(&accounts, &recorder).await;
-            if outcome != crate::recording::SweepOutcome::default() {
-                eprintln!(
-                    "recording sweep retried {} deleted {} failed {}",
-                    outcome.retried, outcome.deleted, outcome.failed
-                );
-            }
-            tokio::time::sleep(SWEEP_INTERVAL).await;
-        }
-    });
-}
-
-/// How often the delivery queue is asked whether anything is due.
-///
-/// Ten seconds, because the queue's own `run_after` is what schedules a retry
-/// and this only decides how late the first attempt can be. A recording that
-/// waits ten seconds for its upload to begin is a recording nobody noticed
-/// waiting.
-pub(crate) const DELIVERY_INTERVAL: Duration = Duration::from_secs(10);
-
-/// The upload that a finished recording still owes.
-///
-/// Separate from the sweeper, because they answer different questions: the
-/// sweeper looks for rows nothing is moving, and this moves them. Running them
-/// on one timer would tie the pace of deliveries to the pace of a scan.
-///
-/// A deployment whose credentials do not build a delivery client gets a warning
-/// and no worker rather than a panic in a router constructor. The binary does
-/// not reach that case: `codetrial web` parses the key before it listens and
-/// refuses to start without one. It is reachable from
-/// this function, which is public and is what the tests build, and there the
-/// warning is the right answer.
-/// The delivery client, or a warning and none.
-///
-/// A `None` here is a deployment that records and never hands anything over,
-/// which the binary refuses to start in: `codetrial web` parses the key before
-/// it listens. It is reachable from the public router
-/// constructors, which is what the tests build, and there a warning is the
-/// right answer rather than a panic inside a constructor.
-pub(crate) fn delivery_provider(
-    recording: &crate::config::RecordingConfig,
-) -> Option<Arc<dyn crate::recording::DeliveryProvider>> {
-    match crate::delivery::GoogleDelivery::new(
-        &recording.service_account_json,
-        &recording.gcs_bucket,
-        &recording.drive_id,
-        Arc::new(|| crate::current_epoch_seconds() as i64),
-    ) {
-        Ok(delivery) => Some(Arc::new(delivery)),
-        Err(error) => {
-            eprintln!("WARNING: recordings cannot be delivered or deleted: {error}");
-            None
-        }
-    }
-}
-
-pub(crate) fn spawn_delivery_worker(accounts: Arc<Accounts>, recorder: crate::recording::Recorder) {
-    let Ok(handle) = tokio::runtime::Handle::try_current() else {
-        eprintln!("recording is configured but there is no runtime to deliver on");
-        return;
-    };
-    let Some(delivery) = recorder.delivery.clone() else {
-        return;
-    };
-    handle.spawn(async move {
-        loop {
-            let outcome = crate::recording::run_delivery_queue(
-                &accounts,
-                &recorder,
-                delivery.as_ref() as &dyn crate::recording::DeliveryProvider,
-            )
-            .await;
-            if outcome != crate::recording::DeliveryOutcome::default() {
-                eprintln!(
-                    "recording delivery delivered {} retrying {} failed {}",
-                    outcome.delivered, outcome.retrying, outcome.failed
-                );
-            }
-            tokio::time::sleep(DELIVERY_INTERVAL).await;
-        }
-    });
+/// Absent, negative or unparseable is the whole replay; a sequence number is
+/// everything past it. Both replay routes take it, so the sentinel is spelled
+/// once: a second spelling is a second thing to keep in step with `ReplayRead`,
+/// which is what actually decides.
+fn replay_after(params: &HashMap<String, String>) -> i64 {
+    params
+        .get("after")
+        .and_then(|after| after.parse::<i64>().ok())
+        .unwrap_or(-1)
 }
 
 /// Starts recording the room this interview claimed.
@@ -251,7 +173,7 @@ pub(crate) async fn start_recording_handler(
 /// because the row moves underneath it: `starting` becomes `recording` when the
 /// egress id lands, and a sweeper retry can have moved it first. Answering with
 /// the older copy told the browser a recording had not begun when it had.
-pub(crate) async fn recording_state_now(
+async fn recording_state_now(
     accounts: &Arc<Accounts>,
     recording: &crate::recording::Recording,
 ) -> Response {
@@ -278,14 +200,14 @@ pub(crate) async fn recording_state_now(
     }
 }
 
-pub(crate) fn recording_accepted(recording: &crate::recording::Recording) -> Response {
+fn recording_accepted(recording: &crate::recording::Recording) -> Response {
     json_response(
         StatusCode::ACCEPTED,
         json!({ "recordingId": recording.id, "state": recording.state.as_str() }),
     )
 }
 
-pub(crate) fn start_refusal_response(refusal: crate::recording::StartRefusal) -> Response {
+fn start_refusal_response(refusal: crate::recording::StartRefusal) -> Response {
     use crate::recording::StartRefusal;
     match refusal {
         StartRefusal::NoConsent => recording_requires_consent(),
@@ -581,10 +503,7 @@ pub(crate) async fn recording_events_handler(
         return refused;
     }
     let now = current_epoch_seconds() as i64;
-    let after = params
-        .get("after")
-        .and_then(|after| after.parse::<i64>().ok())
-        .unwrap_or(-1);
+    let after = replay_after(&params);
 
     // Exact, not truthy. An unknown value is the ordinary snapshot rather than
     // a guess at what the caller meant, so a typo reads one avatar row instead
@@ -656,10 +575,7 @@ fn recording_missing() -> Response {
 /// One function, because the two routes have to answer this the same way: a
 /// history page that listed a recording as watchable and a replay that answered
 /// `410` would be two answers to one question.
-pub(crate) fn gone_response(
-    summary: &crate::recording::RecordingSummary,
-    now: i64,
-) -> Option<Response> {
+fn gone_response(summary: &crate::recording::RecordingSummary, now: i64) -> Option<Response> {
     if summary.deleted_at.is_some() {
         return Some(json_response(
             StatusCode::GONE,
@@ -732,10 +648,7 @@ pub(crate) async fn recording_replay_handler(
         return refused();
     }
 
-    let after = params
-        .get("after")
-        .and_then(|after| after.parse::<i64>().ok())
-        .unwrap_or(-1);
+    let after = replay_after(&params);
     let found = {
         let accounts = accounts.clone();
         let room_name = room_name.clone();
@@ -777,410 +690,4 @@ pub(crate) async fn recording_replay_handler(
         },
         "could not read a replay for a room",
     )
-}
-
-/// LiveKit's webhooks.
-///
-/// Unauthenticated in the session sense and authenticated in every other: the
-/// signature covers the body, and nothing in it is trusted until that checks
-/// out. A refusal says nothing about which step failed, because telling a
-/// caller "wrong secret" apart from "wrong digest" hands them a probe.
-pub(crate) async fn recording_webhook_handler(
-    State(state): State<AppState>,
-    request: Request<Body>,
-) -> Response {
-    let Some(accounts) = state.accounts.clone() else {
-        return state.accounts_error();
-    };
-    let Some(recorder) = state.recorder.clone() else {
-        return StatusCode::NOT_FOUND.into_response();
-    };
-    let (parts, body) = request.into_parts();
-    let Ok(body) = to_bytes(body, MAX_WEBHOOK_BODY_BYTES).await else {
-        return StatusCode::PAYLOAD_TOO_LARGE.into_response();
-    };
-    let authorization = parts
-        .headers
-        .get(header::AUTHORIZATION)
-        .and_then(|value| value.to_str().ok())
-        .unwrap_or_default();
-
-    // The key names the project, and the project owns the secret. Reading it
-    // from the token rather than assuming the primary project is what lets a
-    // deployment with more than one LiveKit project verify a webhook from any
-    // of them; the signature check below is still what decides.
-    let Some((api_key, api_secret)) = webhook_credentials(&state, &recorder, authorization) else {
-        eprintln!("recording webhook refused: unknown_key");
-        return json_response(
-            StatusCode::UNAUTHORIZED,
-            json!({ "error": "webhook_signature_invalid" }),
-        );
-    };
-    if let Err(rejection) = crate::token::verify_livekit_webhook(
-        &api_key,
-        &api_secret,
-        authorization,
-        body.as_ref(),
-        recorder.clock.now().max(0) as u64,
-    ) {
-        eprintln!("recording webhook refused: {rejection}");
-        return json_response(
-            StatusCode::UNAUTHORIZED,
-            json!({ "error": "webhook_signature_invalid" }),
-        );
-    }
-
-    let Ok(event) = serde_json::from_slice::<Value>(body.as_ref()) else {
-        return json_response(
-            StatusCode::BAD_REQUEST,
-            json!({ "error": "webhook_body_invalid" }),
-        );
-    };
-    let Some(event_id) = event.get("id").and_then(Value::as_str).map(str::to_string) else {
-        return json_response(
-            StatusCode::BAD_REQUEST,
-            json!({ "error": "webhook_body_invalid" }),
-        );
-    };
-
-    // Claimed before anything is acted on. A retry is a fresh, validly signed
-    // message with the same id, and acting on it twice is how one recording
-    // gets stopped, transferred, or failed more than once.
-    //
-    // The ceiling: two identical deliveries arriving at once both find the
-    // claim unapplied and both apply it. That is deliberate, because the
-    // alternative is a lock held across a provider call, and every transition
-    // below is idempotent by the table, so the outcome is the same one twice.
-    let fresh = {
-        let accounts = accounts.clone();
-        let now = recorder.clock.now();
-        blocking(move || crate::recording::claim_webhook_event(&accounts, &event_id, now)).await
-    };
-    match fresh {
-        Ok(true) => {}
-
-        // A duplicate is a success. LiveKit retries anything it did not get a
-        // 2xx for, so answering anything else asks for it forever.
-        Ok(false) => return StatusCode::OK.into_response(),
-        Err(error) => {
-            eprintln!("could not record a webhook event: {error}");
-            return json_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                json!({ "error": "webhook_not_recorded" }),
-            );
-        }
-    }
-
-    if !apply_webhook(&state, &accounts, &recorder, &event, &api_key).await {
-        // Not marked applied, so LiveKit's retry gets another attempt at it.
-        // There is no compensating write here on purpose: the earlier version
-        // deleted the claim, and a delete that itself failed lost the event.
-        return json_response(
-            StatusCode::SERVICE_UNAVAILABLE,
-            json!({ "error": "webhook_not_applied" }),
-        );
-    }
-
-    let applied = {
-        let accounts = accounts.clone();
-        let event_id = event
-            .get("id")
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string();
-        let now = recorder.clock.now();
-        blocking(move || crate::recording::mark_webhook_applied(&accounts, &event_id, now)).await
-    };
-    if let Err(error) = applied {
-        // The work is done and the ledger does not know. A redelivery would
-        // repeat a transition that is idempotent by the table, so this is a
-        // line rather than a failure.
-        eprintln!("could not mark a webhook event applied: {error}");
-    }
-    StatusCode::OK.into_response()
-}
-
-/// The secret belonging to the key a webhook claims signed it.
-///
-/// `None` when no configured project holds that key, which is a refusal: a
-/// message signed by a project this server does not serve is not this server's
-/// message. Looking the key up rather than assuming the primary project is what
-/// makes a multi-project deployment work at all, since a room belongs to one
-/// project and the others' secrets verify nothing it signed.
-///
-/// There is deliberately no separate webhook secret. LiveKit signs with the
-/// project's own API key and secret, so a third value would be one an operator
-/// believed was checked.
-pub(crate) fn webhook_credentials(
-    state: &AppState,
-    recorder: &crate::recording::Recorder,
-    authorization: &str,
-) -> Option<(String, String)> {
-    let key = crate::token::livekit_token_issuer(authorization)?;
-    if let Some(livekit) = &recorder.config.livekit
-        && livekit.api_key == key
-    {
-        return Some((livekit.api_key.clone(), livekit.api_secret.clone()));
-    }
-    state
-        .config
-        .pool
-        .providers
-        .iter()
-        .find(|provider| provider.api_key == key)
-        .map(|provider| (provider.api_key.clone(), provider.api_secret.clone()))
-}
-
-/// Whether the project that signed a webhook is the one that owns this room.
-///
-/// The room name routes to a provider exactly as `/api/token` routed it, and
-/// the key that signed the message has to be that provider's. The recording
-/// override only substitutes a different key for the same project, so it is
-/// checked against the room's provider rather than instead of it.
-pub(crate) fn signed_by_the_rooms_project(
-    state: &AppState,
-    recorder: &crate::recording::Recorder,
-    room_name: Option<&str>,
-    signed_by: &str,
-) -> bool {
-    let Some(room_name) = room_name else {
-        // A tombstoned recording has given its room name up, and there is
-        // nothing left for a webhook to change.
-        return false;
-    };
-    let Some(provider) = state
-        .config
-        .pool
-        .for_room(room_name, &state.config.room_prefix)
-    else {
-        return false;
-    };
-
-    // Either key for that project. The override is a different key for the same
-    // project, not a different project, and LiveKit signs a webhook with
-    // whichever key the project's webhook configuration names, which is not
-    // necessarily the one this server makes Egress calls with.
-    if provider.api_key == signed_by {
-        return true;
-    }
-    recorder.config.livekit.as_ref().is_some_and(|livekit| {
-        livekit.api_key == signed_by
-            && crate::config::same_livekit_project(&livekit.url, &provider.url)
-    })
-}
-
-/// Whether the event was dealt with.
-///
-/// `false` asks the caller to give the claim back so LiveKit delivers it again.
-/// The case that matters is an egress event arriving before this server has
-/// written down the egress id it names: dropping it there would lose the only
-/// notice that a recording started, ended, or failed.
-pub(crate) async fn apply_webhook(
-    state: &AppState,
-    accounts: &Arc<Accounts>,
-    recorder: &crate::recording::Recorder,
-    event: &Value,
-    signed_by: &str,
-) -> bool {
-    use crate::recording::RecordingState;
-    let kind = event
-        .get("event")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-
-    // lowerCamelCase, unlike the Twirp call that started this: upstream
-    // marshals the webhook with protojson directly. The contract document is
-    // where that asymmetry is explained.
-    let egress_id = event
-        .pointer("/egressInfo/egressId")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    let status = event
-        .pointer("/egressInfo/status")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-
-    let found = match kind {
-        "room_finished" => {
-            let room = event
-                .pointer("/room/name")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_string();
-            let accounts = accounts.clone();
-            blocking(move || crate::recording::recording_for_room(&accounts, &room)).await
-        }
-        "egress_started" | "egress_updated" | "egress_ended" => {
-            let Some(egress_id) = egress_id else {
-                return true;
-            };
-            let accounts = accounts.clone();
-            blocking(move || crate::recording::recording_for_egress(&accounts, &egress_id)).await
-        }
-
-        // Acknowledged and dropped. Answering anything else asks LiveKit to
-        // keep sending events this pipeline has no opinion about.
-        _ => return true,
-    };
-    let recording = match found {
-        Ok(Some(recording)) => recording,
-
-        // No recording for this event. For a room that is not this server's,
-        // that is the end of it; for an egress event it usually means the start
-        // response has not been written down yet, and this is the only notice
-        // that job will ever get.
-        Ok(None) => return kind == "room_finished",
-        Err(error) => {
-            eprintln!("could not read a recording for a webhook: {error}");
-            return false;
-        }
-    };
-
-    // A valid signature proves which project sent this, not which project owns
-    // the room it names. Without this, any configured project could end another
-    // project's recording by naming its room.
-    if !signed_by_the_rooms_project(state, recorder, recording.room_name.as_deref(), signed_by) {
-        eprintln!(
-            "recording {} was named by a webhook from another project",
-            recording.id
-        );
-        return true;
-    }
-
-    match kind {
-        "room_finished" => finish_recording(state, accounts, recorder, &recording, None)
-            .await
-            .status()
-            .is_success(),
-        "egress_started" => {
-            let accounts = accounts.clone();
-            let clock = recorder.clock.clone();
-            let id = recording.id.clone();
-            blocking(move || {
-                crate::recording::transition(
-                    &accounts,
-                    clock.as_ref(),
-                    &id,
-                    RecordingState::Recording,
-                    None,
-                )
-            })
-            .await
-            .is_ok()
-        }
-        "egress_ended" | "egress_updated" => {
-            apply_egress_status(accounts, recorder, &recording, event, status).await
-        }
-        _ => true,
-    }
-}
-
-/// What the provider's own word for how a job ended means for the row.
-///
-/// `None` is an update that says nothing new. `EGRESS_ACTIVE` and
-/// `EGRESS_STARTING` in particular do not say the job has stopped, and marking
-/// it stopped here would tell the orphan sweep to stop watching a job that is
-/// still running.
-pub(crate) fn egress_outcome(
-    status: &str,
-    event: &Value,
-    expected_object: &str,
-) -> Option<(
-    crate::recording::RecordingState,
-    Option<crate::recording::Failure>,
-)> {
-    use crate::recording::{Failure, RecordingState};
-    let outcome = match status {
-        // A completion with nothing in it is not a completion. A missing file
-        // result, or one of no bytes, is how a truncated recording arrives, and
-        // sending it through the transfer shared a zero-byte video with a
-        // candidate.
-        "EGRESS_COMPLETE" if crate::recording::completed_with_output(event, expected_object) => {
-            (RecordingState::Transferring, None)
-        }
-        "EGRESS_COMPLETE" => (RecordingState::Failed, Some(Failure::PartialOutput)),
-        "EGRESS_FAILED" => (RecordingState::Failed, Some(Failure::Egress)),
-        "EGRESS_ABORTED" => (RecordingState::Failed, Some(Failure::Aborted)),
-        "EGRESS_LIMIT_REACHED" => (RecordingState::Failed, Some(Failure::LimitReached)),
-        _ => return None,
-    };
-    Some(outcome)
-}
-
-/// Applies one `egress_ended` or `egress_updated` to the row it names.
-pub(crate) async fn apply_egress_status(
-    accounts: &Arc<Accounts>,
-    recorder: &crate::recording::Recorder,
-    recording: &crate::recording::Recording,
-    event: &Value,
-    status: &str,
-) -> bool {
-    use crate::recording::RecordingState;
-
-    // The object this recording is going to transfer, not any file the job
-    // happened to write.
-    let expected_object =
-        crate::recording::gcs_object_path(&recorder.config.gcs_prefix, &recording.id);
-    let Some((next, failure)) = egress_outcome(status, event, &expected_object) else {
-        return true;
-    };
-
-    // Terminal, whichever way it ended, so the row stops being one the sweeper
-    // has to chase. A failure here fails the whole application, because the
-    // alternative is a terminal row that looks stopped and a job that is not.
-    let stopped = {
-        let accounts = accounts.clone();
-        let clock = recorder.clock.clone();
-        let id = recording.id.clone();
-        blocking(move || crate::recording::mark_stopped(&accounts, clock.as_ref(), &id)).await
-    };
-    if stopped.is_err() {
-        return false;
-    }
-    let moved = {
-        let accounts = accounts.clone();
-        let clock = recorder.clock.clone();
-        let id = recording.id.clone();
-        let reason = failure.map(|failure| failure.as_str().to_string());
-        blocking(move || {
-            crate::recording::transition(&accounts, clock.as_ref(), &id, next, reason.as_deref())
-        })
-        .await
-    };
-
-    // Queued only when this call moved the row, and after the move rather than
-    // before it. A webhook LiveKit sent twice must not become two deliveries,
-    // and the queue's own `ON CONFLICT` is the second half of that rather than
-    // the first.
-    if next == RecordingState::Transferring
-        && let Ok(Some((_, true))) = &moved
-    {
-        let accounts = accounts.clone();
-        let id = recording.id.clone();
-        let now = recorder.clock.now();
-        if let Err(error) =
-            blocking(move || crate::recording::enqueue_delivery(&accounts, &id, now)).await
-        {
-            // Not fatal to the webhook: the row is `transferring` and the
-            // sweeper will not lose it. It does mean nobody has queued the
-            // delivery, which is worth a line.
-            eprintln!("WARNING: could not queue a delivery: {error}");
-        }
-    }
-
-    // After the transition, and only when it moved. A late `EGRESS_FAILED` for
-    // a row that has already advanced is refused by the table, and an audit
-    // line written first said a recording had failed while its status said
-    // otherwise.
-    if let (Some(failure), Ok(Some((_, true)))) = (failure, &moved) {
-        crate::recording::audit(
-            "recording_failed",
-            &recording.id,
-            &[
-                ("reason", failure.as_str()),
-                ("recovery", failure.recovery()),
-            ],
-        );
-    }
-    moved.is_ok()
 }

--- a/src/web/recordings/mod.rs
+++ b/src/web/recordings/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use webhook::recording_webhook_handler;
 // Not re-exported: the replay route below is the only caller outside `webhook`,
 // so these stay visible to this module and no wider.
 use webhook::{signed_by_the_rooms_project, webhook_credentials};
-pub(crate) use workers::{delivery_provider, spawn_delivery_worker, spawn_recording_sweeper};
+pub(crate) use workers::{RecordingWorkers, delivery_provider, spawn_recording_workers};
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/web/recordings/webhook.rs
+++ b/src/web/recordings/webhook.rs
@@ -1,0 +1,430 @@
+//! LiveKit's webhook, and what one is allowed to change.
+//!
+//! The only entry point in `recordings` a browser never reaches. It answers
+//! LiveKit rather than a candidate, so it authenticates on a signature instead
+//! of a session, and everything below the handler exists to bound what a
+//! verified caller may then touch: `signed_by_the_rooms_project` ties the key
+//! that signed to the project owning the room, so a webhook authenticated for
+//! one project cannot act on another's recording.
+//!
+//! Split out of `recordings.rs` for that reason rather than for its size. A
+//! trust boundary is easier to review as a file than as the last third of one.
+
+use std::sync::Arc;
+
+use axum::body::{Body, to_bytes};
+use axum::extract::State;
+use axum::http::{Request, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use serde_json::{Value, json};
+
+use crate::accounts::{Accounts, blocking};
+
+use super::super::{AppState, MAX_WEBHOOK_BODY_BYTES, json_response};
+use super::finish_recording;
+
+/// LiveKit's webhooks.
+///
+/// Unauthenticated in the session sense and authenticated in every other: the
+/// signature covers the body, and nothing in it is trusted until that checks
+/// out. A refusal says nothing about which step failed, because telling a
+/// caller "wrong secret" apart from "wrong digest" hands them a probe.
+pub(crate) async fn recording_webhook_handler(
+    State(state): State<AppState>,
+    request: Request<Body>,
+) -> Response {
+    let Some(accounts) = state.accounts.clone() else {
+        return state.accounts_error();
+    };
+    let Some(recorder) = state.recorder.clone() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let (parts, body) = request.into_parts();
+    let Ok(body) = to_bytes(body, MAX_WEBHOOK_BODY_BYTES).await else {
+        return StatusCode::PAYLOAD_TOO_LARGE.into_response();
+    };
+    let authorization = parts
+        .headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+
+    // The key names the project, and the project owns the secret. Reading it
+    // from the token rather than assuming the primary project is what lets a
+    // deployment with more than one LiveKit project verify a webhook from any
+    // of them; the signature check below is still what decides.
+    let Some((api_key, api_secret)) = webhook_credentials(&state, &recorder, authorization) else {
+        eprintln!("recording webhook refused: unknown_key");
+        return json_response(
+            StatusCode::UNAUTHORIZED,
+            json!({ "error": "webhook_signature_invalid" }),
+        );
+    };
+    if let Err(rejection) = crate::token::verify_livekit_webhook(
+        &api_key,
+        &api_secret,
+        authorization,
+        body.as_ref(),
+        recorder.clock.now().max(0) as u64,
+    ) {
+        eprintln!("recording webhook refused: {rejection}");
+        return json_response(
+            StatusCode::UNAUTHORIZED,
+            json!({ "error": "webhook_signature_invalid" }),
+        );
+    }
+
+    let Ok(event) = serde_json::from_slice::<Value>(body.as_ref()) else {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            json!({ "error": "webhook_body_invalid" }),
+        );
+    };
+    let Some(event_id) = event.get("id").and_then(Value::as_str).map(str::to_string) else {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            json!({ "error": "webhook_body_invalid" }),
+        );
+    };
+
+    // Claimed before anything is acted on. A retry is a fresh, validly signed
+    // message with the same id, and acting on it twice is how one recording
+    // gets stopped, transferred, or failed more than once.
+    //
+    // The ceiling: two identical deliveries arriving at once both find the
+    // claim unapplied and both apply it. That is deliberate, because the
+    // alternative is a lock held across a provider call, and every transition
+    // below is idempotent by the table, so the outcome is the same one twice.
+    let fresh = {
+        let accounts = accounts.clone();
+        let now = recorder.clock.now();
+        blocking(move || crate::recording::claim_webhook_event(&accounts, &event_id, now)).await
+    };
+    match fresh {
+        Ok(true) => {}
+
+        // A duplicate is a success. LiveKit retries anything it did not get a
+        // 2xx for, so answering anything else asks for it forever.
+        Ok(false) => return StatusCode::OK.into_response(),
+        Err(error) => {
+            eprintln!("could not record a webhook event: {error}");
+            return json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                json!({ "error": "webhook_not_recorded" }),
+            );
+        }
+    }
+
+    if !apply_webhook(&state, &accounts, &recorder, &event, &api_key).await {
+        // Not marked applied, so LiveKit's retry gets another attempt at it.
+        // There is no compensating write here on purpose: the earlier version
+        // deleted the claim, and a delete that itself failed lost the event.
+        return json_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            json!({ "error": "webhook_not_applied" }),
+        );
+    }
+
+    let applied = {
+        let accounts = accounts.clone();
+        let event_id = event
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let now = recorder.clock.now();
+        blocking(move || crate::recording::mark_webhook_applied(&accounts, &event_id, now)).await
+    };
+    if let Err(error) = applied {
+        // The work is done and the ledger does not know. A redelivery would
+        // repeat a transition that is idempotent by the table, so this is a
+        // line rather than a failure.
+        eprintln!("could not mark a webhook event applied: {error}");
+    }
+    StatusCode::OK.into_response()
+}
+
+/// The secret belonging to the key a webhook claims signed it.
+///
+/// `None` when no configured project holds that key, which is a refusal: a
+/// message signed by a project this server does not serve is not this server's
+/// message. Looking the key up rather than assuming the primary project is what
+/// makes a multi-project deployment work at all, since a room belongs to one
+/// project and the others' secrets verify nothing it signed.
+///
+/// There is deliberately no separate webhook secret. LiveKit signs with the
+/// project's own API key and secret, so a third value would be one an operator
+/// believed was checked.
+pub(super) fn webhook_credentials(
+    state: &AppState,
+    recorder: &crate::recording::Recorder,
+    authorization: &str,
+) -> Option<(String, String)> {
+    let key = crate::token::livekit_token_issuer(authorization)?;
+    if let Some(livekit) = &recorder.config.livekit
+        && livekit.api_key == key
+    {
+        return Some((livekit.api_key.clone(), livekit.api_secret.clone()));
+    }
+    state
+        .config
+        .pool
+        .providers
+        .iter()
+        .find(|provider| provider.api_key == key)
+        .map(|provider| (provider.api_key.clone(), provider.api_secret.clone()))
+}
+
+/// Whether the project that signed a webhook is the one that owns this room.
+///
+/// The room name routes to a provider exactly as `/api/token` routed it, and
+/// the key that signed the message has to be that provider's. The recording
+/// override only substitutes a different key for the same project, so it is
+/// checked against the room's provider rather than instead of it.
+pub(super) fn signed_by_the_rooms_project(
+    state: &AppState,
+    recorder: &crate::recording::Recorder,
+    room_name: Option<&str>,
+    signed_by: &str,
+) -> bool {
+    let Some(room_name) = room_name else {
+        // A tombstoned recording has given its room name up, and there is
+        // nothing left for a webhook to change.
+        return false;
+    };
+    let Some(provider) = state
+        .config
+        .pool
+        .for_room(room_name, &state.config.room_prefix)
+    else {
+        return false;
+    };
+
+    // Either key for that project. The override is a different key for the same
+    // project, not a different project, and LiveKit signs a webhook with
+    // whichever key the project's webhook configuration names, which is not
+    // necessarily the one this server makes Egress calls with.
+    if provider.api_key == signed_by {
+        return true;
+    }
+    recorder.config.livekit.as_ref().is_some_and(|livekit| {
+        livekit.api_key == signed_by
+            && crate::config::same_livekit_project(&livekit.url, &provider.url)
+    })
+}
+
+/// Whether the event was dealt with.
+///
+/// `false` asks the caller to give the claim back so LiveKit delivers it again.
+/// The case that matters is an egress event arriving before this server has
+/// written down the egress id it names: dropping it there would lose the only
+/// notice that a recording started, ended, or failed.
+async fn apply_webhook(
+    state: &AppState,
+    accounts: &Arc<Accounts>,
+    recorder: &crate::recording::Recorder,
+    event: &Value,
+    signed_by: &str,
+) -> bool {
+    use crate::recording::RecordingState;
+    let kind = event
+        .get("event")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    // lowerCamelCase, unlike the Twirp call that started this: upstream
+    // marshals the webhook with protojson directly. The contract document is
+    // where that asymmetry is explained.
+    let egress_id = event
+        .pointer("/egressInfo/egressId")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let status = event
+        .pointer("/egressInfo/status")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    let found = match kind {
+        "room_finished" => {
+            let room = event
+                .pointer("/room/name")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let accounts = accounts.clone();
+            blocking(move || crate::recording::recording_for_room(&accounts, &room)).await
+        }
+        "egress_started" | "egress_updated" | "egress_ended" => {
+            let Some(egress_id) = egress_id else {
+                return true;
+            };
+            let accounts = accounts.clone();
+            blocking(move || crate::recording::recording_for_egress(&accounts, &egress_id)).await
+        }
+
+        // Acknowledged and dropped. Answering anything else asks LiveKit to
+        // keep sending events this pipeline has no opinion about.
+        _ => return true,
+    };
+    let recording = match found {
+        Ok(Some(recording)) => recording,
+
+        // No recording for this event. For a room that is not this server's,
+        // that is the end of it; for an egress event it usually means the start
+        // response has not been written down yet, and this is the only notice
+        // that job will ever get.
+        Ok(None) => return kind == "room_finished",
+        Err(error) => {
+            eprintln!("could not read a recording for a webhook: {error}");
+            return false;
+        }
+    };
+
+    // A valid signature proves which project sent this, not which project owns
+    // the room it names. Without this, any configured project could end another
+    // project's recording by naming its room.
+    if !signed_by_the_rooms_project(state, recorder, recording.room_name.as_deref(), signed_by) {
+        eprintln!(
+            "recording {} was named by a webhook from another project",
+            recording.id
+        );
+        return true;
+    }
+
+    match kind {
+        "room_finished" => finish_recording(state, accounts, recorder, &recording, None)
+            .await
+            .status()
+            .is_success(),
+        "egress_started" => {
+            let accounts = accounts.clone();
+            let clock = recorder.clock.clone();
+            let id = recording.id.clone();
+            blocking(move || {
+                crate::recording::transition(
+                    &accounts,
+                    clock.as_ref(),
+                    &id,
+                    RecordingState::Recording,
+                    None,
+                )
+            })
+            .await
+            .is_ok()
+        }
+        "egress_ended" | "egress_updated" => {
+            apply_egress_status(accounts, recorder, &recording, event, status).await
+        }
+        _ => true,
+    }
+}
+
+/// What the provider's own word for how a job ended means for the row.
+///
+/// `None` is an update that says nothing new. `EGRESS_ACTIVE` and
+/// `EGRESS_STARTING` in particular do not say the job has stopped, and marking
+/// it stopped here would tell the orphan sweep to stop watching a job that is
+/// still running.
+fn egress_outcome(
+    status: &str,
+    event: &Value,
+    expected_object: &str,
+) -> Option<(
+    crate::recording::RecordingState,
+    Option<crate::recording::Failure>,
+)> {
+    use crate::recording::{Failure, RecordingState};
+    let outcome = match status {
+        // A completion with nothing in it is not a completion. A missing file
+        // result, or one of no bytes, is how a truncated recording arrives, and
+        // sending it through the transfer shared a zero-byte video with a
+        // candidate.
+        "EGRESS_COMPLETE" if crate::recording::completed_with_output(event, expected_object) => {
+            (RecordingState::Transferring, None)
+        }
+        "EGRESS_COMPLETE" => (RecordingState::Failed, Some(Failure::PartialOutput)),
+        "EGRESS_FAILED" => (RecordingState::Failed, Some(Failure::Egress)),
+        "EGRESS_ABORTED" => (RecordingState::Failed, Some(Failure::Aborted)),
+        "EGRESS_LIMIT_REACHED" => (RecordingState::Failed, Some(Failure::LimitReached)),
+        _ => return None,
+    };
+    Some(outcome)
+}
+
+/// Applies one `egress_ended` or `egress_updated` to the row it names.
+async fn apply_egress_status(
+    accounts: &Arc<Accounts>,
+    recorder: &crate::recording::Recorder,
+    recording: &crate::recording::Recording,
+    event: &Value,
+    status: &str,
+) -> bool {
+    use crate::recording::RecordingState;
+
+    // The object this recording is going to transfer, not any file the job
+    // happened to write.
+    let expected_object =
+        crate::recording::gcs_object_path(&recorder.config.gcs_prefix, &recording.id);
+    let Some((next, failure)) = egress_outcome(status, event, &expected_object) else {
+        return true;
+    };
+
+    // Terminal, whichever way it ended, so the row stops being one the sweeper
+    // has to chase. A failure here fails the whole application, because the
+    // alternative is a terminal row that looks stopped and a job that is not.
+    let stopped = {
+        let accounts = accounts.clone();
+        let clock = recorder.clock.clone();
+        let id = recording.id.clone();
+        blocking(move || crate::recording::mark_stopped(&accounts, clock.as_ref(), &id)).await
+    };
+    if stopped.is_err() {
+        return false;
+    }
+    let moved = {
+        let accounts = accounts.clone();
+        let clock = recorder.clock.clone();
+        let id = recording.id.clone();
+        let reason = failure.map(|failure| failure.as_str().to_string());
+        blocking(move || {
+            crate::recording::transition(&accounts, clock.as_ref(), &id, next, reason.as_deref())
+        })
+        .await
+    };
+
+    // Queued only when this call moved the row, and after the move rather than
+    // before it. A webhook LiveKit sent twice must not become two deliveries,
+    // and the queue's own `ON CONFLICT` is the second half of that rather than
+    // the first.
+    if next == RecordingState::Transferring
+        && let Ok(Some((_, true))) = &moved
+    {
+        let accounts = accounts.clone();
+        let id = recording.id.clone();
+        let now = recorder.clock.now();
+        if let Err(error) =
+            blocking(move || crate::recording::enqueue_delivery(&accounts, &id, now)).await
+        {
+            // Not fatal to the webhook: the row is `transferring` and the
+            // sweeper will not lose it. It does mean nobody has queued the
+            // delivery, which is worth a line.
+            eprintln!("WARNING: could not queue a delivery: {error}");
+        }
+    }
+
+    // After the transition, and only when it moved. A late `EGRESS_FAILED` for
+    // a row that has already advanced is refused by the table, and an audit
+    // line written first said a recording had failed while its status said
+    // otherwise.
+    if let (Some(failure), Ok(Some((_, true)))) = (failure, &moved) {
+        crate::recording::audit(
+            "recording_failed",
+            &recording.id,
+            &[
+                ("reason", failure.as_str()),
+                ("recovery", failure.recovery()),
+            ],
+        );
+    }
+    moved.is_ok()
+}

--- a/src/web/recordings/webhook.rs
+++ b/src/web/recordings/webhook.rs
@@ -447,3 +447,50 @@ async fn apply_egress_status(
     }
     moved.is_ok()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recording::{Failure, RecordingState};
+
+    /// Which provider word means which failure, pinned one arm at a time.
+    ///
+    /// Every arm here reaches the candidate: `Failure` carries the recovery the
+    /// status route prints, so mapping an aborted job to the allowance failure
+    /// tells somebody to wait for a quota that was never the problem. Deleting
+    /// any one arm sends its status to the catch-all instead, where the row is
+    /// left active and the sweeper fails it a minute later for the wrong
+    /// reason, and nothing was checking that.
+    #[test]
+    fn a_provider_status_maps_to_its_own_failure() {
+        let object = "codetrial/rec-1.mp4";
+        let complete = serde_json::json!({
+            "egressInfo": { "fileResults": [{ "filename": object, "size": "1024" }] }
+        });
+        let empty = serde_json::json!({ "egressInfo": { "fileResults": [] } });
+
+        assert_eq!(
+            egress_outcome("EGRESS_COMPLETE", &complete, object),
+            Some((RecordingState::Transferring, None)),
+            "a completion carrying the expected object is the only way to transfer"
+        );
+        for (status, failure) in [
+            ("EGRESS_COMPLETE", Failure::PartialOutput),
+            ("EGRESS_FAILED", Failure::Egress),
+            ("EGRESS_ABORTED", Failure::Aborted),
+            ("EGRESS_LIMIT_REACHED", Failure::LimitReached),
+        ] {
+            assert_eq!(
+                egress_outcome(status, &empty, object),
+                Some((RecordingState::Failed, Some(failure))),
+                "{status}"
+            );
+        }
+
+        // Still running, and saying so must not mark the row stopped: the
+        // orphan sweep would stop watching a job that has not finished.
+        for status in ["EGRESS_ACTIVE", "EGRESS_STARTING", "EGRESS_ENDING", ""] {
+            assert_eq!(egress_outcome(status, &empty, object), None, "{status}");
+        }
+    }
+}

--- a/src/web/recordings/webhook.rs
+++ b/src/web/recordings/webhook.rs
@@ -381,13 +381,32 @@ async fn apply_egress_status(
     if stopped.is_err() {
         return false;
     }
+
+    // Only while the provider still owns the row. Its news can arrive late and
+    // out of order, and `transferring` to `failed` is a move the table has to
+    // allow for the delivery worker, so an `EGRESS_FAILED` retried after a
+    // completed egress could fail a recording whose file was already queued and
+    // whole. Once the transfer side has the row, the provider has nothing left
+    // to say about it.
+    const PROVIDER_OWNED: [RecordingState; 3] = [
+        RecordingState::Starting,
+        RecordingState::Recording,
+        RecordingState::Finalizing,
+    ];
     let moved = {
         let accounts = accounts.clone();
         let clock = recorder.clock.clone();
         let id = recording.id.clone();
         let reason = failure.map(|failure| failure.as_str().to_string());
         blocking(move || {
-            crate::recording::transition(&accounts, clock.as_ref(), &id, next, reason.as_deref())
+            crate::recording::transition_within(
+                &accounts,
+                clock.as_ref(),
+                &id,
+                Some(&PROVIDER_OWNED),
+                next,
+                reason.as_deref(),
+            )
         })
         .await
     };
@@ -413,8 +432,8 @@ async fn apply_egress_status(
     }
 
     // After the transition, and only when it moved. A late `EGRESS_FAILED` for
-    // a row that has already advanced is refused by the table, and an audit
-    // line written first said a recording had failed while its status said
+    // a row that has already advanced is refused above, and an audit line
+    // written first said a recording had failed while its status said
     // otherwise.
     if let (Some(failure), Ok(Some((_, true)))) = (failure, &moved) {
         crate::recording::audit(

--- a/src/web/recordings/workers.rs
+++ b/src/web/recordings/workers.rs
@@ -153,6 +153,48 @@ pub(crate) fn delivery_provider(
 mod tests {
     use super::*;
 
+    /// A throwaway RSA key, generated for this test and used nowhere else. The
+    /// delivery client parses the key material at construction, so asserting
+    /// that a configured deployment gets a client needs one that parses.
+    const TEST_ONLY_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDoSml5zRLkE3B9\nK2p8uBW7Xeccy5KN5xOcCBIJ914tq32oMvPmgmOsI0EqbswJe05Csknu6XtDEWv3\na6dvFgYxnE8EvHmtWJedpJC2HbkWaHrNmh6rk6A9/D/AGGUijL6bZoWwuM3neNF7\ng4V+3YS5itPa+iAEeCH6ng+78bNNGaxZ4NxyqHqBa0yTFxKEpJNJt1r6fDl5LBBu\ngPwbG4VCHhG10uqN4ZNiMb/YjODT0nBGYz9ffR0FEooLpj9hU8olBeVekG2/RlNO\nWkahsuo6nWTWPBWo3Omi+t6ig0Eeic5ExEU1J0jSdAEByjzMMXOVbGle3EjzaNE7\nZy2kZD2zAgMBAAECggEAAZc8F8kgjAbQTJtsPplIwv2UnigBQ30OpDvIXxIDaQaM\n/g+a/Hr9y9HY3TSUaDdNrU1/Z7KRI8+QPa7ksyuPRCQhOaE39D2G5mJHbB+27rOv\njf4pAnyP8DDxKaEMXgLV27+0g7oc5QtDA7ZUuX8g0u1NVgrhPJ69Jhg4w/6Ews5c\nBKvztBawn7hh3WNpqD6TLm4+FXVQi/rvW0hD20nTsb9yM1+18m78YmF6ObPm6pdu\nq7/pp4QZ6nm4VS2zEdTuw+oWmvwRc0F10JCsmVc5noVm/q9oqc6gVYUX2oj7CR2T\nnKDhocF7xnUFJJKKJcP48CerIg16h44i8sGcl/GZsQKBgQD90JHwTa+zon41/jO9\n+najINdtH78C9cBWctnMtEjDyd11lSOdxD18uHIjHpgF+WWstwyT60w2ECAvTOhe\n+ANQeI+WKE3tIiq3QQHlChc0UH5KZan0G5QPq6pQWr9Pj5+7uNe8eMKTEQf+mCEt\ntv5aUc4gQVBdtWR5qFvUxtdEnwKBgQDqSmaqUKNkAerNmd0ChHuuGZzExrAZ0Kum\nQ+tnamLbXs3wR4rmxhEUOO2PGqbd/n3Q+cK+1UdSXRZhDq32xjflzo9AK3ffPuH1\newYPTkwHBChTXrAp3ViFn5l20NOE7VTu2DdrHKUz4MpnYEE3LVQFUUg7H+EqwfM5\nGqP3DNA6bQKBgQC1o+7dD2ufXbl/AGWdHsKKabVh5ec3whGcjGLsCVVNsIhpXor3\nm/n46LLeCUX4eIvX98Prk+edhRrTXvGpDUqp6y2u4zcpblstfDtT403J5ZULvwfK\np3XlZQ/ko5zn3jwNBvJ1ceKlhvm2rL6JzbznfEXMdZGDDo5SNjdJ5ecmtwKBgBc6\n3UcRy8GEtyU/ljxDqoeunm6cTKWinQJVRafxUm/xzHWAgnMzPEpHArbnq5fjPdJU\nkUyelP3DoQ5qiDEpoi0099si9DW8ZGcUlZs65irj7KOnhcwA2GAXXP384pwRdBRi\nd8w1AORN64OodY7k/amxT3odRRQaOuV0kMFUEelZAoGAZX6IVBljoQHlrMURpamm\nfD19TtC1Ggdl5k1raWY4dBIZv+mgETBhb9etYp8VHYinBV7SeKGt6KrU4eZDTe3h\nJMlxhF00N0zksKn37lWNJ3ayeBsiDoVHfsfIU9OpkT4j9it8J/W3WUAFqG3Lc8lv\nOgA+s0vjN/n+Kc5h8HNZONs=\n-----END PRIVATE KEY-----";
+
+    /// A deployment with credentials gets a delivery client, and one without
+    /// gets a warning.
+    ///
+    /// The `None` is a real state: the recording still runs and the sweeper
+    /// still resolves rows, but nothing delivers or deletes. That is worth a
+    /// warning and not a panic inside a router constructor, and both halves
+    /// were decided here with nothing asserting either.
+    #[test]
+    fn a_delivery_client_is_built_only_when_the_credentials_are_there() {
+        let mut recording = crate::config::RecordingConfig {
+            livekit: None,
+            gcs_bucket: "codetrial-staging".to_string(),
+            gcs_prefix: "codetrial".to_string(),
+            drive_id: "0AKfixtureDriveId".to_string(),
+            service_account_json: serde_json::json!({
+                "type": "service_account",
+                "client_email": "codetrial@example.iam.gserviceaccount.com",
+                "private_key": TEST_ONLY_PRIVATE_KEY,
+            })
+            .to_string(),
+            max_minutes: 45,
+            bitrate: 2000,
+            kill_switch: false,
+            template_base_url: "https://recording.codetrial.example".to_string(),
+        };
+        assert!(
+            delivery_provider(&recording).is_some(),
+            "a service account with an address and a key builds a client"
+        );
+
+        recording.service_account_json = "{}".to_string();
+        assert!(
+            delivery_provider(&recording).is_none(),
+            "a service account naming nobody delivers nothing"
+        );
+    }
+
     /// A pass that did nothing says nothing, and a pass that did says what.
     ///
     /// Both loops run on a timer against whatever the database holds, so the

--- a/src/web/recordings/workers.rs
+++ b/src/web/recordings/workers.rs
@@ -1,0 +1,122 @@
+//! The background halves of recording, which no request drives.
+//!
+//! A sweeper that retries and expires, and a delivery worker that moves a
+//! finished artifact to its destination. Named apart from the rest of
+//! `recordings` because nothing here answers a caller: these run on a timer
+//! against whatever the database holds, and their failures are logged rather
+//! than returned.
+//!
+//! Split out of `recordings.rs` along the line its module doc already drew.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::accounts::Accounts;
+
+/// How often the sweeper runs. The shortest retry backoff, because a schedule
+/// checked less often than its own first step is a schedule with a different
+/// first step.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Resolves recordings nobody is looking after, now and then repeatedly.
+///
+/// Now, because a process that died mid-interview left rows no request will
+/// ever touch again. Repeatedly, because the retry schedule is minutes long and
+/// a sweep that only ran at startup would turn every provider hiccup into a
+/// failed recording.
+///
+/// Silent when there is no runtime to spawn on. `web_router` is public and can
+/// be built outside one; a router that serves without a sweeper is degraded,
+/// and a panic at construction is worse.
+pub(crate) fn spawn_recording_sweeper(
+    accounts: Arc<Accounts>,
+    recorder: crate::recording::Recorder,
+) {
+    let Ok(handle) = tokio::runtime::Handle::try_current() else {
+        eprintln!("recording is configured but there is no runtime to sweep on");
+        return;
+    };
+    handle.spawn(async move {
+        loop {
+            let outcome = crate::recording::sweep_recordings(&accounts, &recorder).await;
+            if outcome != crate::recording::SweepOutcome::default() {
+                eprintln!(
+                    "recording sweep retried {} deleted {} failed {}",
+                    outcome.retried, outcome.deleted, outcome.failed
+                );
+            }
+            tokio::time::sleep(SWEEP_INTERVAL).await;
+        }
+    });
+}
+
+/// How often the delivery queue is asked whether anything is due.
+///
+/// Ten seconds, because the queue's own `run_after` is what schedules a retry
+/// and this only decides how late the first attempt can be. A recording that
+/// waits ten seconds for its upload to begin is a recording nobody noticed
+/// waiting.
+const DELIVERY_INTERVAL: Duration = Duration::from_secs(10);
+
+/// The upload that a finished recording still owes.
+///
+/// Separate from the sweeper, because they answer different questions: the
+/// sweeper looks for rows nothing is moving, and this moves them. Running them
+/// on one timer would tie the pace of deliveries to the pace of a scan.
+///
+/// A deployment whose credentials do not build a delivery client gets a warning
+/// and no worker rather than a panic in a router constructor. The binary does
+/// not reach that case: `codetrial web` parses the key before it listens and
+/// refuses to start without one. It is reachable from
+/// this function, which is public and is what the tests build, and there the
+/// warning is the right answer.
+/// The delivery client, or a warning and none.
+///
+/// A `None` here is a deployment that records and never hands anything over,
+/// which the binary refuses to start in: `codetrial web` parses the key before
+/// it listens. It is reachable from the public router
+/// constructors, which is what the tests build, and there a warning is the
+/// right answer rather than a panic inside a constructor.
+pub(crate) fn delivery_provider(
+    recording: &crate::config::RecordingConfig,
+) -> Option<Arc<dyn crate::recording::DeliveryProvider>> {
+    match crate::delivery::GoogleDelivery::new(
+        &recording.service_account_json,
+        &recording.gcs_bucket,
+        &recording.drive_id,
+        Arc::new(|| crate::current_epoch_seconds() as i64),
+    ) {
+        Ok(delivery) => Some(Arc::new(delivery)),
+        Err(error) => {
+            eprintln!("WARNING: recordings cannot be delivered or deleted: {error}");
+            None
+        }
+    }
+}
+
+pub(crate) fn spawn_delivery_worker(accounts: Arc<Accounts>, recorder: crate::recording::Recorder) {
+    let Ok(handle) = tokio::runtime::Handle::try_current() else {
+        eprintln!("recording is configured but there is no runtime to deliver on");
+        return;
+    };
+    let Some(delivery) = recorder.delivery.clone() else {
+        return;
+    };
+    handle.spawn(async move {
+        loop {
+            let outcome = crate::recording::run_delivery_queue(
+                &accounts,
+                &recorder,
+                delivery.as_ref() as &dyn crate::recording::DeliveryProvider,
+            )
+            .await;
+            if outcome != crate::recording::DeliveryOutcome::default() {
+                eprintln!(
+                    "recording delivery delivered {} retrying {} failed {}",
+                    outcome.delivered, outcome.retrying, outcome.failed
+                );
+            }
+            tokio::time::sleep(DELIVERY_INTERVAL).await;
+        }
+    });
+}

--- a/src/web/recordings/workers.rs
+++ b/src/web/recordings/workers.rs
@@ -62,11 +62,8 @@ pub(crate) fn spawn_recording_workers(
         let (accounts, recorder) = sweeping;
         loop {
             let outcome = crate::recording::sweep_recordings(&accounts, &recorder).await;
-            if outcome != crate::recording::SweepOutcome::default() {
-                eprintln!(
-                    "recording sweep retried {} deleted {} failed {}",
-                    outcome.retried, outcome.deleted, outcome.failed
-                );
+            if let Some(line) = sweep_line(&outcome) {
+                eprintln!("{line}");
             }
             tokio::time::sleep(SWEEP_INTERVAL).await;
         }
@@ -84,17 +81,40 @@ pub(crate) fn spawn_recording_workers(
                     delivery.as_ref() as &dyn crate::recording::DeliveryProvider,
                 )
                 .await;
-                if outcome != crate::recording::DeliveryOutcome::default() {
-                    eprintln!(
-                        "recording delivery delivered {} retrying {} failed {}",
-                        outcome.delivered, outcome.retrying, outcome.failed
-                    );
+                if let Some(line) = delivery_line(&outcome) {
+                    eprintln!("{line}");
                 }
                 tokio::time::sleep(DELIVERY_INTERVAL).await;
             }
         }));
     }
     workers
+}
+
+/// What a sweep is worth saying, or nothing when it did nothing.
+///
+/// A pass that finds no work is the ordinary case and runs every minute, so
+/// saying so would bury the passes that moved something. Pulled out of the loop
+/// for the reason `quota_change_line` is out of its own: the line deciding
+/// whether an operator hears about a sweep is worth pinning, and inside a
+/// spawned loop nothing could reach it.
+fn sweep_line(outcome: &crate::recording::SweepOutcome) -> Option<String> {
+    (*outcome != crate::recording::SweepOutcome::default()).then(|| {
+        format!(
+            "recording sweep retried {} deleted {} failed {}",
+            outcome.retried, outcome.deleted, outcome.failed
+        )
+    })
+}
+
+/// The same for a delivery pass.
+fn delivery_line(outcome: &crate::recording::DeliveryOutcome) -> Option<String> {
+    (*outcome != crate::recording::DeliveryOutcome::default()).then(|| {
+        format!(
+            "recording delivery delivered {} retrying {} failed {}",
+            outcome.delivered, outcome.retrying, outcome.failed
+        )
+    })
 }
 
 /// How often the delivery queue is asked whether anything is due.
@@ -132,6 +152,58 @@ pub(crate) fn delivery_provider(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A pass that did nothing says nothing, and a pass that did says what.
+    ///
+    /// Both loops run on a timer against whatever the database holds, so the
+    /// quiet case is the common one and logging it would bury the passes worth
+    /// reading. The counts are in the line because an operator reading it has
+    /// no other view of what the sweep moved.
+    #[test]
+    fn a_worker_pass_reports_only_when_it_moved_something() {
+        use crate::recording::{DeliveryOutcome, SweepOutcome};
+
+        assert_eq!(sweep_line(&SweepOutcome::default()), None);
+        assert_eq!(delivery_line(&DeliveryOutcome::default()), None);
+
+        let swept = SweepOutcome {
+            retried: 1,
+            deleted: 2,
+            failed: 3,
+        };
+        assert_eq!(
+            sweep_line(&swept).as_deref(),
+            Some("recording sweep retried 1 deleted 2 failed 3")
+        );
+
+        let delivered = DeliveryOutcome {
+            delivered: 4,
+            retrying: 5,
+            failed: 6,
+        };
+        assert_eq!(
+            delivery_line(&delivered).as_deref(),
+            Some("recording delivery delivered 4 retrying 5 failed 6")
+        );
+
+        // One field is enough to make a pass worth reporting, whichever it is.
+        for outcome in [
+            SweepOutcome {
+                retried: 1,
+                ..SweepOutcome::default()
+            },
+            SweepOutcome {
+                deleted: 1,
+                ..SweepOutcome::default()
+            },
+            SweepOutcome {
+                failed: 1,
+                ..SweepOutcome::default()
+            },
+        ] {
+            assert!(sweep_line(&outcome).is_some(), "{outcome:?}");
+        }
+    }
 
     /// The guard exists so a sweeper cannot outlive the server that wanted it.
     /// Nothing would prove that: `drop` could be empty and every other test

--- a/src/web/recordings/workers.rs
+++ b/src/web/recordings/workers.rs
@@ -18,25 +18,48 @@ use crate::accounts::Accounts;
 /// first step.
 const SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 
-/// Resolves recordings nobody is looking after, now and then repeatedly.
+/// The timers this module owns, stopped when the server that started them is.
 ///
-/// Now, because a process that died mid-interview left rows no request will
-/// ever touch again. Repeatedly, because the retry schedule is minutes long and
-/// a sweep that only ran at startup would turn every provider hiccup into a
-/// failed recording.
+/// Held rather than detached. A router is built per test and more than one can
+/// share a runtime, so a sweeper nothing aborted went on scanning a database
+/// its own server had finished with, and a delivery worker went on uploading
+/// from it. `QuotaRefresher` is the same shape for the same reason.
+#[derive(Default)]
+pub(crate) struct RecordingWorkers(Vec<tokio::task::JoinHandle<()>>);
+
+impl Drop for RecordingWorkers {
+    fn drop(&mut self) {
+        for handle in self.0.drain(..) {
+            handle.abort();
+        }
+    }
+}
+
+/// Starts the sweeper and the delivery worker, which always run as a pair.
+///
+/// The sweeper resolves recordings nobody is looking after, now and then
+/// repeatedly: now, because a process that died mid-interview left rows no
+/// request will ever touch again, and repeatedly, because the retry schedule is
+/// minutes long and a sweep that only ran at startup would turn every provider
+/// hiccup into a failed recording. The delivery worker moves what the sweeper
+/// finds finished.
 ///
 /// Silent when there is no runtime to spawn on. `web_router` is public and can
-/// be built outside one; a router that serves without a sweeper is degraded,
-/// and a panic at construction is worse.
-pub(crate) fn spawn_recording_sweeper(
+/// be built outside one; a router that serves without these is degraded, and a
+/// panic at construction is worse.
+pub(crate) fn spawn_recording_workers(
     accounts: Arc<Accounts>,
     recorder: crate::recording::Recorder,
-) {
+) -> RecordingWorkers {
     let Ok(handle) = tokio::runtime::Handle::try_current() else {
-        eprintln!("recording is configured but there is no runtime to sweep on");
-        return;
+        eprintln!("recording is configured but there is no runtime to sweep or deliver on");
+        return RecordingWorkers::default();
     };
-    handle.spawn(async move {
+    let mut workers = RecordingWorkers::default();
+
+    let sweeping = (accounts.clone(), recorder.clone());
+    workers.0.push(handle.spawn(async move {
+        let (accounts, recorder) = sweeping;
         loop {
             let outcome = crate::recording::sweep_recordings(&accounts, &recorder).await;
             if outcome != crate::recording::SweepOutcome::default() {
@@ -47,7 +70,31 @@ pub(crate) fn spawn_recording_sweeper(
             }
             tokio::time::sleep(SWEEP_INTERVAL).await;
         }
-    });
+    }));
+
+    // A deployment whose credentials do not build a delivery client records and
+    // hands nothing over, which `delivery_provider` has already warned about.
+    // The sweeper still runs: it is what expires those rows.
+    if let Some(delivery) = recorder.delivery.clone() {
+        workers.0.push(handle.spawn(async move {
+            loop {
+                let outcome = crate::recording::run_delivery_queue(
+                    &accounts,
+                    &recorder,
+                    delivery.as_ref() as &dyn crate::recording::DeliveryProvider,
+                )
+                .await;
+                if outcome != crate::recording::DeliveryOutcome::default() {
+                    eprintln!(
+                        "recording delivery delivered {} retrying {} failed {}",
+                        outcome.delivered, outcome.retrying, outcome.failed
+                    );
+                }
+                tokio::time::sleep(DELIVERY_INTERVAL).await;
+            }
+        }));
+    }
+    workers
 }
 
 /// How often the delivery queue is asked whether anything is due.
@@ -58,18 +105,6 @@ pub(crate) fn spawn_recording_sweeper(
 /// waiting.
 const DELIVERY_INTERVAL: Duration = Duration::from_secs(10);
 
-/// The upload that a finished recording still owes.
-///
-/// Separate from the sweeper, because they answer different questions: the
-/// sweeper looks for rows nothing is moving, and this moves them. Running them
-/// on one timer would tie the pace of deliveries to the pace of a scan.
-///
-/// A deployment whose credentials do not build a delivery client gets a warning
-/// and no worker rather than a panic in a router constructor. The binary does
-/// not reach that case: `codetrial web` parses the key before it listens and
-/// refuses to start without one. It is reachable from
-/// this function, which is public and is what the tests build, and there the
-/// warning is the right answer.
 /// The delivery client, or a warning and none.
 ///
 /// A `None` here is a deployment that records and never hands anything over,
@@ -94,29 +129,45 @@ pub(crate) fn delivery_provider(
     }
 }
 
-pub(crate) fn spawn_delivery_worker(accounts: Arc<Accounts>, recorder: crate::recording::Recorder) {
-    let Ok(handle) = tokio::runtime::Handle::try_current() else {
-        eprintln!("recording is configured but there is no runtime to deliver on");
-        return;
-    };
-    let Some(delivery) = recorder.delivery.clone() else {
-        return;
-    };
-    handle.spawn(async move {
-        loop {
-            let outcome = crate::recording::run_delivery_queue(
-                &accounts,
-                &recorder,
-                delivery.as_ref() as &dyn crate::recording::DeliveryProvider,
-            )
-            .await;
-            if outcome != crate::recording::DeliveryOutcome::default() {
-                eprintln!(
-                    "recording delivery delivered {} retrying {} failed {}",
-                    outcome.delivered, outcome.retrying, outcome.failed
-                );
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The guard exists so a sweeper cannot outlive the server that wanted it.
+    /// Nothing would prove that: `drop` could be empty and every other test
+    /// still passes, which is exactly the leak this type was added to stop.
+    #[tokio::test]
+    async fn dropping_the_workers_aborts_the_tasks_they_own() {
+        let mut workers = RecordingWorkers::default();
+        let watches: Vec<_> = (0..2)
+            .map(|_| {
+                // Never finishes on its own, so anything that ends it is the
+                // abort.
+                let task = tokio::spawn(async {
+                    loop {
+                        tokio::time::sleep(Duration::from_secs(3600)).await;
+                    }
+                });
+                let watch = task.abort_handle();
+                workers.0.push(task);
+                watch
+            })
+            .collect();
+        assert!(
+            watches.iter().all(|watch| !watch.is_finished()),
+            "both tasks are running before the drop"
+        );
+
+        drop(workers);
+
+        // The abort lands at each task's next scheduling point rather than
+        // inside `drop`, so this yields rather than asserting straight away.
+        for _ in 0..100 {
+            if watches.iter().all(|watch| watch.is_finished()) {
+                return;
             }
-            tokio::time::sleep(DELIVERY_INTERVAL).await;
+            tokio::task::yield_now().await;
         }
-    });
+        panic!("a task outlived the RecordingWorkers that owned it");
+    }
 }

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -3989,10 +3989,10 @@ fn a_weakness_tag_matches_its_plan_item_across_stray_whitespace() {
 #[test]
 fn the_interview_contract_is_the_same_bundle_on_both_sides() {
     let browser = std::fs::read_to_string("web/lib.js").expect("web/lib.js is readable");
-    let declaration = "const activeContract = {";
+    let declaration = "export const ACTIVE_CONTRACT = {";
     let start = browser
         .find(declaration)
-        .expect("web/lib.js declares activeContract")
+        .expect("web/lib.js declares ACTIVE_CONTRACT")
         + declaration.len();
     let rest = &browser[start..];
     let end = rest.find('}').expect("the object literal is closed");

--- a/tests/browser/dom-hooks.js
+++ b/tests/browser/dom-hooks.js
@@ -1,0 +1,22 @@
+// Resolves the absolute specifiers `web/replay.js` uses. The page is served from
+// the web root, so `/lib.js` is `web/lib.js`; node has no import map, and this is
+// the smallest thing that lets the module be imported at all.
+
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+
+const WEB = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "web");
+
+export function resolve(specifier, context, next) {
+  // A query is carried through rather than resolved away. It is how a test asks
+  // for a second instance of the page: ESM caches by URL, and re-running the
+  // module scope is the only way to see what a page does when one of its ids is
+  // missing.
+  const [path, query] = specifier.split("?");
+  if (path.startsWith("/") && path.endsWith(".js")) {
+    const url = pathToFileURL(join(WEB, path));
+    if (query) url.search = query;
+    return { url: url.href, shortCircuit: true };
+  }
+  return next(specifier, context);
+}

--- a/tests/browser/dom.js
+++ b/tests/browser/dom.js
@@ -1,11 +1,18 @@
-// A document stub and a module hook, so `node --test` can drive `web/replay.js`.
+// A document stub and a module hook, so `node --test` can drive a page module.
 //
-// `web/replay.js` reads `document.querySelector` at module scope and imports by
-// absolute URL, so it cannot be imported outside a browser and every check on it
-// was a check on its source text. Reading source is how a dozen ways to put an
-// accusation on this page were each closed one at a time while the class stayed
-// open: the page renders through five files, and a guard that names files is a
-// guard somebody adds another to.
+// Nothing here is about one page. The hook resolves any absolute `/x.js` the way
+// the server serves it, and `installDocument` takes whatever markup it is given,
+// so a page is drivable here as soon as somebody hands it its own markup. It was
+// written for `web/replay.js`, which is the worked example throughout, and the
+// naming was narrowed to match once a second caller arrived.
+//
+// The problem it solves is general too. A page module that reads
+// `document.querySelector` at module scope and imports by absolute URL cannot be
+// imported outside a browser, so every check on it is a check on its source
+// text. Reading source is how a dozen ways to put an accusation on the replay
+// page were each closed one at a time while the class stayed open: that page
+// renders through five files, and a guard that names files is a guard somebody
+// adds another to.
 //
 // This is the injected seam the check rules allow, not a browser, and the
 // difference matters in one direction: a stub laxer than a browser passes things
@@ -22,9 +29,27 @@
 // rather than described. Four attempts to write down which ids fail where
 // produced four wrong sentences, because the answer depends on which function
 // first dereferences each node and no reading of the source got it right.
-// `importWithout` below re-imports the page with one id removed so a test can
+// `importWithout` below re-imports a page with one id removed so a test can
 // measure it, and "a missing id is caught, except for the ids nothing drives"
-// in tests/browser/replay-render.test.js holds the answer.
+// in tests/browser/replay-render.test.js holds the answer for that page.
+//
+// What this stub is not is a browser, and a page that needs one is out of its
+// reach rather than badly served by it: there is no layout, no event loop, and
+// no network. `./scripts/browser-check.sh` is where runtime behavior is checked.
+//
+// The boundary that decides which pages fit is markup structure. Selectors are
+// matched flat, against tag, id, class and attribute, in document order, and
+// that is enough for every page whose modules read their nodes by name. What it
+// does not model is nesting the markup declares: `firstElementChild` answers
+// over children a page appended and `null` over children only the HTML has.
+//
+// `web/interview.js` is the measured case and the reason this is written down
+// rather than guessed at. It imports here, which is new and worth having, since
+// a module-scope throw in the largest browser module used to be visible only to
+// the optional browser check. It cannot be driven past import, because
+// `paintEditor` reaches for the `<code>` inside a `<pre>` that only the markup
+// declares. Parsing that would mean a tree, and a tree parsed wrong renders a
+// page no browser would, which is the one failure this file refuses.
 import { register } from "node:module";
 import { pathToFileURL } from "node:url";
 import { failFetchWith } from "./source.js";
@@ -78,6 +103,14 @@ class Element {
     this.#text = String(value);
   }
 
+  /// The first child this page put here, which is structure the stub does have:
+  /// `append` and `replaceChildren` built it. Markup nesting is the kind it does
+  /// not have, and a page reaching for a child the markup declared gets `null`
+  /// rather than an invention.
+  get firstElementChild() {
+    return this.children.find((child) => child.tag !== "#text") ?? null;
+  }
+
   /// The text this element holds itself, which is what a copy check reads. The
   /// getter above would count a parent's words once per ancestor.
   get ownText() {
@@ -100,6 +133,22 @@ class Element {
     this.children = [];
     this.#text = "";
     this.append(...children);
+  }
+
+  /// The other way a page writes an attribute, and it has to reach the same
+  /// reader as the property form: `setAttribute("aria-label", ...)` puts a word
+  /// in front of somebody exactly as `ariaLabel = ...` does, and a copy check
+  /// that saw one and not the other would be a guard with a hole in it.
+  ///
+  /// Stored under the property spelling, so `aria-label` and `ariaLabel` are one
+  /// value rather than two the reader has to know to add up.
+  setAttribute(name, value) {
+    this[name.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())] = String(value);
+  }
+
+  getAttribute(name) {
+    const property = name.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    return property in this ? String(this[property]) : null;
   }
 
   addEventListener(name, handler) {
@@ -129,17 +178,20 @@ class Element {
   }
 
   querySelectorAll(selector) {
-    const wanted = selector.split(",").map((part) => part.trim().replace(/^\[|\]$/g, ""));
-    for (const name of wanted) {
-      if (name !== "data-moment" && name !== "data-window") {
+    // `[data-x]` only, and the dataset key is derived rather than enumerated.
+    // Naming the two attributes this happened to be written for put the pair in
+    // two places that had to agree, so the next page marking a node with a third
+    // one had to patch the stub to be seen at all. Anything that is not a
+    // `data-` attribute asks about structure an element does not model, and is
+    // refused loudly rather than answered with an empty list.
+    const keys = selector.split(",").map((part) => {
+      const name = part.trim().replace(/^\[|\]$/g, "");
+      if (!name.startsWith("data-")) {
         throw new Error(`the stub does not implement the selector ${selector}`);
       }
-    }
-    return [...this.descendants()].filter((node) =>
-      wanted.some((name) =>
-        name === "data-moment" ? "moment" in node.dataset : "window" in node.dataset,
-      ),
-    );
+      return name.slice(5).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    });
+    return [...this.descendants()].filter((node) => keys.some((key) => key in node.dataset));
   }
 
   /// Every string this element and its descendants would put in front of a
@@ -165,30 +217,30 @@ class Element {
 }
 
 /// Installs the stub with one id removed from the page, imports a fresh copy of
-/// `web/replay.js` against it, and reports whether anything failed.
+/// `module` against it, and reports whether anything failed.
 ///
-/// A second instance, because ESM caches by URL and the page reads its nodes
-/// once at module scope. The query string is what makes the copy distinct;
+/// A second instance, because ESM caches by URL and a page reads its nodes once
+/// at module scope. The query string is what makes the copy distinct;
 /// `dom-hooks.js` carries it through.
-export async function importWithout(markup, id, drive) {
+export async function importWithout(markup, module, id, drive) {
   // Put back afterwards. This installs a second document for the copy it
   // imports, and a reader handed out by the first `installDocument` reads
   // `globalThis.document`, so leaving the replacement in place left every later
   // test in the file reading a page nobody rendered into.
   const previous = globalThis.document;
   installDocument(markup.replaceAll(` id="${id}"`, ""));
-  // The list fetch never answers, so `loadList` waits forever instead of taking
-  // a branch. What that measures is the import and the render, which are the two
-  // things a test drives; the alternative was letting the refusal branch run and
-  // reading an unhandled rejection out of it, which is a different thing to
-  // catch and one the test runner also watches for.
+  // A fetch the page starts at import never answers, so it waits forever instead
+  // of taking a branch. What that measures is the import and the render, which
+  // are the two things a test drives; the alternative was letting the refusal
+  // branch run and reading an unhandled rejection out of it, which is a
+  // different thing to catch and one the test runner also watches for.
   //
   // Undone with the document, and for a worse failure than the document's. A
   // stub that never settles is not a wrong answer a later test reads, it is a
   // test that never finishes, and the run reports a timeout somewhere else.
   const restoreFetch = failFetchWith(() => new Promise(() => {}));
   try {
-    drive(await import(`/replay.js?without=${encodeURIComponent(id)}`));
+    drive(await import(`${module}?without=${encodeURIComponent(id)}`));
   } catch (error) {
     return { caught: true, error };
   } finally {
@@ -199,23 +251,86 @@ export async function importWithout(markup, id, drive) {
 }
 
 export function installDocument(markup) {
-  // Only the ids the page actually declares, because that is what a browser
-  // does. Where the page then fails, and which ids this reaches at all, is in
-  // the header: a stub that mints an element for every selector renders happily
-  // against a page that is broken in a browser, and this narrows that without
-  // closing it.
-  const present = new Set([...markup.matchAll(/id="([^"]+)"/g)].map((match) => match[1]));
-  const nodes = new Map();
-  globalThis.document = {
-    querySelector(selector) {
-      if (!present.has(selector.replace(/^#/, ""))) return null;
-      if (!nodes.has(selector)) nodes.set(selector, new Element("div"));
-      return nodes.get(selector);
+  // The page's own elements, scanned out of the markup flat: tag, id, classes
+  // and attributes, in document order. No nesting, no parent, no sibling.
+  //
+  // That boundary is the point rather than a shortcut. A tree parsed wrong is
+  // the one failure mode this file refuses, because it renders a page no
+  // browser would; existence and order need no tree, and reading them out of
+  // the markup is the same thing the id scan here always did. So a selector
+  // that asks about structure is refused loudly below rather than answered
+  // with a guess.
+  const declared = [...markup.matchAll(/<([a-zA-Z][\w-]*)((?:\s+[\w:-]+(?:="[^"]*")?)*)\s*\/?>/g)].map(
+    (match) => {
+      const attributes = Object.fromEntries(
+        [...match[2].matchAll(/([\w:-]+)(?:="([^"]*)")?/g)].map((it) => [it[1], it[2] ?? ""]),
+      );
+      return {
+        tag: match[1].toLowerCase(),
+        id: attributes.id,
+        classes: new Set((attributes.class || "").split(/\s+/).filter(Boolean)),
+        attributes,
+      };
     },
-    createElement: (tag) => new Element(tag),
+  );
+  const nodes = new Map();
+  /// One selector against one scanned element. Supported: `#id`, `.class`,
+  /// `tag`, `[attr]` and `[attr="value"]`, and a concatenation of those on one
+  /// element. Anything with a combinator asks about structure this does not
+  /// model, and throwing is what stops a test quietly asserting over nothing.
+  const matches = (selector, element) => {
+    if (/[\s>+~,]/.test(selector.trim())) {
+      throw new Error(`the document stub models no structure, so it cannot match: ${selector}`);
+    }
+    const parts = selector.trim().match(/^[a-zA-Z][\w-]*|#[\w:-]+|\.[\w-]+|\[[^\]]+\]/g);
+    if (!parts || parts.join("") !== selector.trim()) {
+      throw new Error(`the document stub does not implement the selector: ${selector}`);
+    }
+    return parts.every((part) => {
+      if (part.startsWith("#")) return element.id === part.slice(1);
+      if (part.startsWith(".")) return element.classes.has(part.slice(1));
+      if (part.startsWith("[")) {
+        const [, name, value] = part.slice(1, -1).match(/^([\w:-]+)(?:="?([^"]*)"?)?$/) || [];
+        if (!name) throw new Error(`the document stub cannot read the attribute selector: ${part}`);
+        if (!(name in element.attributes)) return false;
+        return value === undefined || element.attributes[name] === value;
+      }
+      return element.tag === part.toLowerCase();
+    });
   };
-  // The page calls `loadList` at import. Refused rather than answered, so a test
-  // drives the render with the events it chose rather than with a list.
+  // Keyed on the element rather than on the selector, so two selectors that
+  // name the same element hand back the same node. Keying on the selector let
+  // `#start` and `button#start` render into two different places, which is a
+  // page a browser cannot produce.
+  const node = (element) => {
+    if (!nodes.has(element)) nodes.set(element, new Element(element.tag));
+    return nodes.get(element);
+  };
+  globalThis.document = {
+    querySelector: (selector) => {
+      const found = declared.find((element) => matches(selector, element));
+      return found ? node(found) : null;
+    },
+    querySelectorAll: (selector) =>
+      declared.filter((element) => matches(selector, element)).map(node),
+    createElement: (tag) => new Element(tag),
+    // A page that registers a listener while it loads gets to. Nothing here
+    // dispatches, so what this buys is the import rather than the behaviour,
+    // and a test that wants the behaviour drives the handler it was given.
+    addEventListener() {},
+  };
+
+  // Enough `window` for a module that registers a listener or reads the origin
+  // while it loads, and no more. Navigation is recorded rather than performed,
+  // because there is nowhere to go: a test that wants to know where a page sent
+  // somebody reads `window.location.href` back, and one that does not is not
+  // made to care.
+  globalThis.window = {
+    location: { origin: "https://codetrial.test", href: "", search: "", reload() {} },
+    addEventListener() {},
+  };
+  // Whatever the page fetches at import is refused rather than answered, so a
+  // test drives the render with the state it chose rather than with a response.
   failFetchWith(async () => ({ ok: false, status: 500, json: async () => ({}) }));
   return { node: (id) => document.querySelector(`#${id}`) };
 }

--- a/tests/browser/dom.js
+++ b/tests/browser/dom.js
@@ -1,0 +1,221 @@
+// A document stub and a module hook, so `node --test` can drive `web/replay.js`.
+//
+// `web/replay.js` reads `document.querySelector` at module scope and imports by
+// absolute URL, so it cannot be imported outside a browser and every check on it
+// was a check on its source text. Reading source is how a dozen ways to put an
+// accusation on this page were each closed one at a time while the class stayed
+// open: the page renders through five files, and a guard that names files is a
+// guard somebody adds another to.
+//
+// This is the injected seam the check rules allow, not a browser, and the
+// difference matters in one direction: a stub laxer than a browser passes things
+// a browser would render. So the properties that carry words model what a
+// browser does. `textContent` clears its children when set and concatenates them
+// when read; `innerHTML` and its siblings are captured rather than silently
+// stored; `dataset` is read back and stringified, because a stylesheet can draw
+// it with `content: attr(...)`; `childElementCount` counts elements;
+// `querySelectorAll` matches descendants and refuses a selector it does not
+// implement; and `querySelector` answers `null` for an id the page does not
+// declare, which is what a browser does.
+//
+// That last one catches less than it looks like, and how much less is asserted
+// rather than described. Four attempts to write down which ids fail where
+// produced four wrong sentences, because the answer depends on which function
+// first dereferences each node and no reading of the source got it right.
+// `importWithout` below re-imports the page with one id removed so a test can
+// measure it, and "a missing id is caught, except for the ids nothing drives"
+// in tests/browser/replay-render.test.js holds the answer.
+import { register } from "node:module";
+import { pathToFileURL } from "node:url";
+import { failFetchWith } from "./source.js";
+
+register("./dom-hooks.js", pathToFileURL(`${import.meta.dirname}/`));
+
+/// Everything an element can say to a person that is not its text: the
+/// attributes a browser speaks aloud or shows on hover, and the markup
+/// properties that put a string on the page without going through `textContent`.
+const SPOKEN_ATTRIBUTES = ["title", "ariaLabel", "alt", "placeholder", "value"];
+const MARKUP = ["innerHTML", "innerText", "outerHTML"];
+
+class Element {
+  #text = "";
+
+  constructor(tag) {
+    this.tag = tag;
+    this.children = [];
+    this.dataset = {};
+    // The one default the page reads back before setting it.
+    this.hidden = false;
+    this.listeners = {};
+    /// What was assigned through a markup property. A browser parses it; this
+    /// keeps the string, which is all a copy check needs and more than the
+    /// silent own-property a plain object would have given it.
+    this.markup = [];
+    for (const name of MARKUP) {
+      Object.defineProperty(this, name, {
+        set: (value) => void this.markup.push(String(value)),
+        get: () => this.markup.at(-1) ?? "",
+      });
+    }
+    // `toggle` and a reader for it, which is all `web/replay.js` calls and all a
+    // test needs to see the result. `add`, `remove` and `contains` on the class
+    // list itself went unused; `current` below is what a test asks.
+    const classes = new Set();
+    this.classList = { toggle: (name, on) => void (on ? classes.add(name) : classes.delete(name)) };
+    Object.defineProperty(this, "current", { get: () => classes.has("current") });
+  }
+
+  /// A browser's `textContent` is the concatenation of every descendant's text,
+  /// and setting it removes the children. A plain property was neither: a page
+  /// that set it above a list rendered a sentence a browser would show and this
+  /// stub would drop.
+  get textContent() {
+    return this.children.length ? this.children.map((child) => child.textContent).join("") : this.#text;
+  }
+
+  set textContent(value) {
+    this.children = [];
+    this.#text = String(value);
+  }
+
+  /// The text this element holds itself, which is what a copy check reads. The
+  /// getter above would count a parent's words once per ancestor.
+  get ownText() {
+    return this.children.length ? "" : this.#text;
+  }
+
+  append(...children) {
+    for (const child of children) {
+      if (typeof child === "string") {
+        const text = new Element("#text");
+        text.textContent = child;
+        this.children.push(text);
+      } else {
+        this.children.push(child);
+      }
+    }
+  }
+
+  replaceChildren(...children) {
+    this.children = [];
+    this.#text = "";
+    this.append(...children);
+  }
+
+  addEventListener(name, handler) {
+    (this.listeners[name] ||= []).push(handler);
+  }
+
+  click() {
+    for (const handler of this.listeners.click || []) handler();
+  }
+
+  /// Elements only, as a browser counts them: a text node is not a child
+  /// element, and `loadList` decides whether to show "No recordings yet" on
+  /// this number.
+  get childElementCount() {
+    return this.children.filter((child) => child.tag !== "#text").length;
+  }
+
+  *walk() {
+    yield this;
+    for (const child of this.children) yield* child.walk();
+  }
+
+  /// Descendants only, as a browser matches them: `querySelectorAll` never
+  /// returns the element it was called on.
+  *descendants() {
+    for (const child of this.children) yield* child.walk();
+  }
+
+  querySelectorAll(selector) {
+    const wanted = selector.split(",").map((part) => part.trim().replace(/^\[|\]$/g, ""));
+    for (const name of wanted) {
+      if (name !== "data-moment" && name !== "data-window") {
+        throw new Error(`the stub does not implement the selector ${selector}`);
+      }
+    }
+    return [...this.descendants()].filter((node) =>
+      wanted.some((name) =>
+        name === "data-moment" ? "moment" in node.dataset : "window" in node.dataset,
+      ),
+    );
+  }
+
+  /// Every string this element and its descendants would put in front of a
+  /// person: their own text, the attributes a browser speaks, whatever was
+  /// assigned through a markup property, and the dataset, which a stylesheet can
+  /// draw with `content: attr(data-...)`.
+  spoken() {
+    return [...this.walk()]
+      .flatMap((node) => [
+        node.ownText,
+        ...SPOKEN_ATTRIBUTES.map((key) => node[key]),
+        ...node.markup,
+        ...Object.values(node.dataset),
+      ])
+      // Stringified rather than filtered to strings. A browser stringifies every
+      // dataset value and every reflected attribute on its way into the markup,
+      // so `dataset.note = ["likely", "assisted"]` draws as text there and was
+      // invisible here.
+      .filter((value) => value !== undefined && value !== null)
+      .map((value) => String(value))
+      .filter((value) => value.trim());
+  }
+}
+
+/// Installs the stub with one id removed from the page, imports a fresh copy of
+/// `web/replay.js` against it, and reports whether anything failed.
+///
+/// A second instance, because ESM caches by URL and the page reads its nodes
+/// once at module scope. The query string is what makes the copy distinct;
+/// `dom-hooks.js` carries it through.
+export async function importWithout(markup, id, drive) {
+  // Put back afterwards. This installs a second document for the copy it
+  // imports, and a reader handed out by the first `installDocument` reads
+  // `globalThis.document`, so leaving the replacement in place left every later
+  // test in the file reading a page nobody rendered into.
+  const previous = globalThis.document;
+  installDocument(markup.replaceAll(` id="${id}"`, ""));
+  // The list fetch never answers, so `loadList` waits forever instead of taking
+  // a branch. What that measures is the import and the render, which are the two
+  // things a test drives; the alternative was letting the refusal branch run and
+  // reading an unhandled rejection out of it, which is a different thing to
+  // catch and one the test runner also watches for.
+  //
+  // Undone with the document, and for a worse failure than the document's. A
+  // stub that never settles is not a wrong answer a later test reads, it is a
+  // test that never finishes, and the run reports a timeout somewhere else.
+  const restoreFetch = failFetchWith(() => new Promise(() => {}));
+  try {
+    drive(await import(`/replay.js?without=${encodeURIComponent(id)}`));
+  } catch (error) {
+    return { caught: true, error };
+  } finally {
+    globalThis.document = previous;
+    restoreFetch();
+  }
+  return { caught: false };
+}
+
+export function installDocument(markup) {
+  // Only the ids the page actually declares, because that is what a browser
+  // does. Where the page then fails, and which ids this reaches at all, is in
+  // the header: a stub that mints an element for every selector renders happily
+  // against a page that is broken in a browser, and this narrows that without
+  // closing it.
+  const present = new Set([...markup.matchAll(/id="([^"]+)"/g)].map((match) => match[1]));
+  const nodes = new Map();
+  globalThis.document = {
+    querySelector(selector) {
+      if (!present.has(selector.replace(/^#/, ""))) return null;
+      if (!nodes.has(selector)) nodes.set(selector, new Element("div"));
+      return nodes.get(selector);
+    },
+    createElement: (tag) => new Element(tag),
+  };
+  // The page calls `loadList` at import. Refused rather than answered, so a test
+  // drives the render with the events it chose rather than with a list.
+  failFetchWith(async () => ({ ok: false, status: 500, json: async () => ({}) }));
+  return { node: (id) => document.querySelector(`#${id}`) };
+}

--- a/tests/browser/history.test.js
+++ b/tests/browser/history.test.js
@@ -29,6 +29,7 @@ test("replay page dom ids", () => {
     "replay-media",
     "replay-transcript",
     "replay-timeline",
+    "replay-window-note",
     "replay-moment-label",
     "replay-code",
     "replay-tests",
@@ -103,14 +104,18 @@ test("replay expired", () => {
 
 test("replay renders moments, not media", () => {
   const render = withoutComments(functionBody(script, "render"));
-  assert.ok(
-    render.includes('event.kind === "transcript"'),
-    "the transcript accumulates, which is what the schema says",
-  );
-  assert.ok(
-    render.includes('event.kind === "editor" || event.kind === "tests"'),
-    "and the snapshots are the moments",
-  );
+  // Every transcript event becomes a line, which is what the schema means by a
+  // transcript accumulating. Asserted as the two ends rather than as the control
+  // flow between them: an earlier version pinned `if (... !== "transcript")
+  // continue;`, which fails an identical rewrite as `if (... === "transcript")
+  // { ... }` and holds no property either shape does not.
+  assert.match(render, /for \(const event of rows\)/);
+  assert.match(render, /nodes\.transcript\.append\(line\)/);
+  // A body that is not a list is an empty replay rather than a throw, and the
+  // guard has to be here: `findLast` runs before anything downstream is
+  // reached, so a guard only inside `replayTimeline` is one the page never gets
+  // to. What the guard then does is driven in tests/browser/lib.test.js.
+  assert.match(render, /const rows = replayRows\(events\)/);
 
   const moment = withoutComments(functionBody(script, "showMoment"));
   assert.ok(
@@ -184,4 +189,277 @@ test("a rate-limited replay batch is kept, not dropped", () => {
     /REPLAY_MAX_BATCH && Date\.now\(\) >= retryAfter/,
     "the fill trigger has to respect the wait, or nothing does",
   );
+});
+
+/// Every string literal in a slice of source, as the values they parse to
+/// rather than as the escapes they were written with.
+///
+/// All three quotings. `eslint.config.mjs` has no `quotes` rule and nothing else
+/// pins one, so a check that read only double quotes would be telling the next
+/// person that a single-quoted or backticked label is allowed; both were written
+/// and shown to pass an earlier version of this. Single-quoted and backticked
+/// text is requoted before parsing, because JSON accepts neither.
+///
+/// `JSON.parse` rather than the raw match, so an escape in the file and the
+/// character in the allowlist are the same string here. Comment lines go first:
+/// a `///` paragraph explaining the copy is not part of the copy.
+function literals(source) {
+  const bare = source.replace(/^\s*\/\/.*$/gm, "");
+  const requote = (text) => `"${text.replace(/\\(['`])/g, "$1").replace(/"/g, '\\"')}"`;
+  return [
+    ...[...bare.matchAll(/"(?:[^"\\\n]|\\.)*"/g)].map((match) => match[0]),
+    ...[...bare.matchAll(/'(?:[^'\\\n]|\\.)*'/g)].map((match) => requote(match[0].slice(1, -1))),
+    ...[...bare.matchAll(/`(?:[^`\\]|\\.)*`/g)].map((match) =>
+      requote(match[0].slice(1, -1).replace(/\$\{[^}]*\}/g, "").replace(/\n/g, " ")),
+    ),
+  ].map((text) => JSON.parse(text));
+}
+
+test("the response window panel says what the number is worth, in words a test can hold", () => {
+  // Integrity features produce evidence for human review, and a duration
+  // offered as evidence owes its provenance. "No severity language anywhere" is
+  // a negative no test can observe, so this is the positive form: the panel may
+  // use these strings and no others, and the next person to add a label is told
+  // by a failure rather than by nobody.
+
+  // Half of it is the paragraph, which is static because it needs no state.
+  const note = page.slice(page.indexOf('id="replay-window-note"'), page.indexOf("</p>", page.indexOf('id="replay-window-note"')));
+  const prose = note.slice(note.indexOf(">") + 1).replace(/\s+/g, " ").trim();
+  assert.equal(
+    prose,
+      "A response window is the time between the interviewer finishing a turn and the interviewer " +
+      "speaking again. It is measured from the clock of the browser that recorded the interview, which " +
+      "can jump forward as well as back, and it includes the time CodeTrial itself took to prepare the " +
+      "reply, which is not the same on every turn. The interviewer speaks again on its own after about " +
+      "twenty-five seconds of silence, and neither talking nor typing counts as silence, so a window " +
+      "runs long only while the candidate is working: a long window means they were busy, and a run of " +
+      "short windows holding no transcript is what silence looks like. A window opens whenever the " +
+      "interviewer stops speaking, which is often not the end of a question: it also follows the " +
+      "interviewer's own prompts and reactions, a candidate interrupting, a moment when the interviewer " +
+      "published no state at all, the interviewer dropping out and coming back, and the candidate " +
+      "pausing the interview, which is the one of those a window says on itself. Events reach the " +
+      "server in batches and a batch can be lost, so a window can be missing, doubled, shown with no " +
+      "candidate transcript, wrongly marked as paused, or added after the interview ended. A window " +
+      "shows no duration when the recording ended inside it, or when that clock ran backwards. Each " +
+      "turn carries the window its stream started in, and a recording made before that says so on " +
+      "every window it cannot place, rather than reporting a question nobody answered. A long " +
+      "window is a place in the recording to go and watch, not a finding about anybody.",
+  );
+  // Each thing that has to reach the reader, named so a rewrite that drops one
+  // fails rather than reading fine.
+  assert.match(prose, /time between the interviewer finishing a turn/, "what it measures");
+  assert.match(
+    prose,
+    /a recording made before that says so on every window it cannot place/,
+    "that an older recording withholds the attribution rather than denying it",
+  );
+  assert.match(prose, /speaks again on its own after about twenty-five seconds/, "what bounds it");
+  assert.match(prose, /a long window means they were busy/, "so a long one is not the shape to look for");
+  assert.match(prose, /run of short windows holding no transcript/, "and this one is");
+  assert.match(prose, /clock of the browser that recorded the interview/, "whose clock measured it");
+  assert.match(prose, /jump forward as well as back/, "in both directions, so a long reading is not a measurement either");
+  assert.match(prose, /published no state at all/, "a window can open without a question having ended");
+  assert.match(prose, /follows the interviewer's own prompts and reactions/, "and most often does");
+  assert.match(prose, /not a finding about anybody/, "and it is not an accusation");
+  assert.match(prose, /includes the time CodeTrial itself took/, "whose latency is inside the number");
+  assert.match(prose, /a candidate interrupting/, "a window is not always a question ending");
+  // Every consequence of a lost batch, named rather than summarised. A merged
+  // window reads as a long one, a missing window is a question the panel never
+  // lists, a lost transcript row makes an answered question look unanswered, and
+  // losing the interviewer's first row empties the panel entirely.
+  assert.match(prose, /missing, doubled, shown with no candidate transcript, wrongly marked as paused, or added after the interview ended/);
+  assert.match(prose, /the candidate pausing the interview/, "the one cause a window can name");
+
+  // And nothing else on the page speaks. Pinning the paragraph by its id guards
+  // the paragraph, and pinning one `<section>` guards one section: a sibling
+  // with no id was written and passed, and so was a paragraph under the Report
+  // heading, which renders on the same page a reviewer is reading. What this
+  // page may say is therefore the whole of what it says, comments and markup
+  // removed.
+  // From the top of the document, not from `<body>`. The `<title>` is what a
+  // browser writes on the tab, which is in front of the reader like anything
+  // else, and slicing it off was a surface this list did not cover.
+  const spoken = page
+    .slice(page.indexOf("<head>"))
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/<[^>]*>/g, "\u0001")
+    .split("\u0001")
+    .map((text) => text.replace(/\s+/g, " ").trim())
+    .filter(Boolean);
+  // Attributes as well as text. A browser speaks `aria-label` and shows `title`
+  // on hover, and the tag-stripping below erases both before the allowlist sees
+  // them, so `<h3 title="likely assisted">Moments</h3>` renders a sentence the
+  // list would not hold. Both quote styles: HTML takes either, and an earlier
+  // version of this took one.
+  assert.deepEqual(
+    [...page.matchAll(/\s(?:title|aria-label|alt|placeholder)\s*=\s*("[^"]*"|'[^']*')/g)].map(
+      (match) => match[1].slice(1, -1),
+    ),
+    [],
+    "this page says nothing through an attribute",
+  );
+
+  // And no stylesheet of its own. `tests/browser/replay-render.test.js` reads
+  // `web/styles.css` and would not see a second one written here. The scan below
+  // would: it starts at `<head>` and strips tags, so the rules land in it as
+  // text. This fails first and with a better name, which is why it is here and
+  // not left to that.
+  assert.doesNotMatch(page, /<style/i, "this page has no stylesheet of its own");
+
+  assert.deepEqual(
+    spoken,
+    [
+      "CodeTrial - Recordings",
+      "CODETRIAL",
+      "Your recordings",
+      "Interviews this account recorded. A recording is kept for 24 hours and then deleted, along with everything on this page.",
+      "Older",
+      "No recordings yet.",
+      "Choose a recording",
+      "What was said",
+      "Moments",
+      prose,
+      "Code",
+      "Report",
+    ],
+    "every word this page says without being told one by the server",
+  );
+
+  // The stylesheet is not read here. `tests/browser/replay-render.test.js` scans
+  // it for every property that draws text, which is strictly more than the
+  // `content:` scan that stood here, so one file owns `web/styles.css` rather
+  // than two disagreeing about how thoroughly it was checked.
+
+  // The other half is the per-window label, which is the one place a severity
+  // word could be added by hand.
+  const WINDOW_COPY = [
+    "response window",
+    " s",
+    " · ",
+    "duration not recorded",
+    "no candidate transcript recorded",
+    "transcript not matched to a window",
+    "interview paused during this window",
+  ];
+  const words = script.slice(script.indexOf("const WINDOW_WORDS = {"));
+  assert.deepEqual(
+    new Set(literals(words.slice(0, words.indexOf("\n};")))),
+    new Set(WINDOW_COPY),
+    "the words table says these and no others",
+  );
+
+  // Every string this page can say, in one set. Deleting this when the render
+  // check landed was a straight loss: that check drives `render`, and
+  // `MEDIA_WORDS`, `GONE_WORDS` and every "could not load" sentence are written
+  // by `select`, `loadEvents` and `loadReport`, which it does not drive. The two
+  // are complements and were treated as alternatives.
+  assert.deepEqual(
+    new Set(literals(script)),
+    new Set([
+      // Wiring: selectors, module paths, tags, classes, dataset and event names.
+      "", "/lib.js", "/render.js", "/api/reports", "button", "div", "li", "click", "current",
+      "[data-moment]", "replay-item", "replay-line",
+      "replay-moment", "replay-window", "#replay-code", "#replay-empty", "#replay-list",
+      "#replay-media", "#replay-moment-label", "#replay-more", "#replay-report",
+      "#replay-status", "#replay-tests", "#replay-timeline", "#replay-title",
+      "#replay-transcript", "#replay-window-note",
+      // Replay event kinds and the speaker a missing one reads as.
+      "stage", "transcript", "editor", "tests", "candidate",
+      // What the page says about the media, per state.
+      "The video was shared with your verified email address. It is deleted 24 hours after the interview.",
+      "This interview is still being recorded.", "The recording is being finished.",
+      "The recording is being delivered to your email address.",
+      "There is no video for this interview.", "The video has been deleted.",
+      "This recording is past its 24 hours and has been deleted.",
+      "This recording has been deleted.", "This recording is not available on this account.",
+      " The replay below stops before the end of the interview.",
+      // What it says when a read failed, which is not the same as nothing
+      // recorded.
+      "Could not load the replay for this interview.", "Could not load the report.",
+      "Could not read your recordings.", "No report was saved for this interview.",
+      "Sign in to see your recordings.", "No test run before this point.",
+      "Recording", "Deleted", "Not available", "Code",
+      // And the window panel, spread from the set pinned above rather than
+      // retyped: the narrower assertion catches a word relocated out of
+      // `WINDOW_WORDS`, and this one catches a word added anywhere, so they are
+      // different checks over one list.
+      ...WINDOW_COPY,
+      // Template literals, with their interpolations stripped: the routes this
+      // page calls and the separators it joins values with. The events request
+      // is here in the shape it is sent, which is the other half of the done
+      // condition for this feature.
+      "/api/recordings", "/api/recordings/", "/api/recordings//events?avatar=history",
+      "?before=", " ·  · ", " : ", "Code · ", "/ passing",
+    ]),
+    "a string this page can say that is not in this list is one nobody chose",
+  );
+
+  // What the panel then does with those words is asserted by driving it, not
+  // here, and the reason is the whole history of this test. Reading source for
+  // labels was
+  // defeated twelve times: by a single-quoted literal, a template literal, a
+  // second table beside the first, a helper, a computed lookup, a spliced
+  // element, `button.title`, `button[KEY]`, a local named something else, a
+  // conditional field on the span, a third file, and a stylesheet. Each fix
+  // named a surface, and the page renders through five of them.
+  //
+  // `tests/browser/replay-render.test.js` drives the render with sentinels in
+  // every value the server supplies and reads what comes out, which has no such
+  // edge. What is left here is the copy itself, which is worth naming where a
+  // person reading the test can see it.
+});
+
+test("the replay page asks for the avatar history and renders it beside the moments", () => {
+  // The done condition is the request, not what the page then draws with it.
+  // What it draws is asserted in `tests/browser/replay-render.test.js`, which
+  // does import `web/replay.js`; what it asks for is text, and text is what this
+  // file reads.
+  const events = withoutComments(functionBody(script, "loadEvents"));
+  assert.match(
+    events,
+    /\/events\?avatar=history/,
+    "the snapshot keeps one avatar row, and a window needs the history",
+  );
+
+  // Their own array, not `moments`. `data-moment` indexes that one and
+  // `showMoment` rebuilds state by scanning its prefix, so a third kind mixed
+  // in would shift every index and be scanned over as neither snapshot.
+  const render = withoutComments(functionBody(script, "render"));
+  assert.match(
+    render,
+    /const \{ moments, windows, timeline \} = replayTimeline\(rows\)/,
+    "the page draws the timeline; web/lib.js decides it",
+  );
+  // What that timeline is, and that a window is not a moment, is asserted by
+  // driving `replayTimeline` in tests/browser/lib.test.js. Source text was the
+  // wrong tool for it and was the tool this used: an assembly that appended
+  // every window after every moment matched the regexes that stood here.
+  assert.match(
+    withoutComments(functionBody(script, "windowItem")),
+    /dataset\.window = String\(index\)/,
+    "a window is addressed as a window",
+  );
+
+  // Only a moment controls the code and test panels, so a response window
+  // cannot take their selection mark.
+  const current = withoutComments(functionBody(script, "markCurrent"));
+  assert.match(current, /\[data-moment\]/);
+  assert.doesNotMatch(current, /data-window/);
+
+  // The paragraph carries `hidden` in the page, so both of these have to be
+  // here: without the second the caveats are never shown at all, and
+  // without the first they stand over the next recording's empty timeline. The
+  // whole show-and-hide was unguarded, and deleting both lines left the suite
+  // green while the note stopped existing for a reader.
+  assert.match(
+    withoutComments(functionBody(script, "clearDetail")),
+    /nodes\.windowNote\.hidden = true;/,
+    "a new selection hides the paragraph until there is something to explain",
+  );
+  assert.match(
+    render,
+    /nodes\.windowNote\.hidden = windows\.length === 0;/,
+    "and a replay with windows shows it",
+  );
+  assert.ok(page.includes('id="replay-window-note" class="muted small" hidden'));
 });

--- a/tests/browser/lib.test.js
+++ b/tests/browser/lib.test.js
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import { read } from "./source.js";
 
 import {
+  ACTIVE_CONTRACT,
   FRAMEWORKS,
   frameworkChecklist,
   captionWindow,
@@ -1142,6 +1143,33 @@ test("the replay timeline interleaves windows with the moments without joining t
   // A replay with no avatar rows has no windows, so the page has nothing to
   // explain and hides the paragraph explaining it.
   assert.deepEqual(replayTimeline([editor(0, "only")]).windows, []);
+});
+
+test("the contract this build scores is the shape sanitizeReport accepts", () => {
+  // The reason `ACTIVE_CONTRACT` is exported rather than function-local. While
+  // it lived inside `sanitizeReport`, nothing could read it, and moving it left
+  // the whole suite green with the supported-contract branch no longer
+  // rendering: a precondition nobody checks is a precondition that goes.
+  //
+  // Not the versions themselves. `the_interview_contract_is_the_same_bundle_on_
+  // both_sides` in `tests/agent.rs` already compares the whole object against
+  // the server's, which is the stronger check because it is the disagreement
+  // that matters. What is left for here is the shape, which that test reads
+  // rather than asserts.
+  assert.deepEqual(
+    Object.keys(ACTIVE_CONTRACT).sort(),
+    ["bundleVersion", "livePromptVersion", "reportPromptVersion", "reportSchemaVersion", "rubricVersion"],
+    "five versions, and a sixth added without a migration fails here",
+  );
+  // The bounds `reportContract` enforces on a report's own bundle. A build
+  // whose active contract could not pass its own validator would refuse every
+  // report including the ones it just produced.
+  for (const [key, value] of Object.entries(ACTIVE_CONTRACT)) {
+    assert.ok(
+      Number.isSafeInteger(value) && value >= 1 && value <= 999,
+      `${key} is in the range sanitizeReport accepts`,
+    );
+  }
 });
 
 test("the window label says only what its words table gives it", () => {

--- a/tests/browser/lib.test.js
+++ b/tests/browser/lib.test.js
@@ -4,6 +4,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { read } from "./source.js";
 
 import {
   FRAMEWORKS,
@@ -26,6 +27,9 @@ import {
   orPlaceholder,
   providerUiState,
   renderValue,
+  replayTimeline,
+  responseWindowLabel,
+  responseWindows,
   sanitizeReport,
   sessionReport,
   testPayload,
@@ -868,4 +872,715 @@ test("the two frameworks stay apart and tick only what the interviewer banked", 
   // No id appears in both, or a tick in one round would light up the other.
   const ids = Object.values(FRAMEWORKS).flatMap((framework) => framework.steps.map((step) => step.id));
   assert.equal(new Set(ids).size, ids.length);
+});
+
+// The response window: the gap between the interviewer finishing a question and
+// the interviewer speaking again.
+//
+// The shapes below have one test each, because `recordAvatarState` writes only
+// on a change and an interview can stop anywhere. They are all about what the
+// function refuses to invent: a duration it cannot measure, a window it cannot
+// close, a turn nobody said, and a window in front of a question nobody asked.
+//
+// The fixtures divide in two, and the division is the point. Ones built from
+// `listening` and `speaking` alone are sequences a real recording can hold,
+// because those are the two states `src/livekit.rs` publishes. Ones containing
+// `thinking` are reachable only by a deployment that publishes it, and are here
+// to pin that the code still honors it; a suite made only of those asserted a
+// property of its own fixtures through three review rounds.
+//
+// `at` is the candidate's own browser clock throughout. Ordering is the array's,
+// which is the server's `seq` order, and `at` is read for the duration and for
+// nothing else, which is the same rule `src/recording/replay.rs` applies to its
+// own rows.
+const avatar = (at, state, responseWindow) => ({
+  kind: "avatar",
+  at,
+  payload: { state, ...(responseWindow === undefined ? {} : { responseWindow }) },
+});
+const life = (at, state) => ({ kind: "lifecycle", at, payload: { state } });
+const said = (at, speaker, text, responseWindow) => ({
+  kind: "transcript",
+  at,
+  payload: { speaker, text, ...(responseWindow === undefined ? {} : { responseWindow }) },
+});
+
+test("a response window pairs listening with the next close", () => {
+  const windows = responseWindows([
+    { kind: "editor", at: 900, payload: { code: "" } },
+    avatar(1000, "speaking"),
+    avatar(2000, "listening"),
+    said(6000, "you", "I would use a hash map"),
+    avatar(6500, "thinking"),
+    avatar(7000, "speaking"),
+  ]);
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].at, 2000);
+  assert.equal(windows[0].duration, 4500);
+  assert.deepEqual(windows[0].turn, { at: 6000, text: "I would use a hash map" });
+  // The position of the row that opened it, so the page can put the window
+  // beside the moment it happened over without re-deriving the order from `at`.
+  assert.equal(windows[0].index, 2);
+
+  // The interviewer's own lines are not the candidate's answer. A candidate turn
+  // recorded after the window closed still belongs to it, until the interviewer
+  // asks again: that is the delivery race the next test is about, and the last
+  // turn before a new question is the one that closed the old one.
+  const later = responseWindows([
+    avatar(0, "speaking"),
+    avatar(100, "listening", 0),
+    said(1000, "interviewer", "and the complexity?"),
+    said(2000, "you", "linear"),
+    avatar(3000, "thinking"),
+    said(4000, "you", "well, amortized", 0),
+  ]);
+  assert.deepEqual(later[0].turn, { at: 4000, text: "well, amortized" });
+
+  // The last candidate turn inside the window, not the first: a turn is
+  // recorded when its stream closes, so the one that closed the window is the
+  // last to land before the interviewer thought.
+  const twice = responseWindows([
+    avatar(0, "speaking"),
+    avatar(100, "listening"),
+    said(1000, "you", "hmm"),
+    said(2000, "you", "a hash map"),
+    avatar(3000, "thinking"),
+  ]);
+  assert.equal(twice[0].turn.text, "a hash map");
+});
+
+test("a response window that never closed keeps a null duration", () => {
+  // The interview stopped mid-answer. The window is still worth showing, so it
+  // is returned rather than dropped, and the duration is absent rather than
+  // measured to the end of the array.
+  const windows = responseWindows([
+    avatar(0, "speaking"),
+    avatar(1000, "listening", 0),
+    said(4000, "you", "let me think"),
+  ]);
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].at, 1000);
+  assert.equal(windows[0].duration, null);
+  assert.deepEqual(windows[0].turn, { at: 4000, text: "let me think" });
+
+  // And an interview with no `avatar` rows at all has no windows rather than
+  // one that spans it.
+  assert.deepEqual(responseWindows([said(1, "you", "hello")]), []);
+  assert.deepEqual(responseWindows([]), []);
+  assert.deepEqual(responseWindows(undefined), []);
+});
+
+test("a response window holding no candidate turn is kept with a null turn", () => {
+  // The interviewer asked, waited, and asked again. That is exactly the shape
+  // worth seeing, so the window survives with nothing in it rather than being
+  // dropped for being empty.
+  const windows = responseWindows([
+    avatar(0, "speaking"),
+    avatar(1000, "listening"),
+    avatar(9000, "thinking"),
+    avatar(9500, "speaking"),
+    avatar(10_000, "listening", 1),
+    said(12_000, "you", "sorry, could you repeat that", 1),
+    avatar(13_000, "thinking"),
+  ]);
+  assert.equal(windows.length, 2);
+  assert.equal(windows[0].duration, 8000);
+  assert.equal(windows[0].turn, null);
+  assert.equal(windows[1].duration, 3000);
+  assert.equal(windows[1].turn.text, "sorry, could you repeat that");
+
+  // A transcript before any window opened belongs to no window.
+  const early = responseWindows([
+    said(0, "you", "before anything"),
+    avatar(500, "speaking"),
+    avatar(1000, "listening"),
+    avatar(2000, "thinking"),
+  ]);
+  assert.equal(early[0].turn, null);
+});
+
+test("a re-prompt closes the unanswered window and opens its own", () => {
+  // This case was specified the other way round, as "a repeated listening starts
+  // no second window", on the reasoning that restarting the clock at the
+  // re-prompt would report the shorter of two gaps as the whole of it. That
+  // reasoning does not survive what the server publishes. `src/livekit.rs`
+  // writes only `listening` and `speaking`, so `speaking` is what closes a
+  // window; a re-prompt therefore closes the ask nobody answered and opens the
+  // one they did. Two windows, and the first shows no candidate transcript,
+  // which is the shape that case existed to make visible. Folding them into one
+  // long window would have hidden the unanswered ask inside the answered one.
+  const windows = responseWindows([
+    avatar(500, "speaking"),
+    avatar(1000, "listening"),
+    avatar(2000, "speaking"),
+    avatar(3000, "listening", 1),
+    said(4000, "you", "got it", 1),
+    avatar(5000, "speaking"),
+  ]);
+  assert.equal(windows.length, 2);
+  assert.deepEqual(
+    windows.map((span) => [span.at, span.duration, span.turn?.text ?? null]),
+    [
+      [1000, 1000, null],
+      [3000, 2000, "got it"],
+    ],
+  );
+
+  // A window that closed is closed: another close does not reopen it, and a
+  // `listening` the interviewer was not speaking before opens nothing.
+  const stray = responseWindows([
+    avatar(500, "speaking"),
+    avatar(1000, "listening", 0),
+    avatar(2000, "thinking"),
+    avatar(3000, "thinking"),
+    avatar(4000, "listening"),
+  ]);
+  assert.equal(stray.length, 1, "a listening after a thinking follows no question");
+  assert.equal(stray[0].duration, 1000);
+
+  // An `avatar` state nothing here pairs on neither opens nor closes anything.
+  assert.deepEqual(responseWindows([avatar(0, "initializing"), avatar(1, "speaking")]), []);
+});
+
+test("a thinking before its listening measures nothing rather than a negative", () => {
+  // A `thinking` stamped before the `listening` it closes is not a negative
+  // duration. It is a clock that moved, and there is nothing a reader can be
+  // told about a negative second.
+  const backwards = responseWindows([
+    avatar(0, "speaking"),
+    avatar(9000, "listening"),
+    avatar(4000, "thinking"),
+  ]);
+  assert.equal(backwards.length, 1);
+  assert.equal(backwards[0].duration, null);
+
+  // Zero is a measurement and stays one.
+  assert.equal(
+    responseWindows([avatar(0, "speaking"), avatar(9000, "listening"), avatar(9000, "thinking")])[0]
+      .duration,
+    0,
+  );
+
+  // A payload with no clock at all measures nothing rather than NaN.
+  const clockless = responseWindows([
+    { kind: "avatar", at: 0, payload: { state: "speaking" } },
+    { kind: "avatar", payload: { state: "listening" } },
+    { kind: "avatar", at: 5000, payload: { state: "thinking" } },
+  ]);
+  assert.equal(clockless[0].duration, null);
+});
+
+test("a replay body that is not a list is an empty replay, not a throw", () => {
+  // The page reads `body.events || []` off a parsed JSON body on the path where
+  // the response was already `ok`. A string or an object there used to reach
+  // `.entries()` and throw, which paints a blank panel where the page had a
+  // sentence ready to explain itself.
+  for (const nonsense of [undefined, null, "events", 5, {}, { events: [] }]) {
+    assert.deepEqual(responseWindows(nonsense), [], JSON.stringify(nonsense));
+    assert.deepEqual(replayTimeline(nonsense), { moments: [], windows: [], timeline: [] });
+  }
+
+  // A transcript with nothing in it is not a turn. Our own producer guards on
+  // `text.trim()` and cannot emit one, which is exactly why nothing downstream
+  // would notice if a later one did: the window would silently lose the note
+  // saying it holds no transcript.
+  for (const empty of [{}, { speaker: "you" }, { speaker: "you", text: "   " }, { speaker: "you", text: { a: 1 } }]) {
+    const windows = responseWindows([
+      avatar(0, "speaking"),
+      avatar(100, "listening"),
+      { kind: "transcript", at: 1000, payload: empty },
+      avatar(2000, "thinking"),
+    ]);
+    assert.equal(windows[0].turn, null, JSON.stringify(empty));
+  }
+
+  // A null element is skipped rather than read.
+  assert.equal(
+    responseWindows([null, avatar(0, "speaking"), avatar(1, "listening"), undefined]).length,
+    1,
+  );
+});
+
+test("the replay timeline interleaves windows with the moments without joining them", () => {
+  // The whole reason the windows are a separate list: `data-moment` indexes
+  // `moments` and the page rebuilds the code and the test result by scanning its
+  // prefix, so a window mixed into that array would shift every index and then
+  // be scanned over as neither an editor nor a test snapshot.
+  const editor = (at, code) => ({ kind: "editor", at, payload: { code } });
+  const tests = (at, passed) => ({ kind: "tests", at, payload: { passed, total: 5 } });
+  const events = [
+    avatar(-100, "speaking"),
+    avatar(0, "listening"),
+    editor(100, "first"),
+    said(200, "you", "a hash map"),
+    avatar(300, "thinking"),
+    tests(400, 3),
+    avatar(500, "speaking"),
+    avatar(600, "listening"),
+    editor(700, "second"),
+  ];
+  const { moments, windows, timeline } = replayTimeline(events);
+
+  assert.deepEqual(
+    moments.map((moment) => moment.kind),
+    ["editor", "tests", "editor"],
+    "moments are editor and tests snapshots, and nothing else",
+  );
+  assert.equal(windows.length, 2);
+
+  // Interleaved in seq order, not appended after each other. Both an "append
+  // every window at the end" assembly and a "prepend them" one produce a
+  // different list here, which source-text assertions could not tell apart.
+  assert.deepEqual(timeline, [
+    { window: 0 },
+    { moment: 0 },
+    { moment: 1 },
+    { window: 1 },
+    { moment: 2 },
+  ]);
+
+  // A replay with no avatar rows has no windows, so the page has nothing to
+  // explain and hides the paragraph explaining it.
+  assert.deepEqual(replayTimeline([editor(0, "only")]).windows, []);
+});
+
+test("the window label says only what its words table gives it", () => {
+  // The panel may not accuse, and this is the form of that rule a test can
+  // observe. Sentinels rather than the real copy: anything in the output that
+  // the table did not put there is prose the renderer invented, whether it came
+  // from a literal, a helper, a computed lookup, or a second table declared
+  // beside the first. All four were written during review and all four passed a
+  // version of this check that read the renderer's source instead.
+  // One sentinel per key, read off `WINDOW_WORDS` in web/replay.js rather than
+  // listed here, so a key added there without a sentinel fails instead of going
+  // unchecked. Listing them was the earlier version, and the comment claimed
+  // this while the file did the other thing.
+  const table = read("web/replay.js");
+  const keys = [
+    ...table
+      .slice(table.indexOf("const WINDOW_WORDS = {"), table.indexOf("\n};", table.indexOf("const WINDOW_WORDS = {")))
+      .matchAll(/^\s{2}(\w+):/gm),
+  ].map((match) => match[1]);
+  assert.ok(keys.length >= 5, `only ${keys.length} words found in WINDOW_WORDS`);
+  const sentinels = Object.fromEntries(keys.map((key, index) => [key, `Q${index}q`]));
+  // Every field of a window crossed with every other, rather than the cells
+  // somebody thought of. Enumerating by hand missed the no-duration-with-a-turn
+  // cell once, and then missed `at` entirely: every span was `at: 0`, so a
+  // branch on `span.at > 0`, which is true of every window in every real
+  // recording, put a label on the page that this test could not see. A product
+  // is the only version of "all of them" that stays true when a field is added.
+  const spans = [];
+  for (const at of [0, 1_770_000_000_000]) {
+    for (const duration of [null, 0, 4200, 12_345_678]) {
+      for (const turn of [null, { at: at + 1, text: "a hash map" }]) {
+        for (const isPaused of [false, true]) {
+          for (const matched of [false, true]) {
+            spans.push({ at, duration, turn, paused: isPaused, matched });
+          }
+        }
+      }
+    }
+  }
+  for (const span of spans) {
+    const parts = responseWindowLabel(span, sentinels);
+    let rest = parts.join("|");
+    for (const value of Object.values(sentinels)) rest = rest.split(value).join("");
+    // What survives is a clock reading and the separators between it, which is
+    // the only thing in the label that is not a word somebody chose. Stricter
+    // than "no letters", and implying it.
+    assert.doesNotMatch(
+      rest,
+      /[^0-9.|]/,
+      `the label said something its words table did not give it: ${parts.join("|")}`,
+    );
+  }
+
+  // The span's own shape, frozen. The fixtures above are built by hand, so a
+  // field added to a window in `responseWindows` and read in
+  // `responseWindowLabel` is a field this test never sets and never sees: a
+  // `verdict` written that way put prose on every long window and passed the
+  // whole suite. Keys read off a real window rather than listed, so adding one
+  // fails here and is a decision somebody makes.
+  // The union over every shape a window comes in, not one sample. Freezing the
+  // keys of a normally-closed window left a field that only a paused or an
+  // unclosed one carries invisible, which is the same "no fixture sets it" hole
+  // one layer up.
+  const shapes = [
+    [avatar(0, "speaking"), avatar(1000, "listening"), said(2000, "you", "x"), avatar(3000, "speaking")],
+    [avatar(0, "speaking"), avatar(1000, "listening")],
+    [
+      avatar(0, "speaking"),
+      life(500, "paused"),
+      avatar(1000, "listening"),
+      avatar(9000, "speaking"),
+    ],
+    [avatar(0, "speaking"), avatar(9000, "listening"), avatar(1000, "speaking")],
+  ];
+  const real = shapes.flatMap((rows) => responseWindows(rows));
+  assert.ok(real.length >= shapes.length, "every shape produced a window to read keys off");
+  assert.deepEqual(
+    [...new Set(real.flatMap((span) => Object.keys(span)))].sort(),
+    ["at", "duration", "index", "matched", "paused", "turn"],
+    "a field added to a window is one the sentinels above never set and never see",
+  );
+  assert.deepEqual(
+    Object.keys(spans[0]).sort().filter((key) => key !== "index"),
+    Object.keys(real[0]).sort().filter((key) => key !== "index"),
+    "and the sentinel spans carry every field a real one does",
+  );
+
+  // Read by name below rather than by position, so the assertions survive the
+  // words table being reordered.
+  // Each optional piece appears exactly when its case holds, so a window is not
+  // silently missing the one caveat it needed.
+  const label = (span) => responseWindowLabel(span, sentinels);
+  const turn = { at: 1, text: "a hash map" };
+  assert.deepEqual(label({ at: 1, duration: 4200, turn }), [sentinels.label, `4.2${sentinels.seconds}`]);
+  assert.deepEqual(label({ at: 1, duration: 0, turn }), [sentinels.label, `0.0${sentinels.seconds}`]);
+  assert.deepEqual(
+    label({ at: 1, duration: null, turn: null, matched: true }),
+    [sentinels.label, sentinels.unmeasured, sentinels.noTurn],
+  );
+  assert.deepEqual(label({ at: 1, duration: null, turn }), [sentinels.label, sentinels.unmeasured]);
+  assert.deepEqual(
+    label({ at: 1, duration: 300_000, turn: null, paused: true, matched: true }),
+    [sentinels.label, `300.0${sentinels.seconds}`, sentinels.paused, sentinels.noTurn],
+    "a paused window says so before it says nothing was recorded",
+  );
+
+  // The two shapes an empty window comes in are two different sentences, and
+  // which one is chosen is the whole of the fix: a window a transcript could
+  // have named and did not is a fact about the interview, and a window nothing
+  // could have named is a fact about the recording. Asserted as a pair, because
+  // a renderer that reached for one word for both would pass either half alone.
+  assert.deepEqual(
+    label({ at: 1, duration: 4200, turn: null, matched: true }),
+    [sentinels.label, `4.2${sentinels.seconds}`, sentinels.noTurn],
+    "a window that could be named and was not says nothing was recorded",
+  );
+  assert.deepEqual(
+    label({ at: 1, duration: 4200, turn: null, matched: false }),
+    [sentinels.label, `4.2${sentinels.seconds}`, sentinels.unmatchedTurn],
+    "a window nothing could have named says that instead",
+  );
+});
+
+test("a turn recorded after the interviewer moved on still closes its window", () => {
+  // Two independent deliveries. `recordAvatarState` fires on the agent's state
+  // attribute and `consumeTranscript` records the turn only when its text stream
+  // finishes, so the row saying what the candidate said routinely lands after
+  // the row saying the interviewer had moved on. Attributing only inside the
+  // window printed "no transcript in this window" beside ordinary answered
+  // questions, which is the one wrong statement this panel can make: every other
+  // caveat is a number withheld, and that one is a claim about the record.
+  const windows = responseWindows([
+    avatar(500, "speaking"),
+    avatar(1000, "listening", 0),
+    avatar(4000, "thinking"),
+    said(4200, "you", "a hash map", 0),
+    avatar(4500, "speaking"),
+  ]);
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].duration, 3000, "the duration is still the two avatar rows");
+  assert.equal(windows[0].turn.text, "a hash map");
+
+  // That a turn cannot reach back past a question the interviewer has since
+  // asked is the same fixture as "a response window holding no candidate turn is
+  // kept with a null turn" above, and is asserted there.
+
+  // The interviewer's own line after a window closed is still not the
+  // candidate's.
+  const theirs = responseWindows([
+    avatar(0, "speaking"),
+    avatar(100, "listening"),
+    avatar(1000, "thinking"),
+    said(2000, "interviewer", "let me rephrase"),
+  ]);
+  assert.equal(theirs[0].turn, null);
+
+  const legacy = responseWindows([
+    avatar(0, "speaking"),
+    avatar(100, "listening"),
+    avatar(1000, "thinking"),
+    said(2000, "you", "goodbye"),
+  ]);
+  assert.equal(legacy[0].turn, null, "a markerless row after the close is ambiguous");
+});
+
+test("a delayed turn is matched by when its stream started", () => {
+  const events = [
+    avatar(0, "speaking"),
+    avatar(1000, "listening", 0),
+    avatar(5000, "speaking"),
+    avatar(6000, "listening", 1),
+    said(7000, "you", "the first answer", 0),
+    avatar(8000, "speaking"),
+  ];
+  assert.deepEqual(
+    responseWindows(events).map((span) => span.turn?.text ?? null),
+    ["the first answer", null],
+  );
+
+  events[4] = { kind: "transcript", at: 7000, payload: { speaker: "you", text: "legacy" } };
+  assert.deepEqual(
+    responseWindows(events).map((span) => span.turn?.text ?? null),
+    [null, null],
+    "an old multi-window replay does not guess which question a late row answered",
+  );
+
+  events[4] = said(7000, "you", "the first answer", 0);
+  events.splice(0, 2);
+  assert.deepEqual(
+    responseWindows(events).map((span) => span.turn?.text ?? null),
+    [null],
+    "a missing earlier window cannot shift its transcript onto the next visible one",
+  );
+});
+
+test("windows are computed from the two states the server actually publishes", () => {
+  // The whole feature rested on a state nothing emits. `src/livekit.rs` declares
+  // `listening` and `speaking` and every `set_agent_state` call writes one of
+  // them; `thinking` is a label in the browser and a pose on the avatar and is
+  // never published. A window that closed only on `thinking` never closed, so a
+  // real interview drew exactly one row reading "duration not recorded" however
+  // many questions it contained. This fixture is the sequence a real recording
+  // holds, and it must not contain a `thinking` row.
+  const recorded = [
+    avatar(0, "listening"),
+    avatar(1000, "speaking"),
+    avatar(20_000, "listening"),
+    said(45_000, "you", "linear"),
+    avatar(47_000, "speaking"),
+    avatar(60_000, "listening", 1),
+    said(70_000, "you", "a hash map", 1),
+    avatar(72_000, "speaking"),
+  ];
+  // Read out of the server rather than asserted of the fixture. A check that
+  // `recorded` holds no `thinking` cannot fail from any change to
+  // `src/livekit.rs`, so it would not have caught the bug it was written after:
+  // the browser paired on a state the server never publishes, and every fixture
+  // in this file fed it. This is the cross-language pin `INTEGRITY_DETAIL_MAX`
+  // already uses in the other direction, and it fails the day a third state is
+  // declared without `responseWindows` being taught what it means.
+  const livekit = read("src/livekit.rs");
+  // Anchored loosely enough to catch a third state however it is declared: a
+  // pattern that only matched the exact current spelling would fail open on a
+  // `pub const`, which is the direction a pin must never fail.
+  const declared = [...livekit.matchAll(/const\s+(AGENT_STATE_\w+)\s*:\s*&str\s*=\s*"(\w+)"/g)];
+  const published = new Set(declared.map((match) => match[2]));
+  assert.deepEqual(published, new Set(["listening", "speaking"]));
+  // And nothing publishes a state that is not one of those constants. Matched
+  // across newlines and past a trailing comma, because rustfmt wraps a long call
+  // and this file already contains one wrapped that way: a pattern requiring the
+  // close paren on the same line matched no wrapped call at all, so a fourth
+  // state added in the shape the formatter produces failed this open.
+  const publishes = [...livekit.matchAll(/(?<!fn )set_agent_state\(([^{};]*?)\)\s*\.await/g)].map(
+    (match) =>
+      match[1]
+        .split(",")
+        .map((argument) => argument.trim())
+        .filter(Boolean)
+        .at(-1),
+  );
+  assert.ok(publishes.length >= declared.length, `only ${publishes.length} publishes found`);
+  assert.deepEqual(
+    new Set(publishes),
+    new Set(declared.map((match) => match[1])),
+    "every publish names one of the declared constants",
+  );
+  for (const state of published) {
+    assert.ok(
+      recorded.some((event) => event.payload?.state === state),
+      `the fixture has to exercise ${state}, which is a state the server sends`,
+    );
+  }
+  assert.ok(
+    !recorded.some((event) => !published.has(event.payload?.state ?? "listening")),
+    "and only states the server sends, which is the property this test exists for",
+  );
+  assert.deepEqual(
+    responseWindows(recorded).map((span) => [span.at, span.duration, span.turn?.text ?? null]),
+    [
+      [20_000, 27_000, "linear"],
+      [60_000, 12_000, "a hash map"],
+    ],
+    "one window per question, each with a duration and the answer that closed it",
+  );
+
+  // `thinking` still closes a window, for a deployment that publishes it, and
+  // closes it earlier than the reply would: the difference is the model round
+  // trip that closing on `speaking` puts inside the number.
+  assert.equal(
+    responseWindows([
+      avatar(0, "speaking"),
+      avatar(1000, "listening"),
+      avatar(3000, "thinking"),
+      avatar(5000, "speaking"),
+    ])[0].duration,
+    2000,
+    "whichever close comes first is the one that counts",
+  );
+});
+
+test("no window opens before the interviewer has been heard speaking", () => {
+  // `updateAgentState` in web/interview.js runs on first sight of the agent
+  // participant and records `published || "listening"`, so the first `avatar`
+  // row of almost every real interview is a `listening` written before a
+  // question exists. Opened on, it swallowed the greeting and the first
+  // question and reported the interviewer's own speech as elapsed response
+  // time, which is the one number on this panel a reviewer would act on.
+  const greeting = responseWindows([
+    avatar(0, "listening"),
+    avatar(1000, "speaking"),
+    avatar(60_000, "listening"),
+    said(64_000, "you", "a hash map"),
+    avatar(65_000, "thinking"),
+  ]);
+  assert.equal(greeting.length, 1, "the connect-time listening is not a question ending");
+  assert.equal(greeting[0].at, 60_000);
+  assert.equal(greeting[0].duration, 5000, "and the greeting is not part of the answer");
+
+  // An interviewer that never speaks leaves nothing to measure a gap after,
+  // however many states it publishes.
+  assert.deepEqual(responseWindows([avatar(0, "listening")]), []);
+  assert.deepEqual(
+    responseWindows([avatar(0, "listening"), avatar(1, "thinking"), avatar(2, "listening")]),
+    [],
+  );
+
+  // The previous row, not a latch. An earlier version remembered only that the
+  // interviewer had spoken at some point, which admitted the `listening` after a
+  // `thinking`: the interviewer thought, said nothing, and went back to waiting,
+  // and a window opened in front of a question nobody asked. These two sequences
+  // differ only in that row and have to differ in their answer, which is exactly
+  // what a latch cannot do and why one is not used.
+  const asked = responseWindows([
+    avatar(0, "speaking"),
+    avatar(100, "listening"),
+    avatar(200, "thinking"),
+    avatar(300, "speaking"),
+    avatar(400, "listening"),
+    avatar(500, "speaking"),
+  ]);
+  assert.deepEqual(
+    asked.map((span) => [span.at, span.duration]),
+    [
+      [100, 100],
+      [400, 100],
+    ],
+    "each listening follows a speaking, so each is a question ending",
+  );
+  const unasked = responseWindows([
+    avatar(0, "speaking"),
+    avatar(100, "listening"),
+    avatar(200, "thinking"),
+    avatar(400, "listening"),
+    avatar(500, "speaking"),
+  ]);
+  assert.deepEqual(
+    unasked.map((span) => [span.at, span.duration]),
+    [[100, 100]],
+    "and the one that follows a thinking is not",
+  );
+});
+
+test("a window the interview was paused during says so", () => {
+  // `applyPause` in web/interview.js records a `lifecycle` paused row, and its
+  // own comment says why: so the gap is visible rather than passing as thinking
+  // time. The response window is exactly the thing it would otherwise pass as,
+  // and a five-minute break rendered as a five-minute silence is the one reading
+  // on this panel that misleads a reviewer outright.
+  // Paused during the candidate's own turn, which is the ordinary case: no
+  // `avatar` row is written at all and the open window simply runs through it.
+  const during = responseWindows([
+    avatar(0, "speaking"),
+    avatar(100, "listening"),
+    life(1000, "paused"),
+    life(200_000, "resumed"),
+    avatar(201_000, "speaking"),
+  ]);
+  assert.equal(during.length, 1);
+  assert.equal(during[0].paused, true);
+  assert.equal(during[0].duration, 200_900, "the duration is not shortened, it is explained");
+
+  // Paused while the interviewer is mid-turn: src/livekit.rs publishes
+  // `listening`, so the window this opens is the break itself. The two rows are
+  // written by two different sides and either can land first, so both orders
+  // have to mark it.
+  for (const order of [
+    [life(1000, "paused"), avatar(1100, "listening")],
+    [avatar(1000, "listening"), life(1100, "paused")],
+  ]) {
+    const windows = responseWindows([avatar(0, "speaking"), ...order, avatar(300_000, "speaking")]);
+    assert.equal(windows.length, 1);
+    assert.equal(windows[0].paused, true, JSON.stringify(order.map((row) => row.kind)));
+  }
+
+  // A window after the resume is not marked, or every window after the first
+  // break would carry it.
+  const after = responseWindows([
+    avatar(0, "speaking"),
+    avatar(100, "listening"),
+    life(1000, "paused"),
+    life(2000, "resumed"),
+    avatar(3000, "speaking"),
+    avatar(4000, "listening"),
+    avatar(5000, "speaking"),
+  ]);
+  assert.deepEqual(
+    after.map((span) => span.paused),
+    [true, false],
+  );
+
+  // A lifecycle row that is not a pause changes nothing, and there are several:
+  // started, round_transition, rounds_final, ended.
+  const other = responseWindows([
+    avatar(0, "speaking"),
+    avatar(100, "listening"),
+    life(1000, "round_transition"),
+    avatar(2000, "speaking"),
+  ]);
+  assert.equal(other[0].paused, false);
+});
+
+test("the interview ending is not a question, and a lost resume is not the rest of the interview", () => {
+  // `send_wrap_up_and_wait` in src/livekit.rs finishes by setting `listening`
+  // again, and the browser keeps recording past `ended` to write the final
+  // rounds. Without stopping at `ended`, every timed-out interview finished with
+  // a window opened by the goodbye and closed by nothing, rendered as an
+  // interview that stopped mid-answer.
+  const wrapped = responseWindows([
+    avatar(0, "speaking"),
+    avatar(1000, "listening"),
+    avatar(2000, "speaking"),
+    life(3000, "ended"),
+    avatar(4000, "speaking"),
+    avatar(5000, "listening"),
+    life(6000, "rounds_final"),
+  ]);
+  assert.deepEqual(
+    wrapped.map((span) => [span.at, span.duration]),
+    [[1000, 1000]],
+    "the goodbye opens nothing and the rows after it are not read",
+  );
+
+  // A dropped batch can take the `resumed` row with it. Marking every window
+  // after it as paused would spread one lost row across the whole interview, and
+  // that mark is the only affirmative claim this panel makes. The interviewer
+  // speaking is what bounds it: `watch_prompt` returns nothing while paused and
+  // `handle_gemini_event` drops every audio event then, so there is no path from
+  // a paused interview to a `speaking` row.
+  const lost = responseWindows([
+    avatar(0, "speaking"),
+    avatar(10_000, "listening"),
+    life(11_000, "paused"),
+    avatar(61_000, "speaking"),
+    avatar(70_000, "listening"),
+    avatar(80_000, "speaking"),
+  ]);
+  assert.deepEqual(
+    lost.map((span) => span.paused),
+    [true, false],
+    "the window that saw the pause is marked and the interview after it is not",
+  );
 });

--- a/tests/browser/lobby-render.test.js
+++ b/tests/browser/lobby-render.test.js
@@ -1,0 +1,68 @@
+// The lobby page, driven rather than read.
+//
+// `web/app.js` is 676 lines, exports nothing, and reads its nodes at module
+// scope, so until this file the only things that ran it were a browser and
+// `./scripts/browser-check.sh`, which is optional and skipped on a checkout
+// with no Chromium. Everything else about it was a check on its source text.
+//
+// What this adds is small and is the half that source reading cannot do: the
+// page is imported, so a module-scope throw fails a `node --test` run, and what
+// it wrote into the document is read back, so the copy a signed-out visitor
+// actually sees is pinned to strings somebody chose.
+//
+// It is here as much to hold `tests/browser/dom.js` to being general as to hold
+// the lobby. That stub was written for the replay page and claimed to be
+// page-agnostic; a second caller is what turns the claim into a fact, and it
+// found two document-level gaps when it arrived.
+//
+// The boundary is in `dom.js` and is not repeated here beyond what this file
+// depends on: `document.querySelectorAll` answers ids and nothing else, so the
+// problem cards, the difficulty radios, the duration buttons and the loop
+// buttons are all absent, and this drives the page that is left. What that page
+// still proves is the import, the signed-out account state, and the branch the
+// progress panel takes when it cannot read anything.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { read } from "./source.js";
+import { installDocument } from "./dom.js";
+
+const markup = read("web/index.html");
+const dom = installDocument(markup);
+
+// Imported once, at the top, because ESM caches by URL and the page does its
+// work while it loads. Every test below reads the same rendered document.
+await import("/app.js");
+
+/// What the page may say to a signed-out visitor whose device has no history.
+///
+/// Both of those are the stub's doing and neither is contrived: `installDocument`
+/// refuses the fetch the page starts at import, so the session lookup fails, and
+/// plain `node` has no `localStorage`, so the saved-progress read fails too.
+/// That is the worst case a real visitor can also reach, on a first visit with
+/// the network down, and it is the one state this file can produce without a
+/// browser.
+const SIGNED_OUT = {
+  "account-status": "Signed out",
+  start: "Start interview",
+  "progress-summary": "Could not load progress saved on this device.",
+};
+
+test("the lobby page loads outside a browser and says what it was given", () => {
+  for (const [id, expected] of Object.entries(SIGNED_OUT)) {
+    assert.deepEqual(dom.node(id).spoken(), [expected], `#${id}`);
+  }
+});
+
+test("no other panel of the lobby speaks before anything has loaded", () => {
+  // An allowlist over the whole page rather than a check on three nodes. A
+  // panel that starts populated is a panel showing a visitor something that is
+  // not about them yet, and the failure this catches is a default that looks
+  // like data: the progress panels and the grounding statuses are the ones with
+  // somewhere to put a sentence nobody asked for.
+  const spoke = [];
+  for (const [, id] of markup.matchAll(/id="([^"]+)"/g)) {
+    const node = dom.node(id);
+    if (node && node.spoken().length && !(id in SIGNED_OUT)) spoke.push(id);
+  }
+  assert.deepEqual(spoke, [], "a panel put words on the lobby before it had any");
+});

--- a/tests/browser/recording-template.test.js
+++ b/tests/browser/recording-template.test.js
@@ -18,6 +18,7 @@ const interview = withoutInterviewComments(interviewSource());
 const page = read("web/recording/index.html");
 const script = read("web/recording/recording.js");
 const styles = read("web/recording/recording.css");
+const replayFeed = await import("../../web/replay-feed.js");
 
 const withoutComments = (source) => source.replace(/^\s*\/\/.*$/gm, "");
 function withoutInterviewComments(source) {
@@ -350,8 +351,8 @@ test("replay-producer envelope", () => {
 test("replay-producer transcript", () => {
   const body = withoutComments(functionBody(interview, "consumeTranscript"));
   assert.ok(
-    body.includes('recordReplay("transcript", { speaker, text: text.trim() });'),
-    "the transcript is recorded as spoken turns",
+    body.includes('recordReplay("transcript", { speaker, text: text.trim(), responseWindow });'),
+    "the transcript is recorded with the window active when its stream started",
   );
   const emits = body.match(/recordReplay\("transcript"/g) || [];
   assert.equal(emits.length, 1, "one emit, so a second inside the chunk loop cannot hide behind this one");
@@ -440,9 +441,9 @@ test("replay-producer stage", () => {
 test("replay-producer avatar", () => {
   assert.ok(
     withoutComments(functionBody(interview, "recordAvatarState")).includes(
-      'recordReplay("avatar", { state: value });',
+      'recordReplay("avatar", { state: value, responseWindow: opensWindow ? replayWindow : null });',
     ),
-    "the interviewer's state is recorded",
+    "the interviewer's state and each opening window are recorded together",
   );
   assert.ok(
     withoutComments(functionBody(interview, "recordAvatarState")).includes(
@@ -450,6 +451,24 @@ test("replay-producer avatar", () => {
     ),
     "on the change, not on the participant event that happened to carry it",
   );
+});
+
+test("replay transcripts capture only the open response window", () => {
+  assert.equal(replayFeed.responseWindowIndex(), null);
+  replayFeed.recordAvatarState("listening");
+  replayFeed.recordAvatarState("speaking");
+  replayFeed.recordAvatarState("listening");
+  assert.equal(replayFeed.responseWindowIndex(), 0);
+  replayFeed.recordAvatarState("listening");
+  assert.equal(replayFeed.responseWindowIndex(), 0, "a repeated state opens no window");
+  replayFeed.recordAvatarState("speaking");
+  assert.equal(replayFeed.responseWindowIndex(), null, "interviewer speech closes the window");
+  replayFeed.recordAvatarState("listening");
+  assert.equal(replayFeed.responseWindowIndex(), 1);
+  replayFeed.recordAvatarState("thinking");
+  assert.equal(replayFeed.responseWindowIndex(), null);
+  replayFeed.recordAvatarState("listening");
+  assert.equal(replayFeed.responseWindowIndex(), null, "listening after thinking opens no window");
 });
 
 test("replay-producer lifecycle", () => {

--- a/tests/browser/replay-render.test.js
+++ b/tests/browser/replay-render.test.js
@@ -48,7 +48,7 @@ import { installDocument, importWithout } from "./dom.js";
 const dom = installDocument(read("web/replay.html"));
 const { render, momentTime } = await import("/replay.js");
 const { reportMarkup } = await import("/render.js");
-const { sanitizeReport, frameworkPhases } = await import("/lib.js");
+const { sanitizeReport, frameworkPhases, ACTIVE_CONTRACT } = await import("/lib.js");
 
 /// Every value the server supplies, as a token nothing else could produce. A
 /// rendered string is then either first-party copy, a sentinel, or a clock.
@@ -399,15 +399,7 @@ test("the report card this page renders names no finding either", () => {
     // active one or the card says the report is unsupported instead, so both
     // shapes are here: they render different sentences.
     { mode: "practice", interviewLoop: "coding_only" },
-    {
-      interviewContract: {
-        bundleVersion: 4,
-        livePromptVersion: 1,
-        reportPromptVersion: 4,
-        reportSchemaVersion: 1,
-        rubricVersion: 1,
-      },
-    },
+    { interviewContract: { ...ACTIVE_CONTRACT } },
     { interviewContract: { bundleVersion: 1 } },
     {
       // Every phase, or `sanitizeReport` drops the assessment and the

--- a/tests/browser/replay-render.test.js
+++ b/tests/browser/replay-render.test.js
@@ -1,0 +1,619 @@
+// Run with: node --test tests/browser/replay-render.test.js
+//
+// What the replay page actually says, read off the render rather than off the
+// source.
+//
+// Every other check on this page reads its text. That is how a dozen ways to put
+// an accusation on it were each closed one at a time: a guard that names files,
+// functions or variables is a guard somebody writes another around, and the page
+// renders through five of them. This drives the render with sentinels in every
+// value the server supplies and reads what comes out, which has no such edge.
+//
+// What it is: a tripwire over the ways a person adds a label without meaning to
+// hide it. It reads the panels this page draws into, after every button has been
+// pressed, over replays covering every shape a window comes in; it reads text,
+// the attributes a browser speaks, whatever went in through a markup property,
+// and the dataset, because a stylesheet can draw that. It reads the stylesheet
+// separately, because no stub applies one, and the report card's vocabulary
+// across every section that card can draw, because that renders here too.
+//
+// What it is not: a proof. Three commits in a row claimed a word this page
+// invents had nowhere left to hide, and each time a reviewer found more places,
+// so the claim is retired rather than restated. Text can reach a reader
+// through a mechanism no stub models, and the known gaps are written down so the
+// next reader inherits them instead of rediscovering them:
+//
+//  - `select`, `loadEvents` and `loadReport` are never called, and `loadList`
+//    runs once at import but only down its failure branch, because the `fetch`
+//    installed here refuses everything. Driving their success paths needs a stub
+//    with an ordering seam instead. The copy the first three write is held by
+//    the literal allowlist in `tests/browser/history.test.js`, which is a source
+//    check; what `loadReport` writes is the report card, held by the vocabulary
+//    check below, because those words are the report renderer's rather than
+//    this page's, and some of them are `web/lib.js`'s.
+//  - A source check reads string literals. A regex literal stringified, or a
+//    value assembled from character codes, is not one.
+//  - `document.title`, and anything else written to the document rather than to
+//    a node, is outside what this stub models.
+//
+// Integrity features produce evidence for human review, not a claim that the
+// candidate cheated. That is the rule this file exists to make observable, and
+// the list above is what "observable" does not stretch to.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { captures, read } from "./source.js";
+import { installDocument, importWithout } from "./dom.js";
+
+const dom = installDocument(read("web/replay.html"));
+const { render, momentTime } = await import("/replay.js");
+const { reportMarkup } = await import("/render.js");
+const { sanitizeReport, frameworkPhases } = await import("/lib.js");
+
+/// Every value the server supplies, as a token nothing else could produce. A
+/// rendered string is then either first-party copy, a sentinel, or a clock.
+const S = {
+  code: "Sxcode",
+  language: "Sxlang",
+  speaker: "Sxwho",
+  text: "Sxsaid",
+};
+
+/// `responseWindow` is what the producer stamps on the row that opens a window,
+/// and on the transcript row whose stream started inside one. Omitting it is not
+/// a shortcut here: it is the shape a recording made before that stamping has,
+/// and the page says something different about those, so both are fixtures.
+const avatar = (at, state, responseWindow) => ({
+  kind: "avatar",
+  at,
+  payload: { state, ...(responseWindow === undefined ? {} : { responseWindow }) },
+});
+const life = (at, state) => ({ kind: "lifecycle", at, payload: { state } });
+const editor = (at) => ({ kind: "editor", at, payload: { code: S.code, language: S.language } });
+const tests = (at) => ({ kind: "tests", at, payload: { passed: 3, total: 5 } });
+const said = (at, responseWindow) => ({
+  kind: "transcript",
+  at,
+  payload: {
+    speaker: S.speaker,
+    text: S.text,
+    ...(responseWindow === undefined ? {} : { responseWindow }),
+  },
+});
+const stage = (at, mode) => ({ kind: "stage", at, payload: { mode } });
+
+const BASE = 1_770_000_000_000;
+
+/// One question asked and answered: the interviewer speaking, stopping, and
+/// speaking again. Four of the replays below are this and nothing else, differing
+/// only in when the two ends fall.
+const question = (opens, closes, index = 0) => [
+  avatar(opens - 1000, "speaking"),
+  avatar(opens, "listening", index),
+  avatar(closes, "speaking"),
+];
+
+/// Every shape a window comes in, so a label that only fires on one of them is
+/// still rendered at least once. Branching on a value no fixture sets is the
+/// hole this matrix exists to have no room for.
+const REPLAYS = {
+  "a closed window with an answer": [
+    stage(BASE, 0),
+    avatar(BASE, "speaking"),
+    editor(BASE + 500),
+    avatar(BASE + 1000, "listening", 0),
+    said(BASE + 4000, 0),
+    avatar(BASE + 5000, "speaking"),
+    tests(BASE + 6000),
+  ],
+  "a closed window with no answer": question(BASE + 1000, BASE + 40_000),
+  // The same window, from a recording made before the producer stamped its
+  // turns. Two of them, because one open window is the single shape a turn can
+  // still be placed in without guessing, so a one-window fixture would render
+  // the answered case and never reach the sentence this exists for.
+  "windows from before turns were stamped": [
+    avatar(BASE, "speaking"),
+    avatar(BASE + 1000, "listening"),
+    said(BASE + 4000),
+    avatar(BASE + 5000, "speaking"),
+    avatar(BASE + 6000, "listening"),
+    said(BASE + 9000),
+    avatar(BASE + 10_000, "speaking"),
+  ],
+  "a window that never closed": [avatar(BASE, "speaking"), avatar(BASE + 1000, "listening", 0), said(BASE + 2000, 0)],
+  "a window whose clock ran backwards": question(BASE + 9000, BASE + 4000),
+  "a window the interview was paused during": [
+    avatar(BASE, "speaking"),
+    avatar(BASE + 1000, "listening", 0),
+    life(BASE + 2000, "paused"),
+    life(BASE + 300_000, "resumed"),
+    avatar(BASE + 301_000, "speaking"),
+  ],
+  "a long window": question(BASE + 1000, BASE + 3_600_000),
+  "a window before the first snapshot": [...question(BASE + 1000, BASE + 2000), editor(BASE + 3000)],
+  "a replay with no windows at all": [editor(BASE), tests(BASE + 1000), said(BASE + 2000)],
+  // `interviewMode` compares against the string, so a number here falls to
+  // "Scored" and the fixture rendered the opposite of its own name.
+  "the practice mode a legacy report still carries": [
+    stage(BASE, "practice"),
+    avatar(BASE, "speaking"),
+  ],
+  // More than one window, and a run of them holding no transcript, which is the
+  // shape the page's own note singles out as the one worth opening. Every
+  // fixture above yields nought or one, so a label that only fires on a run had
+  // nowhere to fire and nothing to fail.
+  "a run of windows with no transcript": [
+    avatar(BASE, "speaking"),
+    ...[1, 2, 3, 4, 5].flatMap((turn) => [
+      avatar(BASE + turn * 30_000, "listening", turn - 1),
+      avatar(BASE + turn * 30_000 + 26_000, "speaking"),
+    ]),
+  ],
+  "several answered windows and an editor between them": [
+    avatar(BASE, "speaking"),
+    avatar(BASE + 1000, "listening", 0),
+    said(BASE + 4000, 0),
+    avatar(BASE + 5000, "speaking"),
+    editor(BASE + 6000),
+    avatar(BASE + 7000, "listening", 1),
+    said(BASE + 9000, 1),
+    avatar(BASE + 10_000, "speaking"),
+    tests(BASE + 11_000),
+  ],
+};
+
+/// Every word this page may put in front of a person, and nothing else.
+///
+/// Kinds and states are here because the page renders them verbatim: a moment
+/// button says `editor`, which is the event kind. They are the schema's words,
+/// not a judgement, and they are listed so that a kind renamed to something that
+/// reads as one fails here.
+const ALLOWED = [
+  // The response window panel.
+  "response window", "duration not recorded", "no candidate transcript recorded",
+  "transcript not matched to a window",
+  "interview paused during this window", "s",
+  // The moment list and the panels beside it.
+  "editor", "tests", "Code", "passing", "No test run before this point.",
+  // The interview mode a legacy replay carries.
+  "Scored", "Practice",
+  // Every value the server supplied, which this page passes through and does
+  // not author.
+  ...Object.values(S),
+];
+
+/// What is left of a rendered string once the words somebody chose, the clock,
+/// and the punctuation are taken out of it.
+/// Longest first, or the unit "s" eats the "s" out of "tests" and the word it
+/// was part of stops matching. Sorted once: it is a constant of the run.
+const ALLOWED_LONGEST_FIRST = [...ALLOWED].sort((left, right) => right.length - left.length);
+
+/// The clocks one replay holds, formatted by the page's own formatter. Memoized
+/// per replay rather than per string: `toLocaleTimeString` is the expensive part
+/// and a replay has a handful of distinct timestamps against dozens of strings.
+const clocksOf = new Map();
+function clocks(events) {
+  if (!clocksOf.has(events)) {
+    clocksOf.set(events, [...new Set(events.map((event) => event.at))].map(momentTime));
+  }
+  return clocksOf.get(events);
+}
+
+function unaccountedFor(spoken, events) {
+  let rest = spoken;
+  // The clock first, taken from the page's own formatter for the timestamps this
+  // replay holds. A regex for it assumed an English locale: under `zh_TW` the
+  // same clock reads with a Chinese meridiem and under `ar-EG` with Arabic-Indic
+  // digits, and both failed a test that is not about locales.
+  for (const clock of clocks(events)) rest = rest.split(clock).join(" ");
+  for (const word of ALLOWED_LONGEST_FIRST) rest = rest.split(word).join(" ");
+  return rest.replace(/[\s\d.,:;/·|-]/g, "");
+}
+
+test("the replay page says only the words somebody chose", () => {
+  // Every panel this page draws words into, the transcript included. Excluding
+  // it on the grounds that it only renders the server's words was a claim about
+  // the source, which is the kind of claim this file exists to stop making; the
+  // sentinels make it cost nothing to read. `#replay-window-note` is absent
+  // because `render` only toggles its `hidden`: its text is in the markup, and
+  // `tests/browser/history.test.js` pins that.
+  const panels = [
+    "replay-timeline",
+    "replay-status",
+    "replay-tests",
+    "replay-moment-label",
+    "replay-transcript",
+    "replay-code",
+  ];
+  for (const [name, events] of Object.entries(REPLAYS)) {
+    for (const id of panels) {
+      dom.node(id).replaceChildren();
+      dom.node(id).markup.length = 0;
+    }
+    render(events);
+
+    // Read as rendered, then again after every button has been pressed:
+    // `showMoment` and `markCurrent` both write to these panels and neither
+    // runs until somebody clicks. Two reads around one round of clicks, not two
+    // rounds: nothing observed the second round.
+    const readPanels = (pass) => {
+      for (const id of panels) {
+        for (const spoken of dom.node(id).spoken()) {
+          assert.equal(
+            unaccountedFor(spoken, events),
+            "",
+            `${name}, ${pass}: #${id} said something nobody chose: ${JSON.stringify(spoken)}`,
+          );
+        }
+      }
+    };
+    readPanels("as rendered");
+    for (const button of dom.node("replay-timeline").querySelectorAll("[data-moment], [data-window]")) {
+      button.click();
+    }
+    readPanels("after every button is pressed");
+  }
+});
+
+test("the replay page renders a window for every question and none for anything else", () => {
+  // The counterpart to the copy check: that the panel says the right things is
+  // only worth asserting if it says them about the right rows.
+  const windows = (events) => {
+    dom.node("replay-timeline").replaceChildren();
+    render(events);
+    return dom
+      .node("replay-timeline")
+      .querySelectorAll("[data-window]")
+      .map((button) => button.textContent);
+  };
+
+  assert.equal(windows(REPLAYS["a closed window with an answer"]).length, 1);
+  assert.equal(windows(REPLAYS["a replay with no windows at all"]).length, 0);
+  assert.match(windows(REPLAYS["a closed window with no answer"])[0], /no candidate transcript recorded/);
+  // The two sentences an empty window comes in, told apart by the recording
+  // rather than by the interview. Both fixtures hold a window with no turn on
+  // it; only one of them is a recording that could have said so.
+  const legacy = windows(REPLAYS["windows from before turns were stamped"]);
+  assert.equal(legacy.length, 2);
+  assert.match(legacy[1], /transcript not matched to a window/);
+  assert.doesNotMatch(legacy[1], /no candidate transcript recorded/);
+  assert.match(windows(REPLAYS["a window that never closed"])[0], /duration not recorded/);
+  assert.match(windows(REPLAYS["a window whose clock ran backwards"])[0], /duration not recorded/);
+  assert.match(windows(REPLAYS["a window the interview was paused during"])[0], /interview paused during this window/);
+  assert.match(windows(REPLAYS["a long window"])[0], /3599\.0 s/);
+});
+
+test("the stylesheet puts no words on the page either", () => {
+  // Not reachable by rendering: a stub document applies no stylesheet, and
+  // `::after { content: … }` is text a browser draws that no node holds.
+  //
+  // Scoped to the declarations that draw, rather than to every quoted string in
+  // the file. The wider version failed on `input[type="text"]`, which is a
+  // selector and not speech, and having to allowlist `"ready"` for the same
+  // reason was the tell that it was reading the wrong thing. Comments out first:
+  // an apostrophe in a sentence is not a quoted value.
+  const styles = read("web/styles.css").replace(/\/\*[\s\S]*?\*\//g, "");
+  // Every property that can draw text, not only `content`. A list marker does it
+  // too, and both `#replay-timeline` and `#replay-transcript` are lists.
+  // Whitespace before the colon is allowed by CSS and was allowed past an
+  // earlier version of this: `content : "..."` matched nothing.
+  const draws = /(?:^|[;{\s])(content|list-style-type|list-style)\s*:\s*([^;}]+)/gim;
+  assert.deepEqual(
+    new Set([...styles.matchAll(draws)].map((match) => match[2].trim())),
+    new Set(['"\u2713"', "none"]),
+    "a stylesheet that spells a word is a stylesheet saying something",
+  );
+  // `attr()` draws an attribute, so a dataset value becomes text a browser
+  // shows. The render check reads the dataset for the same reason; this refuses
+  // the mechanism outright, because the two together are what make it speech.
+  assert.doesNotMatch(styles, /attr\s*\(/i, "an attribute drawn is an attribute spoken");
+  // And nothing smuggled through a data URI, which carries its text unquoted.
+  assert.doesNotMatch(styles, /url\(\s*['"]?data:/i, "an inline image can hold a sentence");
+});
+
+test("the report card this page renders names no finding either", () => {
+  // `loadReport` writes `reportMarkup(...)` into `#replay-report` as markup, and
+  // that markup comes from `web/render.js`, which the render above never
+  // reaches: `render` does not call it, and the fetch this file installs refuses
+  // everything.
+  //
+  // Held at every word rather than at the headings. Headings alone was the
+  // earlier version and it was wrong twice over: three of them only render on
+  // branches the fixtures did not reach, and the prose between them is not all
+  // the interviewer's own assessment. `chainSentence`, "(none captured)" and the
+  // sentences in the Integrity Evidence section are CodeTrial's words, in the
+  // section a reviewer reads for exactly this.
+  //
+  // `web/render.js` is shared with the interview page, so this is a second
+  // reader of it rather than its owner: a legitimate change to report copy adds
+  // a word here, which is the point.
+  // The raw shape the agent sends, which is what `sanitizeReport` reads. An
+  // earlier version passed the sanitized field names instead, so the base card
+  // rendered its placeholders and every branch below sanitized down to it.
+  const sentinels = ["Sxsum", "Sxstr", "Sximp", "Sxtitle", "Sxlang", "Sxcode", "Sxnote", "Sxwhy", "Sxplan", "Sxev"];
+  const base = {
+    codingScore: 70,
+    communicationScore: 70,
+    decision: "HIRE",
+    summary: "Sxsum",
+    codingFeedback: { strengths: ["Sxstr"], improvements: ["Sximp"] },
+    communicationFeedback: { strengths: ["Sxstr"], improvements: [] },
+    hintsUsed: 0,
+  };
+  // Shapes `sanitizeReport` accepts, taken from tests/browser/render.test.js.
+  // A branch list is a claim, and the section assertion below is what makes this
+  // one check itself: a fixture the sanitizer rejects renders the default card
+  // and looks exactly like a branch that worked.
+  const branches = [
+    {},
+    { hintsUsed: 2 },
+    { decision: "NO HIRE" },
+    { decision: "LEAN HIRE" },
+    {
+      rounds: [
+        { kind: "coding", budgetMin: 37, status: "complete" },
+        { kind: "behavioral", budgetMin: 8, status: "started" },
+      ],
+    },
+    {
+      codingFeedback: { strengths: ["Sxstr"], improvements: ["Sximp"] },
+      improvementPlan: [
+        {
+          phase: "Test",
+          weakness: "Sximp",
+          impact: "high",
+          frequency: 2,
+          drill: "Sxplan",
+          durationMin: 10,
+          successCriterion: "Sxwhy",
+          selfReview: ["Sxnote"],
+        },
+      ],
+    },
+    {
+      frameworkEvidence: [
+        {
+          atMs: 65_000,
+          phase: "algorithm",
+          source: "candidate_speech",
+          kind: "observed",
+          confidence: 95,
+          summary: "Sxev",
+          frameworkVersion: 1,
+        },
+      ],
+    },
+    {
+      integrityEvents: [
+        { type: "FACE_MISSING", severity: "warning", at: 1, detail: "Sxnote", sourceEventIds: ["7"] },
+      ],
+      integrityChainSeq: 2,
+      integrityChainVerified: true,
+    },
+    // The other arm of the chain sentence, which only renders when something
+    // was dropped for space.
+    { integrityEvents: [{ type: "FACE_MISSING", severity: "warning", at: 1 }], integrityChainSeq: 2, integrityDropped: 3 },
+    { incomplete: true, summary: "Sxsum" },
+    // The header, the contract line and the calibration note, none of which any
+    // earlier version of this list reached. The valid contract has to be the
+    // active one or the card says the report is unsupported instead, so both
+    // shapes are here: they render different sentences.
+    { mode: "practice", interviewLoop: "coding_only" },
+    {
+      interviewContract: {
+        bundleVersion: 4,
+        livePromptVersion: 1,
+        reportPromptVersion: 4,
+        reportSchemaVersion: 1,
+        rubricVersion: 1,
+      },
+    },
+    { interviewContract: { bundleVersion: 1 } },
+    {
+      // Every phase, or `sanitizeReport` drops the assessment and the
+      // calibration note with it. The list is read from `frameworkPhases` so a
+      // phase added there does not silently shorten this fixture.
+      frameworkAssessment: {
+        rubricVersion: 1,
+        phases: frameworkPhases.map((phase) => ({ phase, score: 60, weaknessTags: [] })),
+      },
+    },
+    { code: "" },
+  ];
+  const said = new Set();
+  const rendered = [];
+  for (const extra of branches) {
+    const report = sanitizeReport({ ...base, ...extra });
+    const markup = reportMarkup({
+      report,
+      problemTitle: "Sxtitle",
+      language: "Sxlang",
+      code: "code" in extra ? extra.code : "Sxcode",
+    });
+    rendered.push(markup);
+    for (const word of markup.replace(/<[^>]*>/g, " ").split(/\s+/)) {
+      if (word && !sentinels.includes(word)) said.add(word);
+    }
+  }
+
+  // Every section the card can draw appeared at least once, and the list of
+  // sections is read out of the card rather than typed here. Typing it was the
+  // previous version and it was the same defect one layer up: the list named six
+  // sections, nothing checked that it named them all, and the section holding
+  // the calibration note fell through both it and the vocabulary set. A list
+  // derived from the source cannot be short of the source.
+  // `h3` only, and literal `h3` at that. The card's `<section>` titles all use
+  // one; its `h2` is the verdict and its `h4`s are the two feedback lists, none
+  // of which is a section, and the `h2`s further down the file belong to the
+  // problem statement rather than to this card. What the pattern cannot see is a
+  // heading built from an interpolation, and the card has two: the summary
+  // section, whose two arms are named in the sentence list below, and the two
+  // feedback sections, whose titles are the words "Coding" and "Communication"
+  // in the vocabulary set instead.
+  const headings = [...read("web/render.js").matchAll(/<h3[^>]*>([^<{]+)<\/h3>/g)].map(
+    (match) => match[1],
+  );
+  assert.ok(headings.length >= 4, `only ${headings.length} headings found in web/render.js`);
+  for (const section of headings) {
+    assert.ok(
+      rendered.some((markup) => markup.includes(section)),
+      `no branch rendered the ${section} section, so its words are not in this set`,
+    );
+  }
+  // And the sentences that are not under a heading of their own. Each is
+  // first-party copy on a branch that has to be reached deliberately, and the
+  // branch list above is where reaching them is arranged.
+  //
+  // Hand-maintained, and said so rather than claimed to be derived. The heading
+  // list above is read out of the source and cannot be short of it; this one
+  // cannot be, because the copy it names lives inside template interpolations
+  // that a source scan does not recover. What the two together give is a
+  // tripwire, not a proof, which is what the header says.
+  for (const sentence of [
+    "Committee summary",
+    "What happened",
+    "No evaluation",
+    "formative coaching signals",
+    "Contract bundle",
+    "Legacy/unversioned contract",
+    "cannot be scored by this version",
+    "Chain verified through event",
+    "every event it verified is listed above",
+    "were verified and not kept, for space",
+    "predates chain reporting",
+    "source event",
+    "(editor was empty)",
+    "Practice interview report",
+  ]) {
+    assert.ok(
+      rendered.some((markup) => markup.includes(sentence)),
+      `no branch rendered "${sentence}", so its words are not in this set`,
+    );
+  }
+
+  // The valid-contract branch has to carry the contract this build calls active,
+  // or `sanitizeReport` marks it unsupported and the branch collapses into the
+  // invalid one below it. `activeContract` is function-local and cannot be read
+  // from here, so the branch is checked by what it renders instead: a card that
+  // names its bundle and does not say it cannot be scored. Stating the
+  // precondition in a comment and not checking it is how the branch list went
+  // wrong the last two times.
+  assert.ok(
+    rendered.some(
+      (markup) => markup.includes("Contract bundle") && !markup.includes("cannot be scored"),
+    ),
+    "no branch rendered a supported contract, so the active contract has moved",
+  );
+  // Numbers, enum values and phase names are here because the card renders them
+  // verbatim: they are the schema's words, the same category as `editor` on the
+  // timeline, and listing them means one renamed to something that reads as a
+  // judgement fails here.
+  assert.deepEqual(
+    said,
+    new Set([
+      "(.md)", "(Sxlang)", "(editor", "(none", "-", "/", "0", "01:05", "1", "10",
+      "100", "2", "2;", "3", "37", "4", "7", "70", "8", "95%", "Chain",
+      "CodeTrial.", "Coding", "Committee", "Communication", "Contract", "Done",
+      "Download", "Evidence", "FACE_MISSING", "Framework", "HIRE", "INCOMPLETE",
+      "Improve", "Integrity", "Interview", "Interviewer", "Legacy/unversioned",
+      "NO", "No", "Practice", "REACTO/STAR", "Strengths", "Success:", "Test",
+      "This", "What", "Your", "above.", "algorithm", "an", "and", "are", "back",
+      "be", "behavioral", "bundle", "by", "calibrated", "candidate_speech",
+      "cannot", "captured)", "chain", "coaching", "code", "coding",
+      "communication", "complete", "confidence", "contract", "dropped", "during",
+      "empty)", "evaluation", "event", "every", "evidence", "evidence.", "final",
+      "for", "formative", "happened", "high", "hints", "hiring", "how", "impact",
+      "interview", "is", "it", "kept,", "listed", "lobby", "malformed", "min",
+      "more", "much", "next", "not", "observed", "of", "only", "or", "packet",
+      "performance", "phase", "predates", "report", "reporting:", "rounds",
+      "rubric", "schema", "scored", "scores", "session", "signals,", "source",
+      "space", "space.", "started", "summary", "the", "this", "through", "to",
+      "unknown.", "unsupported", "used", "uses", "v1", "verified", "version",
+      "warning", "was", "were", "\u00b7",
+    ]),
+    "a word on the report card is a word somebody chose",
+  );
+});
+
+test("a missing id is caught, except for the ids nothing drives", async () => {
+  // Measured rather than described. `querySelector` answering `null` for an
+  // undeclared id is only worth having if something then fails, and which ids
+  // that covers depends on where each node is first dereferenced: at import, in
+  // `render`, inside `showMoment`, or in a function no test calls. Four attempts
+  // to write that down in a comment produced four wrong sentences, so it is an
+  // assertion now.
+  //
+  // The five below are written only on the fetch-driven paths, which this file
+  // does not drive, so removing one from the page is invisible here and fatal in
+  // a browser. That is the same gap the header declares, with the ids measured
+  // rather than named by hand.
+  //
+  // Which functions those are is deliberately not listed. Naming them is what
+  // this comment did a moment ago, and the list was wrong within the hour:
+  // `#replay-media` is written by `loadEvents` as well as by `select`. The set
+  // below is measured and the functions behind it are not, because a fact
+  // nothing checks is a fact that goes stale.
+  const markup = read("web/replay.html");
+  const declared = captures(markup, /id="([^"]+)"/g);
+  assert.ok(declared.length >= 10, `only ${declared.length} ids declared`);
+  const missed = [];
+  for (const id of declared) {
+    const outcome = await importWithout(markup, id, ({ render: renderAgain }) =>
+      renderAgain(REPLAYS["a closed window with an answer"]),
+    );
+    if (!outcome.caught) missed.push(id);
+  }
+  assert.deepEqual(
+    new Set(missed),
+    new Set(["replay-list", "replay-empty", "replay-title", "replay-media", "replay-report"]),
+  );
+
+  // The loop above installs a fetch that never settles, once per id. A test that
+  // awaited that stub would not fail, it would hang, and the run would time out
+  // in whichever file happened to come next. So the undo is asserted here rather
+  // than trusted: the stub is gone by the time this line runs.
+  const answered = await Promise.race([
+    Promise.resolve(globalThis.fetch("/anything")).then(
+      () => "answered",
+      () => "answered",
+    ),
+    new Promise((resolve) => setTimeout(() => resolve("hung"), 200)),
+  ]);
+  assert.equal(answered, "answered", "importWithout left a fetch that never settles");
+});
+
+test("exactly one moment button is current", () => {
+  dom.node("replay-timeline").replaceChildren();
+  render(REPLAYS["several answered windows and an editor between them"]);
+  const buttons = dom.node("replay-timeline").querySelectorAll("[data-moment]");
+  const current = () => buttons.filter((button) => button.current);
+
+  // The last moment is opened when the page renders, before anything is pressed.
+  assert.deepEqual(
+    current().map((button) => button.dataset.moment),
+    [String(Math.max(...buttons.map((b) => Number(b.dataset.moment ?? -1))))],
+  );
+
+  for (const button of buttons) {
+    button.click();
+    assert.deepEqual(
+      current(),
+      [button],
+      `pressing ${JSON.stringify(button.dataset)} left ${current().length} buttons current`,
+    );
+  }
+  assert.equal(dom.node("replay-timeline").querySelectorAll("[data-window]")[0].tag, "div");
+});
+
+test("a response window does not replace the final editor with missing history", () => {
+  dom.node("replay-timeline").replaceChildren();
+  render([
+    avatar(BASE, "speaking"),
+    avatar(BASE + 1000, "listening"),
+    avatar(BASE + 2000, "speaking"),
+    editor(BASE + 3000),
+  ]);
+  const code = dom.node("replay-code").textContent;
+  dom.node("replay-timeline").querySelectorAll("[data-window]")[0].click();
+  assert.equal(dom.node("replay-code").textContent, code);
+});

--- a/tests/browser/replay-render.test.js
+++ b/tests/browser/replay-render.test.js
@@ -558,7 +558,7 @@ test("a missing id is caught, except for the ids nothing drives", async () => {
   assert.ok(declared.length >= 10, `only ${declared.length} ids declared`);
   const missed = [];
   for (const id of declared) {
-    const outcome = await importWithout(markup, id, ({ render: renderAgain }) =>
+    const outcome = await importWithout(markup, "/replay.js", id, ({ render: renderAgain }) =>
       renderAgain(REPLAYS["a closed window with an answer"]),
     );
     if (!outcome.caught) missed.push(id);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1681,16 +1681,32 @@ fn binary_web_reads_deployment_keys_from_the_config_file() {
     // Ends at the closing brace in column zero rather than at whatever item
     // happens to follow. Keying on the next `async fn` meant deleting the
     // function that used to sit there silently emptied this test's haystack.
-    let serve = source
-        .split_once("fn run_web(")
-        .expect("run_web should exist")
-        .1
-        .split_once("\n}\n")
-        .expect("run_web should end")
-        .0;
+    let body = |name: &str| {
+        source
+            .split_once(&format!("fn {name}("))
+            .unwrap_or_else(|| panic!("{name} should exist"))
+            .1
+            .split_once("\n}\n")
+            .unwrap_or_else(|| panic!("{name} should end"))
+            .0
+            .to_string()
+    };
 
-    assert!(serve.contains("trusted_proxy_hops(&values)"), "{serve}");
+    // Both halves of the startup path. The configuration is assembled in
+    // `web_server_config` and the socket is bound in `run_web`, and the
+    // property is about the pair: what this deployment runs on comes out of the
+    // config file the operator wrote, never out of the ambient environment.
+    // Splitting the function moved the first assertion's subject and would have
+    // left this reading an empty haystack had it kept naming only one of them.
+    let serve = body("run_web");
+    let configure = body("web_server_config");
+
+    assert!(
+        configure.contains("trusted_proxy_hops(values)"),
+        "{configure}"
+    );
     assert!(!serve.contains("std::env::var"), "{serve}");
+    assert!(!configure.contains("std::env::var"), "{configure}");
 }
 
 /// The log is the one place the error text sends a reader with no console, so

--- a/tests/recording.rs
+++ b/tests/recording.rs
@@ -2898,7 +2898,7 @@ mod replay {
         use codetrial::recording::{
             Ingest, MAX_REPLAY_EVENT_BYTES, MAX_REPLAY_EVENTS, MAX_REPLAY_STRING, ReplayKind,
             ReplayRejection, SnapshotView, append_replay_events, parse_replay_event, replay_events,
-            replay_snapshot,
+            replay_review, replay_snapshot, replay_tail,
         };
         use serde_json::json;
 
@@ -3158,6 +3158,178 @@ mod replay {
                 replay_snapshot(&accounts, "int-1", 1, 50).unwrap(),
                 SnapshotView::Deleted
             );
+        }
+
+        /// The template read and the page read, side by side.
+        ///
+        /// `Avatar` is a snapshot kind and stays one: that is what lets a
+        /// recording template joining late learn Jim's current state without
+        /// replaying the interview, and `replay_snapshot` is the read it makes.
+        /// The review page needs the history instead, and gets it without
+        /// widening what the template sees, because the two are different reads
+        /// rather than a changed `is_snapshot`.
+        #[tokio::test]
+        async fn replay_review_keeps_the_avatar_history_the_snapshot_collapses() {
+            let (_scratch, accounts) = harness("replay-review-history");
+
+            let payload = |kind: &str, state: &str| {
+                parse_replay_event(&super::envelope(kind, json!({ "state": state }))).unwrap()
+            };
+
+            // The states the server actually publishes, so this fixture is a
+            // replay a real interview could produce. `src/livekit.rs` writes
+            // `listening` and `speaking` and nothing writes `thinking`.
+            append_replay_events(
+                &accounts,
+                "int-1",
+                1,
+                &[
+                    payload("avatar", "speaking"),
+                    event(ReplayKind::Editor, "first draft"),
+                    event(ReplayKind::Transcript, "a hash map"),
+                    payload("avatar", "listening"),
+                    event(ReplayKind::Editor, "second draft"),
+                    payload("lifecycle", "paused"),
+                    payload("avatar", "speaking"),
+                    payload("lifecycle", "resumed"),
+                ],
+                10,
+            )
+            .unwrap();
+
+            let ready = |view: SnapshotView| match view {
+                SnapshotView::Ready(snapshot) => snapshot,
+                _ => panic!("the owner reads their own replay"),
+            };
+            let kinds = |snapshot: &codetrial::recording::Snapshot| {
+                snapshot
+                    .events
+                    .iter()
+                    .map(|(seq, event)| (*seq, event.kind))
+                    .collect::<Vec<_>>()
+            };
+
+            assert_eq!(
+                kinds(&ready(replay_snapshot(&accounts, "int-1", 1, 100).unwrap())),
+                vec![
+                    (2, ReplayKind::Transcript),
+                    (4, ReplayKind::Editor),
+                    (6, ReplayKind::Avatar),
+                    (7, ReplayKind::Lifecycle),
+                ],
+                "the template gets one avatar row, which is the state Jim is in \
+                 now, and one lifecycle row, which nothing reads"
+            );
+            let review = ready(replay_review(&accounts, "int-1", 1, 100).unwrap());
+            assert_eq!(
+                kinds(&review),
+                vec![
+                    (0, ReplayKind::Avatar),
+                    (2, ReplayKind::Transcript),
+                    (3, ReplayKind::Avatar),
+                    (4, ReplayKind::Editor),
+                    (5, ReplayKind::Lifecycle),
+                    (6, ReplayKind::Avatar),
+                    (7, ReplayKind::Lifecycle),
+                ],
+                "and the page gets every transition, with the editor still collapsed"
+            );
+
+            // The pause in particular, which is what `Collapse::Restatements`
+            // keeps the `lifecycle` history for.
+            assert_eq!(
+                review
+                    .events
+                    .iter()
+                    .filter(|(_, event)| event.kind == ReplayKind::Lifecycle)
+                    .map(|(_, event)| event.payload["state"].as_str().unwrap())
+                    .collect::<Vec<_>>(),
+                vec!["paused", "resumed"],
+                "a collapsed lifecycle read keeps only the resume and loses the break"
+            );
+
+            // `seq` 0 is in that answer, which is the reason this is a read of
+            // its own rather than `?after=0` against `replay_tail`: that one
+            // floors `after` at 0 against `seq > ?3` and cannot return the
+            // first event of an interview at all.
+            assert_eq!(
+                ready(replay_tail(&accounts, "int-1", 1, 0, 100).unwrap())
+                    .events
+                    .first()
+                    .map(|(seq, _)| *seq),
+                Some(1),
+                "the tail cannot reach seq 0, and the review read does not go through it"
+            );
+        }
+
+        /// The retention guards cover the review read, because it is the same
+        /// function with one argument changed.
+        ///
+        /// A second read that skipped them would leave a replay readable past a
+        /// deadline that closed the route beside it, which is the whole reason
+        /// `replay_view` checks expiry and deletion itself rather than trusting
+        /// its callers.
+        #[tokio::test]
+        async fn replay_review_is_gone_when_the_snapshot_is() {
+            let (scratch, accounts) = harness("replay-review-gone");
+            append_replay_events(
+                &accounts,
+                "int-1",
+                1,
+                &[event(ReplayKind::Transcript, "mine")],
+                10,
+            )
+            .unwrap();
+            scratch
+                .open()
+                .execute(
+                    "
+        INSERT INTO recordings (
+            id, account_id, interview_id, room_name, idempotency_key,
+            recipient_email, state, expires_at, created_at, updated_at
+        ) VALUES ('rec-1', 1, 'int-1', 'interview-abc12345', 'int-1',
+            'one@example.test', 'ready', 100, 1, 1)
+        ",
+                    [],
+                )
+                .unwrap();
+
+            assert!(matches!(
+                replay_review(&accounts, "int-1", 1, 99).unwrap(),
+                SnapshotView::Ready(_)
+            ));
+            assert_eq!(
+                replay_review(&accounts, "int-1", 1, 100).unwrap(),
+                SnapshotView::Expired,
+                "the deadline is the deadline for this read too"
+            );
+
+            scratch
+                .open()
+                .execute(
+                    "
+        UPDATE recordings SET state = 'deleted', deleted_at = 90, expires_at = NULL,
+            room_name = NULL, recipient_email = NULL WHERE id = 'rec-1'
+        ",
+                    [],
+                )
+                .unwrap();
+            assert_eq!(
+                replay_review(&accounts, "int-1", 1, 50).unwrap(),
+                SnapshotView::Deleted
+            );
+
+            // And an interview that exists and belongs to account 2 is not
+            // account 1's to review. A nonexistent id would answer the same way
+            // and prove less, so this uses the one the harness owns elsewhere.
+            assert_eq!(
+                replay_review(&accounts, "int-other", 1, 50).unwrap(),
+                SnapshotView::NoInterview
+            );
+            assert!(matches!(
+                replay_review(&accounts, "int-other", 2, 50).unwrap(),
+                SnapshotView::Ready(_)
+            ));
         }
 
         #[tokio::test]

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -5684,17 +5684,20 @@ async fn history_expired_returns_410() {
             [],
         )
         .unwrap();
-    let deleted = client
-        .get(format!("{base}/api/recordings/rec-expired"))
-        .header("cookie", cookie)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(deleted.status(), 410);
-    assert_eq!(
-        deleted.json::<Value>().await.unwrap()["code"],
-        "recording_deleted"
-    );
+    for path_suffix in ["", "/events"] {
+        let deleted = client
+            .get(format!("{base}/api/recordings/rec-expired{path_suffix}"))
+            .header("cookie", cookie.clone())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(deleted.status(), 410, "{path_suffix}");
+        assert_eq!(
+            deleted.json::<Value>().await.unwrap()["code"],
+            "recording_deleted",
+            "{path_suffix}"
+        );
+    }
 
     server.abort();
     remove_database(path);
@@ -5786,7 +5789,7 @@ async fn replay_snapshot_is_owner_scoped() {
         .unwrap();
     let expired = client
         .get(format!("{base}/api/interviews/{interview}/snapshot"))
-        .header("cookie", cookie)
+        .header("cookie", cookie.clone())
         .send()
         .await
         .unwrap();
@@ -5794,6 +5797,33 @@ async fn replay_snapshot_is_owner_scoped() {
     assert_eq!(
         expired.json::<Value>().await.unwrap()["code"],
         "replay_expired"
+    );
+
+    // And a deleted recording, which is the other half of the same promise and
+    // was asserted nowhere: this route has no `gone_response` ahead of it, so
+    // `SnapshotView::Deleted` reaches the response mapping directly here. The
+    // status was free to become a `404` without a test noticing, which is the
+    // difference between "taken away" and "never yours" going missing.
+    rusqlite::Connection::open(&path)
+        .unwrap()
+        .execute(
+            "
+        UPDATE recordings SET state = 'deleted', deleted_at = 5, expires_at = NULL,
+            room_name = NULL, recipient_email = NULL WHERE id = 'rec-snap'
+        ",
+            [],
+        )
+        .unwrap();
+    let deleted = client
+        .get(format!("{base}/api/interviews/{interview}/snapshot"))
+        .header("cookie", cookie)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(deleted.status(), 410);
+    assert_eq!(
+        deleted.json::<Value>().await.unwrap()["code"],
+        "recording_deleted"
     );
 
     let signed_out = client

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -5717,6 +5717,85 @@ async fn the_recorder_reads_the_replay_for_the_room_its_token_names() {
     remove_database(path);
 }
 
+/// A full page is not the same as a page with more behind it.
+///
+/// The listing asks for one row more than a page and uses the extra row as the
+/// answer to "is there another page". Only a single-row listing was covered, so
+/// the comparison that decides it was free to be off by one: a cursor handed
+/// out at exactly one page sends the client back for a page that is empty, and
+/// a cursor withheld at one page more hides every recording past the twentieth.
+#[tokio::test]
+async fn a_full_page_offers_a_cursor_only_when_more_follows() {
+    let (base, server, path, client, cookie) = recorded_server("listing-page-edge").await;
+
+    // One recording per interview, which the schema enforces, so each row
+    // brings its own.
+    let insert = |count: i64| {
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        connection.execute("DELETE FROM recordings", []).unwrap();
+        for row in 0..count {
+            let interview_id = format!("int-page-{row}");
+            let room = format!("interview-page{row:04}");
+
+            // With its room, because an interview still waiting for one is
+            // unique per account and consent version, and these are past.
+            connection
+                .execute(
+                    "INSERT OR IGNORE INTO interviews
+                       (id, account_id, consent_version, consent_at, room_name)
+                       VALUES (?1, 1, '2026-08-21', 1, ?2)",
+                    [&interview_id, &room],
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO recordings (
+                         id, account_id, interview_id, room_name, idempotency_key,
+                         recipient_email, state, created_at, updated_at
+                     ) VALUES (?1, 1, ?2, ?3, ?1, 'one@example.test', 'ready', ?4, ?4)",
+                    rusqlite::params![format!("rec-page-{row}"), interview_id, room, 1000 + row],
+                )
+                .unwrap();
+        }
+    };
+    let listing = || async {
+        client
+            .get(format!("{base}/api/recordings"))
+            .header("cookie", &cookie)
+            .send()
+            .await
+            .unwrap()
+            .json::<Value>()
+            .await
+            .unwrap()
+    };
+
+    let page = codetrial::recording::RECORDING_PAGE;
+    insert(page);
+    let body = listing().await;
+    assert_eq!(body["recordings"].as_array().unwrap().len(), page as usize);
+    assert_eq!(
+        body["nextCursor"],
+        Value::Null,
+        "exactly one page has nothing behind it"
+    );
+
+    insert(page + 1);
+    let body = listing().await;
+    assert_eq!(
+        body["recordings"].as_array().unwrap().len(),
+        page as usize,
+        "a page is still a page"
+    );
+    assert!(
+        body["nextCursor"].is_string(),
+        "one row more than a page is another page"
+    );
+
+    server.abort();
+    remove_database(path);
+}
+
 /// A signature from one project does not reach another project's room.
 ///
 /// The signature proves which project sent the webhook. It does not prove the

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -4946,6 +4946,110 @@ async fn a_completion_with_no_file_fails_the_recording() {
     remove_database(path);
 }
 
+/// A provider failure arriving after a good completion leaves the file alone.
+///
+/// LiveKit retries webhooks, so its news can arrive twice and out of order. The
+/// state table has to allow `transferring` to `failed`, because that is how the
+/// delivery worker reports an upload it could not finish, and that same edge
+/// let a stale `EGRESS_FAILED` fail a recording whose file was already queued
+/// and whole. The candidate was then told to record again over a video that
+/// existed.
+#[tokio::test]
+async fn a_late_provider_failure_does_not_fail_a_queued_recording() {
+    let provider = std::sync::Arc::new(FakeRecordingProvider::default());
+    let (base, server, path, client, cookie) =
+        recorded_server_with_provider("late-failure", provider.clone()).await;
+    let interview = start_interview(&client, &base, &cookie).await;
+    assert_eq!(
+        client
+            .post(format!("{base}/api/token"))
+            .header("cookie", cookie.clone())
+            .json(&json!({ "interviewId": interview }))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+    assert_eq!(
+        client
+            .post(format!("{base}/api/interviews/{interview}/recording"))
+            .header("cookie", cookie.clone())
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        202
+    );
+
+    let recording_id: String = rusqlite::Connection::open(&path)
+        .unwrap()
+        .query_row(
+            "SELECT id FROM recordings WHERE interview_id = ?1",
+            [&interview],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    // The object this recording is going to transfer, named the way the webhook
+    // predicate expects it, so this is a completion that really carries a file.
+    let complete = json!({
+        "event": "egress_ended",
+        "id": "EV_complete",
+        "createdAt": "1770000123",
+        "egressInfo": {
+            "egressId": "EG_web_fake",
+            "status": "EGRESS_COMPLETE",
+            "fileResults": [{
+                "filename": format!("codetrial/{recording_id}.mp4"),
+                "size": "1024"
+            }]
+        }
+    })
+    .to_string();
+    assert_eq!(post_webhook(&client, &base, &complete).await.status(), 200);
+
+    let state = |path: &std::path::Path| -> (String, Option<String>) {
+        rusqlite::Connection::open(path)
+            .unwrap()
+            .query_row(
+                "SELECT state, error FROM recordings WHERE id = ?1",
+                [&recording_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap()
+    };
+    assert_eq!(
+        state(&path).0,
+        "transferring",
+        "a completion carrying the expected object queues the transfer"
+    );
+
+    // The same egress, reported failed afterwards. Nothing here is delivered,
+    // so the row can only move if this webhook moves it.
+    let failed = json!({
+        "event": "egress_ended",
+        "id": "EV_late_failure",
+        "createdAt": "1770000456",
+        "egressInfo": {
+            "egressId": "EG_web_fake",
+            "status": "EGRESS_FAILED",
+            "error": "provider gave up"
+        }
+    })
+    .to_string();
+    assert_eq!(post_webhook(&client, &base, &failed).await.status(), 200);
+
+    assert_eq!(
+        state(&path),
+        ("transferring".to_string(), None),
+        "a stale provider failure must not take back a completed egress"
+    );
+
+    server.abort();
+    remove_database(path);
+}
+
 /// Signs a webhook body the way LiveKit does and posts it.
 ///
 /// The signature covers the exact bytes, so the body is passed as a string and

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -5656,6 +5656,77 @@ async fn the_server_starts_the_recording_workers() {
     panic!("the sweeper never ran: the recording is still {reached}");
 }
 
+/// A storage failure is not the same answer as no such recording.
+///
+/// This route is what the recording template asks before it decides a replay
+/// exists. A read that failed used to arrive as `404`, which tells the template
+/// the recording is gone: a permanent answer to a temporary condition, and one
+/// no caller retries.
+#[tokio::test]
+async fn a_replay_read_that_fails_is_not_reported_as_missing() {
+    let (base, server, path, client, cookie) = recorded_server("replay-read-error").await;
+    let interview = start_interview(&client, &base, &cookie).await;
+    let room = "interview-abc12345";
+    rusqlite::Connection::open(&path)
+        .unwrap()
+        .execute(
+            "
+        INSERT INTO recordings (
+            id, account_id, interview_id, room_name, idempotency_key,
+            recipient_email, state, created_at, updated_at
+        ) VALUES ('rec-err', 1, ?1, ?2, ?1, 'one@example.test', 'recording', 1, 1)
+        ",
+            [&interview, &room.to_string()],
+        )
+        .unwrap();
+    let token = codetrial::token::livekit_token(codetrial::token::LivekitTokenInput {
+        api_key: "devkey",
+        api_secret: "devsecret",
+        identity: "EG_recorder",
+        name: "recorder",
+        room,
+        metadata: "",
+        agent: false,
+        now_seconds: codetrial::current_epoch_seconds(),
+    })
+    .unwrap();
+    let replay = |token: String| {
+        let url = format!("{base}/api/recording/replay");
+        let client = client.clone();
+        async move {
+            client
+                .get(url)
+                .header("authorization", token)
+                .send()
+                .await
+                .unwrap()
+        }
+    };
+
+    assert_eq!(
+        replay(token.clone()).await.status(),
+        200,
+        "the room this token names has a recording to read"
+    );
+
+    // The table out from under the read, which is the shape a storage failure
+    // takes here: the query errors rather than returning no rows.
+    rusqlite::Connection::open(&path)
+        .unwrap()
+        .execute_batch("DROP TABLE recordings")
+        .unwrap();
+
+    let broken = replay(token).await;
+    assert_eq!(
+        broken.status(),
+        500,
+        "a failed read is not the answer 'no such recording'"
+    );
+
+    server.abort();
+    remove_database(path);
+}
+
 /// The history a candidate reads about their own interviews.
 #[tokio::test]
 async fn history_lists_own_recordings_only() {

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -5384,20 +5384,22 @@ async fn the_recorder_reads_the_replay_for_the_room_its_token_names() {
             [&interview, &room.to_string()],
         )
         .unwrap();
-    let event = |kind: &str, text: &str| {
-        json!({
-            "v": codetrial::recording::REPLAY_VERSION,
-            "kind": kind,
-            "at": 1_770_000_000_000i64,
-            "payload": { "text": text }
-        })
-    };
+    let event = |kind: &str, text: &str| envelope(kind, json!({ "text": text }));
     let posted = client
         .post(format!("{base}/api/interviews/{interview}/events"))
         .header("cookie", cookie.clone())
+        // The `avatar` and `lifecycle` rows are what make the assertion below
+        // able to fail. They are the only kinds the snapshot's collapse and the
+        // review read's differ on, so without them the template's answer is the
+        // same either way and "the template still gets the collapsed snapshot"
+        // held whether or not this route honoured the parameter, which is the
+        // one thing it exists to catch.
         .json(&json!({ "events": [
+            envelope("avatar", json!({ "state": "speaking" })),
             event("editor", "first draft"),
             event("transcript", "hello"),
+            envelope("avatar", json!({ "state": "listening" })),
+            envelope("lifecycle", json!({ "state": "paused" })),
             event("editor", "second draft"),
         ] }))
         .send()
@@ -5434,7 +5436,7 @@ async fn the_recorder_reads_the_replay_for_the_room_its_token_names() {
     let snapshot = replay(token_for(room), "").await;
     assert_eq!(snapshot.status(), 200);
     let body = snapshot.json::<Value>().await.unwrap();
-    assert_eq!(body["seq"], 2);
+    assert_eq!(body["seq"], 5);
     assert_eq!(
         body["events"]
             .as_array()
@@ -5442,8 +5444,26 @@ async fn the_recorder_reads_the_replay_for_the_room_its_token_names() {
             .iter()
             .map(|event| event["kind"].as_str().unwrap())
             .collect::<Vec<_>>(),
-        vec!["transcript", "editor"],
-        "the snapshot drops the superseded editor frame"
+        vec!["transcript", "avatar", "lifecycle", "editor"],
+        "the snapshot drops the superseded editor and avatar frames"
+    );
+
+    // The template's read does not take the review page's parameter, and this
+    // is the assertion that says so. The whole reason `Avatar` stays a snapshot
+    // kind is that a template joining late should learn Jim's current state
+    // without replaying the interview; a refactor that plumbed `avatar=history`
+    // through to here would undo that with nothing to notice.
+    let unwidened = replay(token_for(room), "?avatar=history").await;
+    assert_eq!(unwidened.status(), 200);
+    assert_eq!(
+        unwidened.json::<Value>().await.unwrap()["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|event| event["kind"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["transcript", "avatar", "lifecycle", "editor"],
+        "the template still gets the collapsed snapshot, parameter or no parameter"
     );
 
     // The tail keeps every frame, superseded or not: a reader carrying on from
@@ -5455,7 +5475,7 @@ async fn the_recorder_reads_the_replay_for_the_room_its_token_names() {
             .as_array()
             .unwrap()
             .len(),
-        2
+        5
     );
 
     // A token for another room opens nothing here.
@@ -5600,7 +5620,7 @@ async fn history_cross_account_denied() {
     // it exists. The two paths are refused by two different scopings, which is
     // the point of asking both: the detail is scoped by `recording_summary`'s
     // `account_id`, and the events by the replay read's own ownership check.
-    for path_suffix in ["", "/events"] {
+    for path_suffix in ["", "/events", "/events?avatar=history"] {
         let response = client
             .get(format!("{base}/api/recordings/rec-theirs{path_suffix}"))
             .header("cookie", cookie.clone())
@@ -5657,7 +5677,14 @@ async fn history_expired_returns_410() {
 
     // Gone rather than missing: this account owns the interview and is owed the
     // difference between "never yours" and "not any more".
-    for path_suffix in ["", "/events"] {
+    //
+    // `?avatar=history` is in this list to pin where the refusal happens, not
+    // to re-prove it. The parameter is parsed before `gone_response` and used
+    // after it, so what fails here is an edit that moves the read itself in
+    // front of the guard. That the review read refuses on its own, guard or no
+    // guard, is `replay_review_is_gone_when_the_snapshot_is` in
+    // `tests/recording.rs`, which calls it directly.
+    for path_suffix in ["", "/events", "/events?avatar=history"] {
         let response = client
             .get(format!("{base}/api/recordings/rec-expired{path_suffix}"))
             .header("cookie", cookie.clone())
@@ -5684,7 +5711,7 @@ async fn history_expired_returns_410() {
             [],
         )
         .unwrap();
-    for path_suffix in ["", "/events"] {
+    for path_suffix in ["", "/events", "/events?avatar=history"] {
         let deleted = client
             .get(format!("{base}/api/recordings/rec-expired{path_suffix}"))
             .header("cookie", cookie.clone())
@@ -5703,19 +5730,149 @@ async fn history_expired_returns_410() {
     remove_database(path);
 }
 
+/// The review page's read: every `avatar` row, and one editor buffer.
+///
+/// The snapshot keeps the newest row of every replaceable kind, which is what a
+/// recording template joining late needs and exactly what a response window
+/// cannot be computed from. `?avatar=history` lifts the collapse on that one
+/// kind and on no other, so the page pays for the state history it reads rather
+/// than for a code buffer per debounce.
+#[tokio::test]
+async fn history_events_avatar_history_returns_every_state() {
+    let (base, server, path, client, cookie) = recorded_server("history-avatar").await;
+    let interview = start_interview(&client, &base, &cookie).await;
+    {
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        connection
+            .execute(
+                "
+        INSERT INTO recordings (
+            id, account_id, interview_id, room_name, idempotency_key,
+            recipient_email, state, created_at, updated_at
+        ) VALUES ('rec-window', 1, ?1, 'interview-abc12345', ?1,
+            'one@example.test', 'ready', 10, 10)
+        ",
+                [&interview],
+            )
+            .unwrap();
+    }
+
+    let posted = client
+        .post(format!("{base}/api/interviews/{interview}/events"))
+        .header("cookie", cookie.clone())
+        .json(&json!({ "events": [
+
+            // The states the server publishes, so this is a replay a real
+            // interview could produce: `src/livekit.rs` writes `listening` and
+            // `speaking` and nothing writes `thinking`.
+            envelope("avatar", json!({ "state": "speaking" })),
+            envelope("editor", json!({ "code": "first draft" })),
+            envelope("transcript", json!({ "speaker": "you", "text": "a hash map" })),
+            envelope("avatar", json!({ "state": "listening" })),
+            envelope("editor", json!({ "code": "second draft" })),
+            envelope("lifecycle", json!({ "state": "paused" })),
+            envelope("avatar", json!({ "state": "speaking" })),
+        ] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(posted.status(), 200);
+
+    let rows = async |query: &str| {
+        let response = client
+            .get(format!("{base}/api/recordings/rec-window/events{query}"))
+            .header("cookie", cookie.clone())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200, "{query}");
+        response.json::<Value>().await.unwrap()["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|event| {
+                (
+                    event["seq"].as_i64().unwrap(),
+                    event["kind"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let snapshot = rows("").await;
+    assert_eq!(
+        snapshot,
+        vec![
+            (2, "transcript".to_string()),
+            (4, "editor".to_string()),
+            (5, "lifecycle".to_string()),
+            (6, "avatar".to_string()),
+        ],
+        "the default read is the snapshot the recording template also takes"
+    );
+    assert_eq!(
+        rows("?avatar=history").await,
+        vec![
+            (0, "avatar".to_string()),
+            (2, "transcript".to_string()),
+            (3, "avatar".to_string()),
+            (4, "editor".to_string()),
+            (5, "lifecycle".to_string()),
+            (6, "avatar".to_string()),
+        ],
+        "the page read keeps every transition, seq 0 included, and still one editor"
+    );
+
+    // Exact, not truthy. A value nobody wrote is the ordinary snapshot rather
+    // than a guess at what the caller meant. Compared against the whole default
+    // answer rather than against its length: three rows of the wrong kinds is
+    // also three rows.
+    assert_eq!(
+        rows("?avatar=latest").await,
+        snapshot,
+        "an unrecognised value reads the snapshot, not every avatar row"
+    );
+
+    // The tail collapses nothing already, so the parameter has nothing to lift
+    // there and the request is answered as the tail it asked for.
+    assert_eq!(
+        rows("?after=0&avatar=history").await,
+        vec![
+            (1, "editor".to_string()),
+            (2, "transcript".to_string()),
+            (3, "avatar".to_string()),
+            (4, "editor".to_string()),
+            (5, "lifecycle".to_string()),
+            (6, "avatar".to_string()),
+        ],
+        "and the tail is still the tail, which is why the page does not use it"
+    );
+
+    server.abort();
+    remove_database(path);
+}
+
+/// One replay event on the wire, at a fixed clock.
+///
+/// Free rather than a closure per test: three tests were writing the same eight
+/// lines, so `REPLAY_VERSION` and the timestamp were pinned in three places and
+/// a
+/// version bump touched all of them.
+fn envelope(kind: &str, payload: Value) -> Value {
+    json!({
+        "v": codetrial::recording::REPLAY_VERSION,
+        "kind": kind,
+        "at": 1_770_000_000_000i64,
+        "payload": payload
+    })
+}
+
 /// A late join reads the snapshot, and only its own.
 #[tokio::test]
 async fn replay_snapshot_is_owner_scoped() {
     let (base, server, path, client, cookie) = recorded_server("replay-snapshot").await;
     let interview = start_interview(&client, &base, &cookie).await;
-    let event = |kind: &str, text: &str| {
-        json!({
-            "v": codetrial::recording::REPLAY_VERSION,
-            "kind": kind,
-            "at": 1_770_000_000_000i64,
-            "payload": { "text": text }
-        })
-    };
+    let event = |kind: &str, text: &str| envelope(kind, json!({ "text": text }));
     let posted = client
         .post(format!("{base}/api/interviews/{interview}/events"))
         .header("cookie", cookie.clone())

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -5717,6 +5717,126 @@ async fn the_recorder_reads_the_replay_for_the_room_its_token_names() {
     remove_database(path);
 }
 
+/// Each webhook LiveKit sends does its own job, and says whether to resend.
+///
+/// The kinds were routed and acted on with nothing asserting either half. An
+/// arm quietly dropped would leave the row where it was while the message was
+/// answered 200, so LiveKit would never send it again and no test would notice
+/// the recording had stopped moving.
+///
+/// The answer matters as much as the action. A `room_finished` for a room this
+/// server does not know is finished business, but an egress event naming a job
+/// nothing has written down yet is the only notice that job will ever get, so
+/// it has to be given back rather than swallowed.
+#[tokio::test]
+async fn each_webhook_kind_moves_the_row_and_answers_for_itself() {
+    // The fake provider, because ending a recording really calls StopEgress and
+    // the real one answers a test server with 401.
+    let provider = std::sync::Arc::new(FakeRecordingProvider::default());
+    let (base, server, path, client, _cookie) =
+        recorded_server_with_provider("webhook-kinds", provider.clone()).await;
+
+    // Fresh, so the sweeper that started with the server leaves this alone.
+    let now = codetrial::current_epoch_seconds() as i64;
+    let room = "interview-abc12345";
+    let connection = rusqlite::Connection::open(&path).unwrap();
+    connection
+        .execute(
+            "INSERT INTO interviews (id, account_id, consent_version, consent_at, room_name)
+               VALUES ('int-kinds', 1, '2026-08-21', ?1, ?2)",
+            rusqlite::params![now, room],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO recordings (
+                 id, account_id, interview_id, room_name, idempotency_key,
+                 recipient_email, state, egress_id, created_at, updated_at
+             ) VALUES ('rec-kinds', 1, 'int-kinds', ?2, 'idem-kinds',
+                 'one@example.test', 'starting', 'EG_kinds', ?1, ?1)",
+            rusqlite::params![now, room],
+        )
+        .unwrap();
+    drop(connection);
+
+    let state = || -> String {
+        rusqlite::Connection::open(&path)
+            .unwrap()
+            .query_row(
+                "SELECT state FROM recordings WHERE id = 'rec-kinds'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+    };
+
+    let egress_started = json!({
+        "event": "egress_started",
+        "id": "EV_started",
+        "createdAt": "1770000001",
+        "egressInfo": { "egressId": "EG_kinds", "status": "EGRESS_ACTIVE" }
+    })
+    .to_string();
+    assert_eq!(
+        post_webhook(&client, &base, &egress_started).await.status(),
+        200
+    );
+    assert_eq!(
+        state(),
+        "recording",
+        "egress_started is what says the job is running"
+    );
+
+    let room_finished = json!({
+        "event": "room_finished",
+        "id": "EV_finished",
+        "createdAt": "1770000002",
+        "room": { "name": room }
+    })
+    .to_string();
+    assert_eq!(
+        post_webhook(&client, &base, &room_finished).await.status(),
+        200
+    );
+    assert_eq!(
+        state(),
+        "finalizing",
+        "the room ending is what ends the recording in it"
+    );
+
+    // A room this server never recorded. Nothing to do, and nothing to resend.
+    let other_room = json!({
+        "event": "room_finished",
+        "id": "EV_unknown_room",
+        "createdAt": "1770000003",
+        "room": { "name": "interview-nosuchroom" }
+    })
+    .to_string();
+    assert_eq!(
+        post_webhook(&client, &base, &other_room).await.status(),
+        200,
+        "a room with no recording is finished business"
+    );
+
+    // An egress nothing has written down. The start response may still be in
+    // flight, so this has to come back rather than be answered.
+    let unknown_egress = json!({
+        "event": "egress_ended",
+        "id": "EV_unknown_egress",
+        "createdAt": "1770000004",
+        "egressInfo": { "egressId": "EG_never_seen", "status": "EGRESS_COMPLETE" }
+    })
+    .to_string();
+    assert_eq!(
+        post_webhook(&client, &base, &unknown_egress).await.status(),
+        503,
+        "an unknown egress is given back so LiveKit sends it again"
+    );
+
+    server.abort();
+    remove_database(path);
+}
+
 /// A full page is not the same as a page with more behind it.
 ///
 /// The listing asks for one row more than a page and uses the extra row as the

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -5717,6 +5717,51 @@ async fn the_recorder_reads_the_replay_for_the_room_its_token_names() {
     remove_database(path);
 }
 
+/// A refused start says which refusal it was.
+///
+/// Every branch here is a different thing for the candidate to do: join the
+/// interview first, wait because the server has recording switched off, or
+/// finish the recording already running. Nothing asserted any of them, so the
+/// whole mapping could have collapsed to one answer and the page would have
+/// shown the wrong instruction with the right status.
+#[tokio::test]
+async fn a_refused_recording_says_which_refusal_it_was() {
+    let (base, server, path, client, cookie) = recorded_server("start-refusals").await;
+
+    // No room yet, because nothing minted a token for this interview.
+    let interview = start_interview(&client, &base, &cookie).await;
+    let refused = client
+        .post(format!("{base}/api/interviews/{interview}/recording"))
+        .header("cookie", cookie.clone())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), 409);
+    assert_eq!(
+        refused.json::<Value>().await.unwrap()["code"],
+        "recording_has_no_room",
+        "an interview with no room is told to join first"
+    );
+
+    // An interview that is not this account's is refused as if it did not
+    // exist, which is the same answer as consent withdrawn on purpose.
+    let (other_cookie, _) = second_account(&client, &base, &path).await;
+    let theirs = client
+        .post(format!("{base}/api/interviews/{interview}/recording"))
+        .header("cookie", other_cookie)
+        .send()
+        .await
+        .unwrap();
+    assert_ne!(
+        theirs.status(),
+        202,
+        "another account may not start this recording"
+    );
+
+    server.abort();
+    remove_database(path);
+}
+
 /// Each webhook LiveKit sends does its own job, and says whether to resend.
 ///
 /// The kinds were routed and acted on with nothing asserting either half. An

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -5025,6 +5025,21 @@ async fn a_late_provider_failure_does_not_fail_a_queued_recording() {
         "a completion carrying the expected object queues the transfer"
     );
 
+    // Queued, not merely moved. The row reaching `transferring` is what the
+    // delivery worker looks for, and the queue entry is what tells it to look:
+    // without it the recording waits for the sweeper to notice it was orphaned.
+    let queued = |path: &std::path::Path| -> i64 {
+        rusqlite::Connection::open(path)
+            .unwrap()
+            .query_row(
+                "SELECT count(*) FROM delivery_queue WHERE recording_id = ?1",
+                [&recording_id],
+                |row| row.get(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(queued(&path), 1, "the completion queued the delivery");
+
     // The same egress, reported failed afterwards. Nothing here is delivered,
     // so the row can only move if this webhook moves it.
     let failed = json!({
@@ -5044,6 +5059,11 @@ async fn a_late_provider_failure_does_not_fail_a_queued_recording() {
         state(&path),
         ("transferring".to_string(), None),
         "a stale provider failure must not take back a completed egress"
+    );
+    assert_eq!(
+        queued(&path),
+        1,
+        "and it did not queue a second delivery either"
     );
 
     server.abort();

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -5598,6 +5598,64 @@ async fn the_recorder_reads_the_replay_for_the_room_its_token_names() {
     remove_database(path);
 }
 
+/// The server starts the recording workers it is configured for.
+///
+/// Nothing checked that it does. `web_router` decides whether to spawn them
+/// from the accounts handle and the recorder, and a build that quietly stopped
+/// would serve every request correctly while no recording was ever swept,
+/// delivered or expired. The kill switch makes that observable in a test: it
+/// takes every active row on the first pass, and the first pass runs when the
+/// worker starts rather than a minute later.
+#[tokio::test]
+async fn the_server_starts_the_recording_workers() {
+    let (mut config, _cookie, path) = signed_in_web_config("worker-start");
+    config.recording = Some(codetrial::config::RecordingConfig {
+        kill_switch: true,
+        ..recording_config()
+    });
+
+    // Written before the server exists, because the sweep this asserts on is
+    // the one the worker runs as it starts.
+    rusqlite::Connection::open(&path)
+        .unwrap()
+        .execute_batch(
+            "INSERT INTO interviews (id, account_id, consent_version, consent_at)
+               VALUES ('int-worker', 1, '2026-08-21', 1);
+             INSERT INTO recordings (
+                 id, account_id, interview_id, room_name, idempotency_key,
+                 recipient_email, state, created_at, updated_at
+             ) VALUES ('rec-worker', 1, 'int-worker', 'interview-worker1', 'idem-worker',
+                 'one@example.test', 'recording', 1, 1);",
+        )
+        .unwrap();
+
+    let (_base, server) = spawn_web_server(config).await;
+
+    let state = || {
+        rusqlite::Connection::open(&path)
+            .unwrap()
+            .query_row(
+                "SELECT state FROM recordings WHERE id = 'rec-worker'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap()
+    };
+    for _ in 0..100 {
+        if state() == "failed" {
+            server.abort();
+            remove_database(path);
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    let reached = state();
+    server.abort();
+    remove_database(path);
+    panic!("the sweeper never ran: the recording is still {reached}");
+}
+
 /// The history a candidate reads about their own interviews.
 #[tokio::test]
 async fn history_lists_own_recordings_only() {

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -22,9 +22,9 @@ use codetrial::token::{
     livekit_token,
 };
 use codetrial::web::{
-    MAX_BODY_BYTES, MAX_REPORT_BYTES, REPLAY_RATE_LIMIT, RoomDispatcher, TOKEN_RATE_LIMIT,
-    TokenConfig, WebServerConfig, initialize_account_database, login_config, static_file_meta,
-    token_response,
+    MAX_BODY_BYTES, MAX_REPORT_BYTES, READ_RATE_LIMIT, REPLAY_RATE_LIMIT, RoomDispatcher,
+    TOKEN_RATE_LIMIT, TokenConfig, WebServerConfig, initialize_account_database, login_config,
+    static_file_meta, token_response,
 };
 
 type HmacSha256 = Hmac<Sha256>;
@@ -5173,6 +5173,95 @@ async fn replay_ingestion_rate_limits_a_looping_client() {
         )
         .unwrap();
     assert_eq!(stored, i64::from(REPLAY_RATE_LIMIT));
+
+    server.abort();
+    remove_database(path);
+}
+
+/// Reading a recording costs budget too, and the three read routes share one.
+///
+/// Every one of them was already owner scoped and already bounded per answer,
+/// so what was missing was a bound on how often, and the review read added for
+/// the response window is what made that worth closing: it returns every
+/// `avatar` and `lifecycle` transition where the snapshot returns the newest of
+/// each.
+///
+/// Spent across the three routes rather than one, because they share a bucket
+/// and a test that spent it on one route would pass on a server that gave each
+/// route its own.
+#[tokio::test]
+async fn recording_reads_share_one_rate_limit() {
+    let (base, server, path, client, cookie) = recorded_server("read-rate-limit").await;
+    let interview = start_interview(&client, &base, &cookie).await;
+    rusqlite::Connection::open(&path)
+        .unwrap()
+        .execute(
+            "
+        INSERT INTO recordings (
+            id, account_id, interview_id, room_name, idempotency_key,
+            recipient_email, state, created_at, updated_at
+        ) VALUES ('rec-read', 1, ?1, 'interview-abc12345', ?1,
+            'one@example.test', 'ready', 10, 10)
+        ",
+            [&interview],
+        )
+        .unwrap();
+
+    let paths = [
+        "/api/recordings".to_string(),
+        "/api/recordings/rec-read".to_string(),
+        "/api/recordings/rec-read/events".to_string(),
+        "/api/recordings/rec-read/events?avatar=history".to_string(),
+    ];
+    for spent in 0..READ_RATE_LIMIT {
+        let url = format!("{base}{}", paths[spent as usize % paths.len()]);
+        let response = client
+            .get(&url)
+            .header("cookie", &cookie)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200, "read {spent} should be allowed");
+    }
+
+    // Every route, because one bucket means the next request is refused
+    // whichever of them asks.
+    for path_suffix in &paths {
+        let blocked = client
+            .get(format!("{base}{path_suffix}"))
+            .header("cookie", &cookie)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(blocked.status(), 429, "{path_suffix}");
+        assert_eq!(blocked.headers().get("retry-after").unwrap(), "60");
+    }
+
+    // A different account is untouched, which is what keying on the account
+    // rather than the address buys: both accounts reach this server on the same
+    // loopback address, so an address-keyed bucket would refuse this read too.
+    // It asks for its own listing, the one read of the three it owns anything
+    // to answer.
+    let (other_cookie, _) = second_account(&client, &base, &path).await;
+    let other = client
+        .get(format!("{base}/api/recordings"))
+        .header("cookie", &other_cookie)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(other.status(), 200);
+
+    // Posting a replay still works too: the read budget and the write budget
+    // are separate buckets, so a reviewer reading a history cannot lock a
+    // candidate out of recording their own interview.
+    let posted = client
+        .post(format!("{base}/api/interviews/{interview}/events"))
+        .header("cookie", &cookie)
+        .json(&json!({ "events": [envelope("transcript", json!({ "text": "hello" }))] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(posted.status(), 200);
 
     server.abort();
     remove_database(path);

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -5055,6 +5055,21 @@ async fn a_late_provider_failure_does_not_fail_a_queued_recording() {
 /// The signature covers the exact bytes, so the body is passed as a string and
 /// never re-serialized between here and the request.
 async fn post_webhook(client: &reqwest::Client, base: &str, body: &str) -> reqwest::Response {
+    post_webhook_signed_by(client, base, body, "devkey", b"devsecret").await
+}
+
+/// The same, signed by a named project rather than by the primary one.
+///
+/// A valid signature proves which project sent a webhook, not which project
+/// owns the room it names, and those are different questions once a deployment
+/// has more than one project.
+async fn post_webhook_signed_by(
+    client: &reqwest::Client,
+    base: &str,
+    body: &str,
+    api_key: &str,
+    api_secret: &[u8],
+) -> reqwest::Response {
     use base64::Engine as _;
     use sha2::Digest as _;
 
@@ -5063,7 +5078,7 @@ async fn post_webhook(client: &reqwest::Client, base: &str, body: &str) -> reqwe
         .unwrap()
         .as_secs();
     let claims = json!({
-        "iss": "devkey",
+        "iss": api_key,
         "nbf": now,
         "exp": now + 300,
         "sha256": base64::engine::general_purpose::STANDARD.encode(sha2::Sha256::digest(body.as_bytes())),
@@ -5071,7 +5086,7 @@ async fn post_webhook(client: &reqwest::Client, base: &str, body: &str) -> reqwe
     let header = URL_SAFE_NO_PAD.encode(json!({ "alg": "HS256", "typ": "JWT" }).to_string());
     let payload = URL_SAFE_NO_PAD.encode(claims.to_string());
     let signing_input = format!("{header}.{payload}");
-    let mut mac = HmacSha256::new_from_slice(b"devsecret").unwrap();
+    let mut mac = HmacSha256::new_from_slice(api_secret).unwrap();
     mac.update(signing_input.as_bytes());
     let token = format!(
         "{signing_input}.{}",
@@ -5696,6 +5711,119 @@ async fn the_recorder_reads_the_replay_for_the_room_its_token_names() {
             .unwrap()
             .status(),
         401
+    );
+
+    server.abort();
+    remove_database(path);
+}
+
+/// A signature from one project does not reach another project's room.
+///
+/// The signature proves which project sent the webhook. It does not prove the
+/// project owns the room the webhook names, and a deployment with more than one
+/// LiveKit project has both questions to answer. Without the second one, any
+/// configured project could end another project's recording by naming its room,
+/// and nothing here was asking it.
+#[tokio::test]
+async fn a_webhook_from_another_project_does_not_touch_the_room() {
+    let (mut config, _cookie, path) = signed_in_web_config("webhook-other-project");
+
+    // The recording override: a second key for the same project, which is what
+    // it is for. LiveKit signs a webhook with whichever key the project's
+    // webhook configuration names, and that need not be the key this server
+    // makes Egress calls with, so both have to open this project's own rooms
+    // and neither may open anybody else's.
+    let mut recording = recording_config();
+    recording.livekit = Some(codetrial::config::RecordingLivekit {
+        url: "wss://example.livekit.cloud".to_string(),
+        api_key: "override-key".to_string(),
+        api_secret: "override-secret".to_string(),
+    });
+    config.recording = Some(recording);
+
+    // Two projects, so the intruder's key verifies. The room routes to the
+    // primary one, which is the project that owns this recording.
+    config.pool.providers.push(provider("eu", "eu"));
+
+    // Fresh, because the sweeper starts with the server and fails an active row
+    // that has gone quiet. A recording reaped for being stale would look
+    // exactly like one the intruder ended.
+    let now = codetrial::current_epoch_seconds() as i64;
+    rusqlite::Connection::open(&path)
+        .unwrap()
+        .execute(
+            "INSERT INTO interviews (id, account_id, consent_version, consent_at)
+               VALUES ('int-other', 1, '2026-08-21', ?1)",
+            [now],
+        )
+        .unwrap();
+    rusqlite::Connection::open(&path)
+        .unwrap()
+        .execute(
+            "INSERT INTO recordings (
+                 id, account_id, interview_id, room_name, idempotency_key,
+                 recipient_email, state, egress_id, created_at, updated_at
+             ) VALUES ('rec-other', 1, 'int-other', 'interview-abc12345', 'idem-other',
+                 'one@example.test', 'recording', 'EG_other', ?1, ?1)",
+            [now],
+        )
+        .unwrap();
+
+    let (base, server) = spawn_web_server(config).await;
+    let client = reqwest::Client::new();
+
+    let failed = json!({
+        "event": "egress_ended",
+        "id": "EV_other_project",
+        "createdAt": "1770000123",
+        "egressInfo": { "egressId": "EG_other", "status": "EGRESS_FAILED" }
+    })
+    .to_string();
+
+    // Signed by the other project, correctly. The signature check passes and
+    // the ownership check is the only thing between it and the row.
+    let response = post_webhook_signed_by(&client, &base, &failed, "eu-key", b"eu-secret").await;
+    assert_eq!(
+        response.status(),
+        200,
+        "the message is answered rather than retried forever"
+    );
+
+    let state = || -> String {
+        rusqlite::Connection::open(&path)
+            .unwrap()
+            .query_row(
+                "SELECT state FROM recordings WHERE id = 'rec-other'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(
+        state(),
+        "recording",
+        "another project's webhook must not end this recording"
+    );
+
+    // The override key, for this project's own room, is the case the override
+    // exists for and it has to still work.
+    let owned = json!({
+        "event": "egress_ended",
+        "id": "EV_own_project",
+        "createdAt": "1770000456",
+        "egressInfo": { "egressId": "EG_other", "status": "EGRESS_FAILED" }
+    })
+    .to_string();
+    assert_eq!(
+        post_webhook_signed_by(&client, &base, &owned, "override-key", b"override-secret")
+            .await
+            .status(),
+        200
+    );
+    assert_eq!(
+        state(),
+        "failed",
+        "the project's own second key opens its own room"
     );
 
     server.abort();

--- a/web/interview.js
+++ b/web/interview.js
@@ -58,6 +58,7 @@ import {
   recordReplay,
   recordStage,
   recordStageTick,
+  responseWindowIndex,
 } from "./replay-feed.js";
 import {
   AUDIO_OUTPUT_KEY,
@@ -1100,6 +1101,7 @@ async function consumeTranscript(room, reader, participant) {
   const id = attrs["lk.segment_id"] || reader.info?.id || randomId();
   const speaker = participant?.identity === room.localParticipant.identity ? "you" : "interviewer";
   if (speaker === "interviewer" && !isCurrentAgent(participant)) return;
+  const responseWindow = responseWindowIndex();
   const final = attrs["lk.transcription_final"] === "true";
   let text = "";
   try {
@@ -1119,7 +1121,7 @@ async function consumeTranscript(room, reader, participant) {
     updateCaptions(speaker, text, id);
     // Once per turn, at the end of the stream, not once per chunk: a chunk is a
     // few words and a turn is a sentence, and the replay is read as sentences.
-    recordReplay("transcript", { speaker, text: text.trim() });
+    recordReplay("transcript", { speaker, text: text.trim(), responseWindow });
   }
 }
 

--- a/web/lib.js
+++ b/web/lib.js
@@ -403,19 +403,139 @@ export function loopLabel(value) {
 
 const textEncoder = new TextEncoder();
 
+/// The five versions this build renders, and the only bundle it will score.
+///
+/// Here rather than inside `sanitizeReport` so a test can read it. While it was
+/// function-local, moving it left the whole suite green with the supported-card
+/// branch no longer rendering, which is the defect a local constant invites.
+export const ACTIVE_CONTRACT = {
+  bundleVersion: 4,
+  livePromptVersion: 1,
+  reportPromptVersion: 4,
+  reportSchemaVersion: 1,
+  rubricVersion: 1,
+};
+
+/// The report's contract bundle, and whether this build can score against it.
+///
+/// Two answers rather than one, because they are not the same question. The
+/// bundle is what the report claims and is kept whenever it is well formed, so
+/// a reader is told which rubric produced it. Supported is whether every version
+/// matches this build, and only that decides whether the scores below are shown.
+/// A report with no bundle at all predates the contract and is neither.
+function reportContract(raw) {
+  const keys = Object.keys(ACTIVE_CONTRACT);
+  const claimed = raw?.interviewContract;
+  const wellFormed = claimed && typeof claimed === "object" && !Array.isArray(claimed)
+    && Object.keys(claimed).sort().join(",") === [...keys].sort().join(",")
+    && keys.every((key) => Number.isSafeInteger(claimed[key]) && claimed[key] >= 1 && claimed[key] <= 999);
+  const interviewContract = claimed === undefined
+    ? null
+    : wellFormed ? Object.fromEntries(keys.map((key) => [key, claimed[key]])) : null;
+  const unsupported = claimed !== undefined
+    && (interviewContract === null || keys.some((key) => interviewContract[key] !== ACTIVE_CONTRACT[key]));
+  return { interviewContract, unsupported };
+}
+
+/// The framework evidence rows, bounded and ordered.
+///
+/// Its own function because it is the one part of a report that carries fields
+/// this build has never heard of. Everything else here is a closed shape read
+/// key by key; this one round-trips the unknown, and the rules that make that
+/// safe, a byte ceiling and a null prototype, are easier to hold in one place
+/// than in the middle of the rest.
+function reportEvidence(raw) {
+  const knownEvidenceFields = new Set([
+    "atMs", "phase", "source", "kind", "confidence", "summary", "frameworkVersion",
+  ]);
+  const evidencePhases = new Set(frameworkPhases.map((phase) => phase.toLowerCase()));
+  const frameworkSources = new Set(["candidate_speech", "editor_snapshot", "test_event", "session_timing"]);
+  const frameworkKinds = new Set(["observed", "inferred", "skipped"]);
+  return (Array.isArray(raw?.frameworkEvidence) ? raw.frameworkEvidence : [])
+    .map((item) => {
+      const phase = typeof item?.phase === "string" ? item.phase : "";
+      const source = typeof item?.source === "string" ? item.source : "";
+      const kind = typeof item?.kind === "string" ? item.kind : "";
+      const atMs = Math.trunc(Number(item?.atMs));
+      const confidence = Math.trunc(Number(item?.confidence));
+      const frameworkVersion = Math.trunc(Number(item?.frameworkVersion));
+      const summary = typeof item?.summary === "string" ? boundedText(item.summary, 240).trim() : "";
+      if (!evidencePhases.has(phase) || !frameworkSources.has(source) || !frameworkKinds.has(kind)
+        || (source === "session_timing") !== (kind === "skipped")
+        || !Number.isFinite(atMs) || atMs < 0 || !Number.isFinite(confidence)
+        || confidence < 0 || confidence > 100 || !Number.isFinite(frameworkVersion)
+        || frameworkVersion < 1 || !summary) return null;
+      // Unknown fields round-trip, so a newer report re-saved by an older
+      // client does not quietly lose what that client could not name. They
+      // are also the only part of an evidence row with no size of its own,
+      // and the whole report has to fit what the account sync accepts, which
+      // refuses the request rather than trimming it: over that, the candidate
+      // keeps the local copy and the account copy simply never arrives. So
+      // they are carried while they are a field rather than a payload.
+      // The common row has nothing unknown on it and this runs over whatever
+      // length arrived from storage or the wire, before the cap below trims it,
+      // so that row allocates nothing and is never serialized to be measured.
+      // Null prototype, not `{}`: assigning a key named `__proto__` to a plain
+      // object runs the inherited setter, which ignores a string and drops the
+      // field. A newer client's field is not ours to name, so it cannot be ours
+      // to lose either.
+      let extras = null;
+      for (const key of Object.keys(item)) {
+        if (!knownEvidenceFields.has(key)) (extras ??= Object.create(null))[key] = item[key];
+      }
+      // Spreading null spreads nothing, which is what both the common row and
+      // an over-budget one want.
+      const carried = extras && textEncoder.encode(JSON.stringify(extras)).length <= 512 ? extras : null;
+      return {
+        ...carried,
+        // A year, which no interview approaches: this is a sanity bound on a
+        // timestamp that arrives as untrusted JSON, not a statement about how
+        // long a session runs.
+        atMs: clamp(atMs, 0, 31_536_000_000),
+        phase,
+        source,
+        kind,
+        confidence,
+        summary,
+        frameworkVersion,
+      };
+    })
+    .filter(Boolean)
+    .slice(0, 64)
+    .sort((left, right) => left.atMs - right.atMs);
+}
+
+/// The two rounds an interview is made of, or nothing.
+///
+/// All or nothing on purpose: the pair is one statement about how the time was
+/// divided, and half of it is not a shorter version of that statement, it is a
+/// different and unsupported one. So a round that fails any of its own rules,
+/// or a pair whose budgets do not add up to a length this product offers, or a
+/// behavioral round that disagrees with the loop the report recorded, returns
+/// the empty list rather than the half that parsed.
+function reportRounds(raw, interviewLoop) {
+  const kinds = ["coding", "behavioral"];
+  const codingStatuses = new Set(["complete", "incomplete"]);
+  const behavioralStatuses = new Set(["complete", "started", "skipped", "not_configured"]);
+  const rounds = Array.isArray(raw?.rounds) && raw.rounds.length === 2
+    ? raw.rounds.map((round, index) => round?.kind === kinds[index]
+      && Number.isInteger(round.budgetMin) && round.budgetMin >= 0 && round.budgetMin <= 90
+      && (index === 0 ? codingStatuses : behavioralStatuses).has(round.status)
+      ? { kind: round.kind, budgetMin: round.budgetMin, status: round.status } : null)
+    : [];
+  // `[].every(Boolean)` is true, so the pair has to be proved present before
+  // anything reads into it. Writing the length test second cost an exception on
+  // every report with no rounds at all, which is most of them.
+  if (rounds.length !== 2 || !rounds.every(Boolean)) return [];
+  const total = rounds[0].budgetMin + rounds[1].budgetMin;
+  const behavioralFits = interviewLoop === "coding_only"
+    ? rounds[1].budgetMin === 0 && rounds[1].status === "not_configured"
+    : rounds[1].budgetMin === 8 && rounds[1].status !== "not_configured";
+  return total >= 10 && total <= 90 && behavioralFits ? rounds : [];
+}
+
 export function sanitizeReport(raw) {
-  const activeContract = { bundleVersion: 4, livePromptVersion: 1, reportPromptVersion: 4, reportSchemaVersion: 1, rubricVersion: 1 };
-  const contractKeys = Object.keys(activeContract);
-  const candidateContract = raw?.interviewContract;
-  const contractValues = candidateContract && typeof candidateContract === "object" && !Array.isArray(candidateContract)
-    ? Object.keys(candidateContract).sort().join(",") === [...contractKeys].sort().join(",")
-      && contractKeys.every((key) => Number.isSafeInteger(candidateContract[key])
-        && candidateContract[key] >= 1 && candidateContract[key] <= 999)
-      ? Object.fromEntries(contractKeys.map((key) => [key, candidateContract[key]])) : null
-    : null;
-  const interviewContract = candidateContract === undefined ? null : contractValues;
-  const unsupportedContract = candidateContract !== undefined
-    && (interviewContract === null || contractKeys.some((key) => interviewContract[key] !== activeContract[key]));
+  const { interviewContract, unsupported: unsupportedContract } = reportContract(raw);
   // Only what the report actually recorded. Defaulting this to "scored" put a
   // mode on every new report and made the header announce a distinction that no
   // longer exists; a report written before the split still says what it was.
@@ -426,22 +546,7 @@ export function sanitizeReport(raw) {
   // never ran, the same way defaulting the mode did.
   const interviewLoop = codingLoop(raw?.interviewLoop);
   const recordedLoop = raw?.interviewLoop === undefined ? undefined : interviewLoop;
-  const roundKinds = ["coding", "behavioral"];
-  const codingStatuses = new Set(["complete", "incomplete"]);
-  const behavioralStatuses = new Set(["complete", "started", "skipped", "not_configured"]);
-  const rounds = Array.isArray(raw?.rounds) && raw.rounds.length === 2
-    ? raw.rounds.map((round, index) => round?.kind === roundKinds[index]
-      && Number.isInteger(round.budgetMin) && round.budgetMin >= 0 && round.budgetMin <= 90
-      && (index === 0 ? codingStatuses : behavioralStatuses).has(round.status)
-      ? { kind: round.kind, budgetMin: round.budgetMin, status: round.status } : null)
-    : [];
-  const roundSummary = rounds.length === 2 && rounds.every(Boolean)
-    && rounds[0].budgetMin + rounds[1].budgetMin >= 10
-    && rounds[0].budgetMin + rounds[1].budgetMin <= 90
-    && (interviewLoop === "coding_only"
-      ? rounds[1].budgetMin === 0 && rounds[1].status === "not_configured"
-      : rounds[1].budgetMin === 8 && rounds[1].status !== "not_configured")
-    ? rounds : [];
+  const roundSummary = reportRounds(raw, interviewLoop);
   const bounded = (value, max) => {
     const number = Math.trunc(Number(value));
     return Number.isFinite(number) ? clamp(number, 0, max) : 0;
@@ -549,64 +654,8 @@ export function sanitizeReport(raw) {
       phases: assessmentPhases.map((phase) => normalizedAssessment.get(phase)),
     }
     : null;
-  const knownEvidenceFields = new Set([
-    "atMs", "phase", "source", "kind", "confidence", "summary", "frameworkVersion",
-  ]);
-  const evidencePhases = new Set(frameworkPhases.map((phase) => phase.toLowerCase()));
-  const frameworkSources = new Set(["candidate_speech", "editor_snapshot", "test_event", "session_timing"]);
-  const frameworkKinds = new Set(["observed", "inferred", "skipped"]);
-  const frameworkEvidence = (Array.isArray(raw?.frameworkEvidence) ? raw.frameworkEvidence : [])
-    .map((item) => {
-      const phase = typeof item?.phase === "string" ? item.phase : "";
-      const source = typeof item?.source === "string" ? item.source : "";
-      const kind = typeof item?.kind === "string" ? item.kind : "";
-      const atMs = Math.trunc(Number(item?.atMs));
-      const confidence = Math.trunc(Number(item?.confidence));
-      const frameworkVersion = Math.trunc(Number(item?.frameworkVersion));
-      const summary = typeof item?.summary === "string" ? boundedText(item.summary, 240).trim() : "";
-      if (!evidencePhases.has(phase) || !frameworkSources.has(source) || !frameworkKinds.has(kind)
-        || (source === "session_timing") !== (kind === "skipped")
-        || !Number.isFinite(atMs) || atMs < 0 || !Number.isFinite(confidence)
-        || confidence < 0 || confidence > 100 || !Number.isFinite(frameworkVersion)
-        || frameworkVersion < 1 || !summary) return null;
-      // Unknown fields round-trip, so a newer report re-saved by an older
-      // client does not quietly lose what that client could not name. They
-      // are also the only part of an evidence row with no size of its own,
-      // and the whole report has to fit what the account sync accepts, which
-      // refuses the request rather than trimming it: over that, the candidate
-      // keeps the local copy and the account copy simply never arrives. So
-      // they are carried while they are a field rather than a payload.
-      // The common row has nothing unknown on it and this runs over whatever
-      // length arrived from storage or the wire, before the cap below trims it,
-      // so that row allocates nothing and is never serialized to be measured.
-      // Null prototype, not `{}`: assigning a key named `__proto__` to a plain
-      // object runs the inherited setter, which ignores a string and drops the
-      // field. A newer client's field is not ours to name, so it cannot be ours
-      // to lose either.
-      let extras = null;
-      for (const key of Object.keys(item)) {
-        if (!knownEvidenceFields.has(key)) (extras ??= Object.create(null))[key] = item[key];
-      }
-      // Spreading null spreads nothing, which is what both the common row and
-      // an over-budget one want.
-      const carried = extras && textEncoder.encode(JSON.stringify(extras)).length <= 512 ? extras : null;
-      return {
-        ...carried,
-        // A year, which no interview approaches: this is a sanity bound on a
-        // timestamp that arrives as untrusted JSON, not a statement about how
-        // long a session runs.
-        atMs: clamp(atMs, 0, 31_536_000_000),
-        phase,
-        source,
-        kind,
-        confidence,
-        summary,
-        frameworkVersion,
-      };
-    })
-    .filter(Boolean)
-    .slice(0, 64)
-    .sort((left, right) => left.atMs - right.atMs);
+  const frameworkEvidence = reportEvidence(raw);
+
   // A report with nothing in it must survive normalization as a report with
   // nothing in it. Falling through to the fields below would score the missing
   // numbers as 0 and coerce the missing decision to NO_HIRE, which is how a

--- a/web/lib.js
+++ b/web/lib.js
@@ -836,3 +836,289 @@ export function providerUiState(kind, detail = "") {
   };
   return states[kind] || states.degraded;
 }
+
+/// The candidate's own words in one transcript event, or nothing.
+///
+/// Two questions, and both have to be answered before a window may say a turn
+/// closed it. Whose line it is: `consumeTranscript` in `web/interview.js` writes
+/// `"you"` for the local participant and `"interviewer"` for the agent, and
+/// `web/replay.js` reads a missing speaker as the candidate, so anything that is
+/// not the interviewer is the candidate. And whether there is a line at all: a
+/// payload with no text, a non-string text, or whitespace is not a turn, and
+/// counting it as one would take the "no transcript in this window" note off a
+/// window that has none. Our own producer cannot emit that shape, which is
+/// exactly why nothing downstream would notice if some later one did.
+function candidateTurnText(event) {
+  if ((event.payload?.speaker || "candidate") === "interviewer") return "";
+  const text = event.payload?.text;
+  return typeof text === "string" ? text.trim() : "";
+}
+
+/// How long a window lasted, or nothing when the clock will not say.
+///
+/// `at` is the candidate's own browser clock and it can jump: a `thinking`
+/// stamped before the `listening` it closes is not a negative duration, it is a
+/// clock that moved. Null rather than a number, because a reader can be told
+/// "not measurable" and cannot be told what a negative second means.
+function windowSpan(start, end) {
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  const duration = end - start;
+  return duration >= 0 ? duration : null;
+}
+
+/// The gap between Jim finishing a question and Jim starting on the answer.
+///
+/// Screen evidence and gaze evidence are both designed around by the shipped
+/// interview assistants; what none of them removes is time, because each still
+/// needs the question to finish, a turn to close, a model round trip, and the
+/// candidate to read. That lands in this window, so this is what the replay page
+/// renders.
+///
+/// What it can show is bounded by the interviewer, and the bound is the first
+/// thing to know about the number. `timing_decision` in `src/agent.rs` nudges a
+/// candidate who has been silent for `SILENCE_THRESHOLD_S`, and the nudge makes
+/// Jim speak, which closes the window. Neither talking nor typing counts as
+/// silence, so a window runs long only while the candidate is working, and a
+/// candidate who is silently reading is interrupted at twenty-five seconds and
+/// gets a run of short windows instead of one long one. A long window therefore
+/// means the candidate was busy, which is the innocent reading; the shape that
+/// is not innocent is several windows in a row holding no transcript at all.
+///
+/// It is a duration and not a finding, and two things make it softer than it
+/// looks. `at` is the candidate's own browser clock, which
+/// `src/recording/replay.rs` documents as never trusted for ordering. And
+/// `web/interview.js` falls back to `listening` when the agent publishes no
+/// `lk.agent.state`, so some `listening` rows mean "attribute absent" rather
+/// than "Jim stopped". Both belong beside any number this produces.
+///
+/// Ordering is the array's, which is `seq` order from the server. `at` is read
+/// for the duration and for nothing else, which is the same rule
+/// `src/recording/replay.rs` applies to its own rows.
+///
+/// A window opens on a `listening` row whose previous `avatar` row was
+/// `speaking`, and closes on the next `speaking` or `thinking`. Both halves of
+/// that are about what the server actually publishes rather than about what the
+/// state names suggest.
+///
+/// `src/livekit.rs` declares two agent states, `listening` and `speaking`, and
+/// every `set_agent_state` call writes one of them; nothing writes `thinking`.
+/// So a real interview records `listening, speaking, listening, speaking, ...`,
+/// and a window that closed only on `thinking` never closed at all: one row per
+/// interview reading "duration not recorded", however many questions were asked.
+/// `thinking` still closes a window, for a deployment that publishes it, but it
+/// is not what closes one today.
+///
+/// Closing on `speaking` puts CodeTrial's own model round trip inside the
+/// number, because the interviewer starts speaking after it rather than after
+/// the candidate stops. `src/livekit.rs` already measures that round trip on the
+/// server's own clock and logs it; joining the two is a server change and is
+/// written up as a candidate improvement, not done here.
+///
+/// Opening on the previous row rather than on a latch is what keeps three
+/// non-questions from opening a window. The first `avatar` row of almost every
+/// interview is a `listening` written on first sight of the agent participant,
+/// before a question exists. A `listening` that follows a `thinking` is the
+/// interviewer having thought and said nothing. And a `listening` with no
+/// earlier row at all is a replay that starts mid-interview. A latch would admit
+/// the second of those, because "has spoken at some point" stays true.
+///
+/// What it does not exclude is an interviewer that stopped speaking for a
+/// reason other than finishing a question, and the commonest one is the
+/// interviewer itself. A silence nudge, a proactive review, a reaction to a
+/// test run, the time warning, the round transition and the wrap-up all end in
+/// a `speaking` row followed by a `listening` row, and none of them is a
+/// question. The candidate interrupting, the agent dropping out and coming
+/// back, a Gemini socket restart, and the candidate pressing Pause while the
+/// interviewer is mid-turn write the same pair. There is no row that tells
+/// those from a question ending, so the page says so beside the number rather
+/// than guessing.
+///
+/// The pause is the exception, because there is a row: `applyPause` in
+/// `web/interview.js` records a `lifecycle` `paused`, and its comment says why,
+/// which is that a break must be visible rather than passing as thinking time.
+/// A window overlapping one carries `paused`, and the page says so on that
+/// window rather than only in the paragraph above the list. Marked rather than
+/// hidden or subtracted: how long the break was is in the rows, and a duration
+/// this function silently shortened would be a number nothing on the page
+/// explains.
+///
+/// Six shapes, because `recordAvatarState` writes only on a change and an
+/// interview can stop anywhere:
+///
+/// - A `listening` with no later close is a window that never closed. It is
+///   returned with a null duration rather than dropped, because an interview
+///   that ended mid-answer is still a window a reviewer may want to open.
+/// - A closed window holding no candidate turn returns a null turn rather than
+///   being dropped. The interviewer asking twice with nothing said in between is
+///   exactly the shape worth seeing, and it is two windows rather than one:
+///   the re-prompt closes the first and opens the second, so the unanswered ask
+///   is visible on its own instead of being folded into the answered one.
+/// - A `listening` the interviewer was not speaking before starts no window.
+/// - A close whose `at` precedes its `listening` returns a null duration rather
+///   than a negative one.
+/// - A window the interview was paused during carries `paused`, whichever of
+///   the two rows arrived first.
+/// - Nothing after a `lifecycle` `ended` row is read, because the interview is
+///   over and the goodbye is not a question.
+export function responseWindows(events) {
+  const windows = [];
+  const windowsById = new Map();
+  let open = null;
+  /// The previous `avatar` state, which is what decides whether a `listening`
+  /// row is the end of a question or something else. `null` until the first one,
+  /// so a replay that opens on a `listening` starts no window.
+  let previous = null;
+  /// Whether the interview is paused right now, from the `lifecycle` rows.
+  /// Carried across the whole scan rather than read per window, because the
+  /// `paused` row and the `listening` row a pause causes are written by two
+  /// different sides and either can land first.
+  let paused = false;
+  for (const [index, event] of replayRows(events).entries()) {
+    if (event?.kind === "lifecycle") {
+      const state = event.payload?.state;
+      if (state === "paused" || state === "resumed") paused = state === "paused";
+      // A window already open when the break started keeps the mark, which is
+      // the ordinary case: the candidate pauses during their own turn and no
+      // `avatar` row is written at all.
+      if (paused && open) open.paused = true;
+      // The interview is over. `send_wrap_up_and_wait` in `src/livekit.rs` ends
+      // by setting `listening` again, and the browser keeps recording past
+      // `ended` to write `rounds_final`, so without this every timed-out
+      // interview finishes with a window opened by the goodbye and closed by
+      // nothing. That row is not an interview that stopped mid-answer, which is
+      // what an unclosed window otherwise means.
+      if (state === "ended") break;
+      continue;
+    }
+    if (event?.kind === "transcript") {
+      const text = candidateTurnText(event);
+      // The stream can finish after the next question opens. Its window index
+      // is captured before that await; sequence position is not.
+      //
+      // A row without one is a recording made before the producer stamped them,
+      // or one whose stream started before the first window opened. There is
+      // exactly one shape those can be placed in without guessing: a single
+      // window that is still open is the only window the turn could belong to.
+      // Past that the answer is unknowable, and `matched` below is what stops
+      // the page reading the silence as a claim.
+      const responseWindow = event.payload?.responseWindow;
+      const target = Number.isInteger(responseWindow)
+        ? windowsById.get(responseWindow)
+        : windows.length === 1 && open === windows[0]
+          ? open
+          : null;
+      if (target && text) target.turn = { at: event.at, text };
+      continue;
+    }
+    if (event?.kind !== "avatar") continue;
+    const state = event.payload?.state;
+    // Read before either branch and written after both, so "the previous row"
+    // means the previous `avatar` row and not the previous row of any kind.
+    const before = previous;
+    previous = state;
+
+    // The interviewer speaking is proof the interview is not paused, which is
+    // what bounds a lost `resumed` row to the windows before it. `watch_prompt`
+    // in `src/livekit/turn.rs` returns nothing while `state.paused`, and
+    // `handle_gemini_event` in `src/livekit.rs` drops every audio event then, so
+    // there is no path from a paused interview to a `speaking` row. Without this
+    // one dropped batch painted every remaining window as paused, and that mark
+    // is the panel's only affirmative claim.
+    if (state === "speaking") paused = false;
+
+    // Closed first. A `speaking` row both ends the window before it and, on the
+    // next `listening`, opens the one after; taking them in the other order
+    // would let one row close a window it had just opened.
+    if ((state === "speaking" || state === "thinking") && open) {
+      open.duration = windowSpan(open.at, event.at);
+      open = null;
+    }
+    if (state === "listening" && !open && before === "speaking") {
+      // `paused` is read here as well, for the other order: pausing mid-turn
+      // makes the server publish `listening`, so the window this opens is the
+      // break itself.
+      // `matched` is whether a turn could have been attributed to this window
+      // at all, which is not the same question as whether one was. A window
+      // whose opening row carries an index can be named by a transcript row, so
+      // an empty one means nothing was said. A window with no index can only be
+      // reached by the single-window fallback above, so an empty one means the
+      // recording cannot say, and the page owes the reader that difference:
+      // "nothing recorded" is a claim about the candidate and this is the one
+      // place the panel could make a false one.
+      const responseWindow = event.payload?.responseWindow;
+      const matched = Number.isInteger(responseWindow);
+      open = { index, at: event.at, duration: null, turn: null, paused, matched };
+      windows.push(open);
+      if (matched) windowsById.set(responseWindow, open);
+    }
+  }
+  return windows;
+}
+
+/// What one response window says, as the pieces it is joined from.
+///
+/// Pure and given its words, so that a test can hand it a table of sentinels and
+/// assert that nothing came out which the table did not put in. That is the only
+/// form of "the panel does not accuse" that is actually observable: reading the
+/// renderer's source for labels catches a literal and misses a helper, a
+/// computed lookup, and a second table declared beside the first, all three of
+/// which were written and shown to pass a source-reading version of this check.
+///
+/// The clock is not here. It is the caller's, because formatting a wall-clock
+/// time is `toLocaleTimeString` and that is the browser's job, not this one's.
+export function responseWindowLabel(span, words) {
+  const parts = [
+    words.label,
+    span.duration === null
+      ? words.unmeasured
+      : `${(span.duration / 1000).toFixed(1)}${words.seconds}`,
+  ];
+  if (span.paused) parts.push(words.paused);
+  if (!span.turn) parts.push(span.matched ? words.noTurn : words.unmatchedTurn);
+  return parts;
+}
+
+/// Whatever arrived where a list of events was expected, as a list of events.
+///
+/// The server sends an array and the page reads `body.events || []` off a parsed
+/// JSON body, which is one bad deploy or one proxy away from a string or an
+/// object. `.entries()` on either throws, and a throw here paints a blank panel
+/// where the page had a sentence ready to explain itself. An empty replay is the
+/// honest answer to a body that is not one.
+export function replayRows(events) {
+  return Array.isArray(events) ? events : [];
+}
+
+/// The replay page's timeline, assembled without a DOM.
+///
+/// Two lists and the order they interleave in, which is every decision the page
+/// makes about the timeline and none of the drawing. Here rather than in
+/// `web/replay.js` for the reason `web/devices.js` and `web/face-check.js` are
+/// here: that file reads `document.querySelector` at module scope, so importing
+/// it costs a stub document and a module hook, and a helper that needs neither
+/// belongs where neither is needed.
+///
+/// The windows are their own list and do not join `moments`. `data-moment`
+/// indexes that array and the page rebuilds the code and the test result by
+/// scanning its prefix, so a third kind mixed in would shift every index and
+/// then be scanned over as neither an editor nor a test snapshot.
+export function replayTimeline(events) {
+  const rows = replayRows(events);
+  const moments = [];
+  const windows = responseWindows(rows);
+  // Keyed by the position of the `avatar` row that opened each window, which is
+  // the only ordering `responseWindows` trusts. One window per position, so no
+  // two entries can collide.
+  const opened = new Map(windows.map((span, index) => [span.index, index]));
+  const timeline = [];
+  for (const [index, event] of rows.entries()) {
+    if (event?.kind === "editor" || event?.kind === "tests") {
+      moments.push(event);
+      timeline.push({ moment: moments.length - 1 });
+      continue;
+    }
+    const opening = opened.get(index);
+    if (opening !== undefined) timeline.push({ window: opening });
+  }
+  return { moments, windows, timeline };
+}

--- a/web/replay-feed.js
+++ b/web/replay-feed.js
@@ -42,6 +42,8 @@ let replayTimer = null;
 let replayClosed = false;
 let replayStageAt = 0;
 let replayAvatarState = "";
+let replayWindow = -1;
+let replayWindowOpen = false;
 
 /// One event onto the queue.
 ///
@@ -211,6 +213,13 @@ export function recordStageTick(remainingSeconds) {
 /// one event, not sixty.
 export function recordAvatarState(value) {
   if (value === replayAvatarState) return;
+  const opensWindow = value === "listening" && replayAvatarState === "speaking";
+  if (opensWindow) replayWindow += 1;
+  replayWindowOpen = opensWindow;
   replayAvatarState = value;
-  recordReplay("avatar", { state: value });
+  recordReplay("avatar", { state: value, responseWindow: opensWindow ? replayWindow : null });
+}
+
+export function responseWindowIndex() {
+  return replayWindowOpen ? replayWindow : null;
 }

--- a/web/replay.html
+++ b/web/replay.html
@@ -39,9 +39,49 @@
           </section>
           <section>
             <h3>Moments</h3>
-            <!-- Every editor and test snapshot, by the time it happened. The
-                 replay is a list of moments rather than a video scrubber,
-                 because the events are what this server has. -->
+            <!-- Every editor and test snapshot, plus every response window, by
+                 the time each happened. The replay is a list of moments rather
+                 than a video scrubber, because the events are what this server
+                 has. -->
+            <!-- The one place the window wording is written for the browser.
+                 What the number measures, whose clock measured it, what a
+                 window with no duration means, what bounds how long one can
+                 run, why a window can open without a question having ended,
+                 what a lost batch does to any of that, and what a long window
+                 is worth.
+
+                 tests/browser/replay-render.test.js drives this page and reads
+                 back what it rendered, and tests/browser/history.test.js holds
+                 this paragraph and every other string in the markup. Between
+                 them they catch a label added the way a person adds one. They
+                 are not a proof and the tests say where they stop: three
+                 commits claimed otherwise and a reviewer found more each time.
+                 What neither bounds is what the server says, which this page
+                 prints verbatim: the recording state, and a moment's kind. -->
+            <p id="replay-window-note" class="muted small" hidden>
+              A response window is the time between the interviewer finishing a turn and
+              the interviewer speaking again. It is measured from the clock of the
+              browser that recorded the interview, which can jump forward as well as
+              back, and it includes the time CodeTrial itself took to prepare the reply,
+              which is not the same on every turn. The interviewer speaks again on its
+              own after about twenty-five seconds of silence, and neither talking nor
+              typing counts as silence, so a window runs long only while the candidate
+              is working: a long window means they were busy, and a run of short windows
+              holding no transcript is what silence looks like. A window opens whenever
+              the interviewer stops speaking, which is often not the end of a question:
+              it also follows the interviewer's own prompts and reactions, a candidate
+              interrupting, a moment when the interviewer published no state at all, the
+              interviewer dropping out and coming back, and the candidate pausing the
+              interview, which is the one of those a window says on itself. Events reach
+              the server in batches and a batch can be lost, so a window can be missing,
+              doubled, shown with no candidate transcript, wrongly marked as paused, or
+              added after the interview ended. A window shows no duration when the
+              recording ended inside it, or when that clock ran backwards. Each turn
+              carries the window its stream started in, and a recording made before
+              that says so on every window it cannot place, rather than reporting a
+              question nobody answered. A long window is a place in the recording to go
+              and watch, not a finding about anybody.
+            </p>
             <ol id="replay-timeline" class="replay-timeline"></ol>
           </section>
         </div>

--- a/web/replay.js
+++ b/web/replay.js
@@ -11,7 +11,7 @@
 // section it already serves.
 
 import { reportMarkup } from "/render.js";
-import { modeLabel, sanitizeReport } from "/lib.js";
+import { modeLabel, replayRows, replayTimeline, responseWindowLabel, sanitizeReport } from "/lib.js";
 
 const nodes = {
   list: document.querySelector("#replay-list"),
@@ -22,6 +22,7 @@ const nodes = {
   media: document.querySelector("#replay-media"),
   transcript: document.querySelector("#replay-transcript"),
   timeline: document.querySelector("#replay-timeline"),
+  windowNote: document.querySelector("#replay-window-note"),
   momentLabel: document.querySelector("#replay-moment-label"),
   code: document.querySelector("#replay-code"),
   tests: document.querySelector("#replay-tests"),
@@ -59,6 +60,51 @@ let latest = { code: "", language: "" };
 const GONE_WORDS = {
   replay_expired: "This recording is past its 24 hours and has been deleted.",
   recording_deleted: "This recording has been deleted.",
+};
+
+/// Every word a response window may put on the timeline.
+///
+/// One object, because `tests/browser/history.test.js` holds it to an allowlist,
+/// alongside every other string this file can say. "No severity language
+/// anywhere" is a negative no test can observe; "these strings and no others" is
+/// one it can, and it is what tells the next person who reaches for a label that
+/// the wording is a decision rather than a blank.
+///
+/// That allowlist is the static half. The other half is
+/// `tests/browser/replay-render.test.js`, which drives this page through a stub
+/// document and reads back what it rendered, because a table of allowed strings
+/// says nothing about where they are put or what is put beside them.
+///
+/// The sentence explaining what the number is worth is not here. It is the
+/// static `#replay-window-note` in `web/replay.html`, written once, because a
+/// paragraph that needs no state does not need a renderer.
+const WINDOW_WORDS = {
+  label: "response window",
+  seconds: " s",
+  separator: " · ",
+  /// Both reasons `responseWindows` returns a null duration: a window the
+  /// recording ended inside, and a clock that ran backwards between the two
+  /// rows. One phrase for both, because neither is a measurement and the note
+  /// above the list says what they are.
+  unmeasured: "duration not recorded",
+  /// A window a transcript row could have named and none did. The producer
+  /// stamps each turn with the window its stream started in, so this is a fact
+  /// about the interview rather than about the record: the candidate said
+  /// nothing between the interviewer's two turns.
+  noTurn: "no candidate transcript recorded",
+  /// A window nothing could have named, which is a fact about the recording
+  /// instead. Recordings made before the producer stamped its turns carry no
+  /// index to match on, and past the first window there is no way to place a
+  /// turn without guessing at timing.
+  ///
+  /// Its own sentence rather than `noTurn`, because that one is the only claim
+  /// about the candidate this panel makes, and making it on a recording that
+  /// cannot support it is the one thing here that would be false rather than
+  /// merely withheld.
+  unmatchedTurn: "transcript not matched to a window",
+  /// The one cause of a long window the replay can name; why, in
+  /// `responseWindows`.
+  paused: "interview paused during this window",
 };
 
 export function momentTime(at) {
@@ -141,6 +187,11 @@ async function select(recordingId) {
 
 function clearDetail() {
   latest = { code: "", language: "" };
+  // The paragraph explaining a response window is hidden until there is one to
+  // explain. A replay with no `avatar` rows is a replay this feature has nothing
+  // to say about, and a standing note about an empty list reads as a promise the
+  // page did not keep.
+  nodes.windowNote.hidden = true;
   nodes.momentLabel.textContent = "Code";
   nodes.status.textContent = "";
   nodes.media.textContent = "";
@@ -151,8 +202,33 @@ function clearDetail() {
   nodes.report.replaceChildren();
 }
 
+/// The events, with the `avatar` history rather than the newest `avatar` row.
+///
+/// A response window is computed from the `avatar` rows and marked from the
+/// `lifecycle` ones, and the default read keeps one of each: both are snapshot
+/// kinds on the server, so the newest row supersedes every earlier one. Three
+/// ways to reach the history, and this is the one that was taken.
+///
+///  - `?after=0` alone, with no server change. The tail collapses nothing, so it
+///    also returns every superseded `editor` snapshot, a whole code buffer per
+///    debounce, bounded only by the per-interview replay ceiling, sent to a page
+///    that wants one buffer and a list of states. And the tail floors its `after`
+///    at 0 against a `seq > ?` bound, so `seq` 0 is unreachable through it.
+///  - Dropping `Avatar` from `ReplayKind::is_snapshot`. The smallest diff and
+///    the wrong one; `ReplayClass` in `src/recording/replay.rs` says why.
+///  - A read that collapses only what restates a whole value, `editor` and
+///    `stage`, so the `avatar` and `lifecycle` transitions survive. This one. It
+///    costs a server change and a query parameter, and it is the only one of the
+///    three where the page pays for what it reads.
+///
+/// `seq` 0 comes with it. This read binds `after` at `-1` as the snapshot does,
+/// so the bound is `seq > -1` and the first event of the interview is in the
+/// answer; nothing here has to argue that the first event does not matter,
+/// because it is not missing.
 async function loadEvents(recordingId) {
-  const response = await fetch(`/api/recordings/${encodeURIComponent(recordingId)}/events`);
+  const response = await fetch(
+    `/api/recordings/${encodeURIComponent(recordingId)}/events?avatar=history`,
+  );
   if (selected !== recordingId) return;
   if (!response.ok) {
     const body = await response.json().catch(() => ({}));
@@ -183,7 +259,13 @@ async function loadEvents(recordingId) {
 /// replaces the last one. Every snapshot keeps its time, so a moment can be
 /// opened rather than scrubbed to.
 export function render(events) {
-  const stage = events.findLast((event) => event.kind === "stage");
+  // Guarded here rather than only inside `replayTimeline`. The page reads
+  // `body.events || []` off a parsed JSON body on the path where the response
+  // was already `ok`, so a string or an object there is one bad deploy away, and
+  // `findLast` on either throws before anything defensive downstream is reached.
+  // A throw paints a blank panel where this page had a sentence ready.
+  const rows = replayRows(events);
+  const stage = rows.findLast((event) => event?.kind === "stage");
   // Only where the recording actually carried one. Reading it unconditionally
   // floored `undefined` to "Scored" and announced a distinction that no longer
   // exists on every replay made since the practice mode was removed.
@@ -193,30 +275,74 @@ export function render(events) {
       ? `${nodes.status.textContent} · ${mode}`
       : mode;
   }
-  const moments = [];
-  for (const event of events) {
-    if (event.kind === "transcript") {
-      const line = document.createElement("li");
-      line.className = "replay-line";
-      line.textContent = `${momentTime(event.at)} ${event.payload?.speaker || "candidate"}: ${event.payload?.text || ""}`;
-      nodes.transcript.append(line);
-      continue;
-    }
-    if (event.kind === "editor" || event.kind === "tests") moments.push(event);
+  for (const event of rows) {
+    if (event?.kind !== "transcript") continue;
+    const line = document.createElement("li");
+    line.className = "replay-line";
+    line.textContent = `${momentTime(event.at)} ${event.payload?.speaker || "candidate"}: ${event.payload?.text || ""}`;
+    nodes.transcript.append(line);
   }
 
-  for (const [index, moment] of moments.entries()) {
-    const item = document.createElement("li");
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = "replay-moment";
-    button.dataset.moment = String(index);
-    button.textContent = `${momentTime(moment.at)} · ${moment.kind}`;
-    button.addEventListener("click", () => showMoment(moments, index));
-    item.append(button);
-    nodes.timeline.append(item);
-  }
+  // Two lists, not one: a window does not join `moments`, because `showMoment`
+  // scans that list as editor and test snapshots. They are interleaved in one
+  // timeline because that is where a reader looks for both.
+  const { moments, windows, timeline } = replayTimeline(rows);
+
+  nodes.windowNote.hidden = windows.length === 0;
+  // Appended once. Interleaving the windows roughly quadruples this list, and a
+  // node at a time is a layout pass at a time.
+  nodes.timeline.append(
+    ...timeline.map((entry) => {
+      const item = document.createElement("li");
+      item.append(
+        entry.window === undefined
+          ? momentButton(moments, entry.moment)
+          : windowItem(windows[entry.window], entry.window),
+      );
+      return item;
+    }),
+  );
   if (moments.length) showMoment(moments, moments.length - 1);
+}
+
+function momentButton(moments, index) {
+  const moment = moments[index];
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "replay-moment";
+  button.dataset.moment = String(index);
+  button.textContent = `${momentTime(moment.at)} · ${moment.kind}`;
+  button.addEventListener("click", () => showMoment(moments, index));
+  return button;
+}
+
+/// One response window, in the only words it is allowed.
+///
+/// Every string it can write comes from `WINDOW_WORDS`, and what is left here is
+/// a time, a number and the separators between them. What holds that is
+/// `tests/browser/replay-render.test.js`, which renders this row and reads
+/// the result rather than reading this source: twelve ways to put a word on this
+/// page were closed one at a time by reading source, and a thirteenth kept
+/// arriving until the check started reading the output instead.
+function windowItem(span, index) {
+  const item = document.createElement("div");
+  item.className = "replay-window";
+  item.dataset.window = String(index);
+  // The clock here and every word from `responseWindowLabel`, which is given
+  // `WINDOW_WORDS` and can say nothing else. Empty parts dropped rather than
+  // joined: `momentTime` answers a clock it cannot read with "", and joining
+  // that left the label opening on a separator with nothing in front of it.
+  item.textContent = [momentTime(span.at), ...responseWindowLabel(span, WINDOW_WORDS)]
+    .filter(Boolean)
+    .join(WINDOW_WORDS.separator);
+  return item;
+}
+
+/// The editor or test moment currently shown in the panels.
+function markCurrent(index) {
+  for (const button of nodes.timeline.querySelectorAll("[data-moment]")) {
+    button.classList.toggle("current", button.dataset.moment === String(index));
+  }
 }
 
 /// The editor and the test results as they stood at one moment.
@@ -243,9 +369,7 @@ function showMoment(moments, index) {
   nodes.tests.textContent = tests
     ? `${tests.passed ?? 0}/${tests.total ?? 0} passing`
     : "No test run before this point.";
-  for (const button of nodes.timeline.querySelectorAll("[data-moment]")) {
-    button.classList.toggle("current", Number(button.dataset.moment) === index);
-  }
+  markCurrent(index);
 }
 
 /// The report, which is `/api/reports` rather than anything recording owns.

--- a/web/styles.css
+++ b/web/styles.css
@@ -1172,7 +1172,8 @@ p {
 }
 
 .replay-item,
-.replay-moment {
+.replay-moment,
+.replay-window {
   width: 100%;
   padding: 0.5rem 0.65rem;
   border: 1px solid var(--hairline);
@@ -1182,6 +1183,17 @@ p {
   font: inherit;
   text-align: left;
   cursor: pointer;
+}
+
+/* A response window shares the timeline with the editor and test snapshots and
+   must not look louder than they do. Dashed and unfilled, because it is a
+   duration somebody may want to go and watch rather than a result: no colour
+   that could be read as a severity, and none of the emphasis the current
+   selection uses. */
+.replay-window {
+  border-style: dashed;
+  background: none;
+  cursor: default;
 }
 
 .replay-item + .replay-item,


### PR DESCRIPTION
Screen and gaze evidence are both designed around by the shipped interview
assistants. Time is not: a turn still needs the question to finish, a model
round trip, and the candidate to read. The replay page now shows that gap,
computed from the avatar history the snapshot read had collapsed away, and
matched to a turn at stream start rather than at write, because a turn is
written when its text stream finishes and that is routinely after the
interviewer has moved on.

The number is a duration and not a finding, and the page says so where it
shows it. The page producing it is the candidate's own, so a modified one can
stamp a turn with another window's number; that is disclosed rather than
defended, because the scheme it replaced placed a turn by row order and the
same page chose the order.

The rest is what that grew past. Reads are bounded per account, on a bucket
separate from the write side so a reviewer reading a history cannot lock a
candidate out of recording their own interview. The recording routes and
`src/livekit.rs` split along seams their own module docs already named. The
replay routes answer the retention promise once instead of three times. The
README's detail moves into `docs/`. The gate reports what it did not check,
rather than exiting green over the tenth of the browser suite a checkout
without Chromium skips.

## Review fixes

The last nine commits answer a review. Three were regressions this branch
introduced: a test helper left a `fetch` stub that never settles, so a later
test would hang rather than fail; the gate counted a passing test as a skipped
one; and a comment claimed a second account was unaffected by the read budget
while the test exercised one account.

The other four were older and are fixed here rather than left, since the file
splits put them under review anyway: the RoomService URL was built by replacing
a literal prefix, which mishandles the mixed-case scheme and the query string
that validation accepts; the recording workers were spawned detached, so
nothing could stop them; a failed replay read was reported as a missing
recording, which is a permanent answer to a temporary condition; and a retried
provider failure could fail a recording whose file had already arrived, because
the state table has to allow that move for the delivery worker.

Each has a test that fails without its fix.
