### PR TITLE
Make saved report history visible and erasable

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -65,7 +65,11 @@ const CORRECTNESS = {
 
 export default [
   {
-    ignores: ["web/vendor/**", "node_modules/**", "target/**"],
+    // `externals/` holds unrelated checkouts, is untracked, and is excluded in
+    // `.git/info/exclude`. Linting it failed the gate on somebody else's JSX,
+    // and a gate that is red for something outside the repository is one whose
+    // red line stops being read.
+    ignores: ["web/vendor/**", "node_modules/**", "target/**", "externals/**"],
   },
   {
     // The browser tier. `web/*worker*.js` runs without a `window`, so the

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1147,6 +1147,14 @@ pub fn list_reports(accounts: &Accounts, user_id: i64) -> rusqlite::Result<Vec<V
     })
 }
 
+/// Deletes every saved report owned by one account and returns the row count.
+/// Interviews, replay events, and recordings have separate lifecycles and are
+/// deliberately untouched.
+pub fn delete_reports(accounts: &Accounts, user_id: i64) -> rusqlite::Result<usize> {
+    accounts
+        .with(|connection| connection.execute("DELETE FROM reports WHERE user_id = ?1", [user_id]))
+}
+
 pub fn save_report(
     accounts: &Accounts,
     user_id: i64,
@@ -1956,6 +1964,38 @@ mod migration_tests {
         assert_eq!(
             list_reports(&accounts, user).unwrap().len() as i64,
             MAX_REPORTS_PER_USER
+        );
+    }
+
+    #[test]
+    fn deleting_reports_is_scoped_idempotent_and_reclaims_quota() {
+        let path = scratch("delete-reports");
+        initialize_account_database(&path).unwrap();
+        let accounts = accounts_at(&path);
+        let deleting = user_id_for(&accounts, &sign_in_as(&path, "deleting", -1));
+        let other = user_id_for(&accounts, &sign_in_as(&path, "other", -2));
+        for index in 0..MAX_REPORTS_PER_USER {
+            save_report(
+                &accounts,
+                deleting,
+                &format!("r{index}"),
+                "two-sum",
+                &json!({}),
+            )
+            .unwrap();
+        }
+        save_report(&accounts, other, "other-report", "two-sum", &json!({})).unwrap();
+
+        assert_eq!(
+            delete_reports(&accounts, deleting).unwrap() as i64,
+            MAX_REPORTS_PER_USER
+        );
+        assert!(list_reports(&accounts, deleting).unwrap().is_empty());
+        assert_eq!(list_reports(&accounts, other).unwrap().len(), 1);
+        assert_eq!(delete_reports(&accounts, deleting).unwrap(), 0);
+        assert_eq!(
+            save_report(&accounts, deleting, "after-clear", "two-sum", &json!({})).unwrap(),
+            ReportSave::Saved,
         );
     }
 

--- a/src/web/interviews.rs
+++ b/src/web/interviews.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 
 use crate::accounts::{
     MAX_INTERVIEWS_PER_USER, MAX_REPORTS_PER_USER, ReportSave, blocking, create_interview,
-    list_reports, random_token, save_report,
+    delete_reports, list_reports, random_token, save_report,
 };
 use crate::current_epoch_seconds;
 
@@ -38,6 +38,16 @@ pub(crate) async fn list_reports_handler(Owner { accounts, user }: Owner) -> Res
         Err(_) => json_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             json!({ "error": "Could not read reports." }),
+        ),
+    }
+}
+
+pub(crate) async fn delete_reports_handler(Owner { accounts, user }: Owner) -> Response {
+    match blocking(move || delete_reports(&accounts, user.id)).await {
+        Ok(deleted) => json_response(StatusCode::OK, json!({ "deleted": deleted })),
+        Err(_) => json_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            json!({ "error": "Could not delete reports." }),
         ),
     }
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -362,7 +362,9 @@ pub(crate) fn web_router(
         .route("/runtime-config.js", get(runtime_config_handler))
         .route(
             "/api/reports",
-            get(list_reports_handler).post(save_report_handler),
+            get(list_reports_handler)
+                .post(save_report_handler)
+                .delete(delete_reports_handler),
         )
         .fallback(web_static_handler)
         .layer(axum::middleware::from_fn_with_state(

--- a/tests/browser/account.test.js
+++ b/tests/browser/account.test.js
@@ -378,6 +378,20 @@ test("a cross-tab sign-out keeps the account copy rather than claiming a clear",
   assert.deepEqual(calls, ["/api/session"]);
 });
 
+test("every history request carries a deadline", async () => {
+  const deadlines = [];
+  const fetcher = async (url, options) => {
+    deadlines.push(options?.signal instanceof AbortSignal);
+    return url === "/api/session" ? response({ signedIn: true }) : response({ deleted: 1 });
+  };
+  const storage = memoryStorage();
+  await saveReportHistory({ id: "deadline" }, { fetcher, storage });
+  await clearReportHistory({ fetcher, storage });
+  // Session probe and report POST for the save, then the same pair for the
+  // clear. A request without one hangs whatever the candidate is waiting on.
+  assert.deepEqual(deadlines, [true, true, true, true]);
+});
+
 function response(body, ok = true) {
   return {
     ok,

--- a/tests/browser/account.test.js
+++ b/tests/browser/account.test.js
@@ -5,7 +5,12 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { historyKey, readLocalHistory, saveReportHistory } from "../../web/history.js";
+import {
+  clearReportHistory,
+  historyKey,
+  readLocalHistory,
+  saveReportHistory,
+} from "../../web/history.js";
 import { functionBody, memoryStorage, root } from "./source.js";
 
 const web = join(root, "web");
@@ -15,7 +20,16 @@ test("lobby exposes signed in and signed out account hooks", () => {
   const page = read("index.html");
   const script = read("app.js");
 
-  for (const id of ["account-status", "github-login", "login-link", "logout", "history"]) {
+  for (const id of [
+    "account-status",
+    "github-login",
+    "login-link",
+    "logout",
+    "history-header",
+    "history",
+    "delete-reports",
+    "report-delete-status",
+  ]) {
     assert.match(page, new RegExp(`id="${id}"`), `index.html must keep #${id}`);
   }
   assert.match(script, /fetch\("\/api\/login", \{/);
@@ -25,6 +39,7 @@ test("lobby exposes signed in and signed out account hooks", () => {
   assert.match(script, /fetchJson\("\/api\/reports"\)/);
   assert.match(script, /fetch\("\/api\/logout", \{ method: "POST" \}\)/);
   assert.match(script, /readLocalHistory\(\)/);
+  assert.match(script, /clearReportHistory\(\{ account: accountHistory \}\)/);
   assert.match(script, /setStartGate\(true\)/, "GitHub username must gate interview start when required");
 });
 
@@ -266,6 +281,101 @@ test("report history exposes every local and account failure", async () => {
     );
     assert.equal(calls, 1, "a failed or malformed session must not POST a report");
   }
+});
+
+test("report history rechecks signed-out and signed-in storage before clearing", async () => {
+  const signedOut = memoryStorage();
+  signedOut.setItem(historyKey, "local");
+  const signedOutCalls = [];
+  assert.equal(await clearReportHistory({
+    storage: signedOut,
+    fetcher: async (url) => {
+      signedOutCalls.push(url);
+      return response({ signedIn: false });
+    },
+  }), "cleared");
+  assert.equal(signedOut.getItem(historyKey), null);
+  assert.deepEqual(signedOutCalls, ["/api/session"]);
+
+  const signedIn = memoryStorage();
+  signedIn.setItem(historyKey, "local");
+  const calls = [];
+  const clear = () => clearReportHistory({
+    storage: signedIn,
+    fetcher: async (url, options) => {
+      calls.push({ url, options });
+      return url === "/api/session" ? response({ signedIn: true }) : response({ deleted: 1 });
+    },
+  });
+  assert.equal(await clear(), "cleared");
+  signedIn.setItem(historyKey, "local-again");
+  assert.equal(await clear(), "cleared");
+  assert.equal(signedIn.getItem(historyKey), null);
+  assert.deepEqual(calls.map(({ url }) => url), [
+    "/api/session", "/api/reports", "/api/session", "/api/reports",
+  ]);
+  assert.equal(calls[1].options.method, "DELETE");
+});
+
+test("report history retains local data on account failure and reports a partial clear", async () => {
+  const retained = memoryStorage();
+  retained.setItem(historyKey, "keep");
+  for (const fetcher of [
+    async () => { throw new Error("offline"); },
+    async () => response({}, false),
+  ]) {
+    assert.equal(await clearReportHistory({ storage: retained, fetcher }), "failed");
+    assert.equal(retained.getItem(historyKey), "keep");
+  }
+
+  const brokenStorage = {
+    removeItem: () => { throw new Error("blocked"); },
+  };
+  assert.equal(await clearReportHistory({
+    storage: brokenStorage,
+    fetcher: async (url) => url === "/api/session"
+      ? response({ signedIn: true })
+      : response({ deleted: 1 }),
+  }), "account-cleared-local-failed");
+  assert.equal(await clearReportHistory({
+    storage: brokenStorage,
+    fetcher: async () => response({}),
+  }), "failed");
+});
+
+test("history deletion observes a cross-tab sign-in", async () => {
+  const storage = memoryStorage();
+  storage.setItem(historyKey, "keep");
+  const calls = [];
+  assert.equal(await clearReportHistory({
+    storage,
+    fetcher: async (url, options) => {
+      calls.push({ url, options });
+      return url === "/api/session" ? response({ signedIn: true }) : response({ deleted: 1 });
+    },
+  }), "cleared");
+  assert.equal(storage.getItem(historyKey), null);
+  assert.deepEqual(calls.map(({ url }) => url), ["/api/session", "/api/reports"]);
+  assert.equal(calls[1].options.method, "DELETE");
+});
+
+test("a cross-tab sign-out keeps the account copy rather than claiming a clear", async () => {
+  const storage = memoryStorage();
+  storage.setItem(historyKey, "keep");
+  const calls = [];
+  // The lobby loaded account history, then the session went away in another
+  // tab. This browser can no longer authenticate the delete, so the account
+  // copy is still there and saying it was erased would be a lie.
+  assert.equal(await clearReportHistory({
+    account: true,
+    storage,
+    fetcher: async (url) => {
+      calls.push(url);
+      return response({ signedIn: false });
+    },
+  }), "failed");
+  assert.equal(storage.getItem(historyKey), "keep");
+  assert.deepEqual(calls, ["/api/session"]);
 });
 
 function response(body, ok = true) {

--- a/tests/browser/account.test.js
+++ b/tests/browser/account.test.js
@@ -30,10 +30,19 @@ test("lobby exposes signed in and signed out account hooks", () => {
 
 test("interview history routes through the shared persistence helper", () => {
   const script = read("interview.js");
-  const saveHistory = script.slice(script.indexOf("function saveHistory"));
+  const saveHistory = functionBody(script, "saveHistory");
 
   assert.match(script, /import \{ saveReportHistory \} from "\.\/history\.js"/);
   assert.match(saveHistory, /return saveReportHistory\(entry\)/);
+  for (const name of ["receiveReport", "showReport"]) {
+    const body = functionBody(script, name);
+    assert.match(body, /renderReport\(\)/);
+    assert.match(body, /renderReportSaveStatus\(await saving\)/);
+    assert.ok(body.indexOf("renderReport()") < body.indexOf("await saving"));
+  }
+  assert.match(functionBody(script, "renderReport"), /saveResult: null/);
+  assert.match(functionBody(script, "renderReportSaveStatus"), /querySelector\("#done"\)\.disabled = false/);
+  assert.match(functionBody(script, "renderReport"), /nodes\.ending\.hidden = true/);
 });
 
 test("a completed test run keeps pause and round locks", () => {
@@ -183,7 +192,7 @@ test("report history writes local storage before account sync", async () => {
   assert.deepEqual(posts, []);
 
   releaseSession();
-  assert.equal(await saved, true);
+  assert.deepEqual(await saved, { local: "saved", account: "saved" });
   assert.equal(posts.length, 1);
   assert.equal(posts[0].url, "/api/reports");
   assert.equal(posts[0].options.method, "POST");
@@ -191,18 +200,18 @@ test("report history writes local storage before account sync", async () => {
 
 test("report history keeps anonymous and failed account saves local", async () => {
   const anonymous = memoryStorage();
-  assert.equal(
+  assert.deepEqual(
     await saveReportHistory({ id: "anon", problemId: "two-sum" }, {
       storage: anonymous,
       fetcher: async () => response({ signedIn: false }),
     }),
-    false,
+    { local: "saved", account: "skipped" },
   );
   assert.equal(JSON.parse(anonymous.getItem(historyKey))[0].id, "anon");
 
   const failed = memoryStorage();
   const calls = [];
-  assert.equal(
+  assert.deepEqual(
     await saveReportHistory({ id: "fail", problemId: "two-sum" }, {
       storage: failed,
       fetcher: async (url) => {
@@ -210,10 +219,53 @@ test("report history keeps anonymous and failed account saves local", async () =
         return url === "/api/session" ? response({ signedIn: true }) : response({}, false);
       },
     }),
-    false,
+    { local: "saved", account: "failed" },
   );
   assert.deepEqual(calls, ["/api/session", "/api/reports"]);
   assert.equal(JSON.parse(failed.getItem(historyKey))[0].id, "fail");
+});
+
+test("report history exposes every local and account failure", async () => {
+  const brokenStorage = {
+    getItem: () => null,
+    setItem: () => { throw new Error("quota"); },
+  };
+  assert.deepEqual(
+    await saveReportHistory({ id: "local-fail" }, {
+      storage: brokenStorage,
+      fetcher: async () => response({ signedIn: false }),
+    }),
+    { local: "failed", account: "skipped" },
+  );
+
+  const accountFailure = async (fetcher) => saveReportHistory({ id: "account-fail" }, {
+    storage: memoryStorage(),
+    fetcher,
+  });
+  assert.deepEqual(
+    await accountFailure(async () => { throw new Error("offline"); }),
+    { local: "saved", account: "failed" },
+  );
+  assert.deepEqual(
+    await accountFailure(async () => response(null)),
+    { local: "saved", account: "failed" },
+  );
+  assert.deepEqual(
+    await accountFailure(async () => ({ ok: true, json: async () => { throw new Error("bad json"); } })),
+    { local: "saved", account: "failed" },
+  );
+
+  for (const session of [response({}, false), response({ loginRequired: true })]) {
+    let calls = 0;
+    assert.deepEqual(
+      await accountFailure(async () => {
+        calls += 1;
+        return session;
+      }),
+      { local: "saved", account: "failed" },
+    );
+    assert.equal(calls, 1, "a failed or malformed session must not POST a report");
+  }
 });
 
 function response(body, ok = true) {

--- a/tests/browser/account.test.js
+++ b/tests/browser/account.test.js
@@ -3,13 +3,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 import { historyKey, readLocalHistory, saveReportHistory } from "../../web/history.js";
-import { functionBody } from "./source.js";
+import { functionBody, memoryStorage, root } from "./source.js";
 
-const web = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "web");
+const web = join(root, "web");
 const read = (name) => readFileSync(join(web, name), "utf8");
 
 test("lobby exposes signed in and signed out account hooks", () => {
@@ -216,14 +215,6 @@ test("report history keeps anonymous and failed account saves local", async () =
   assert.deepEqual(calls, ["/api/session", "/api/reports"]);
   assert.equal(JSON.parse(failed.getItem(historyKey))[0].id, "fail");
 });
-
-function memoryStorage() {
-  const data = new Map();
-  return {
-    getItem: (key) => data.get(key) ?? null,
-    setItem: (key, value) => data.set(key, String(value)),
-  };
-}
 
 function response(body, ok = true) {
   return {

--- a/tests/browser/compiler-explorer.test.js
+++ b/tests/browser/compiler-explorer.test.js
@@ -292,16 +292,8 @@ public:
 
 test("Java BSTIterator class harness can produce passing Compiler Explorer JSON", (t) => {
   try {
-    // The generated harness uses `instanceof String s` pattern matching, so a
-    // present-but-older javac fails to compile it and reports a syntax error,
-    // which reads as a harness bug rather than a toolchain gap.
-    const version = execFileSync("javac", ["--version"], { encoding: "utf8" });
-    const major = Number.parseInt(version.replace(/^javac\s+/, ""), 10);
-    if (!Number.isFinite(major) || major < 16) {
-      t.skip(`javac ${major} is older than 16, which the harness needs`);
-      return;
-    }
-    execFileSync("java", ["--version"], { stdio: "ignore" });
+    execFileSync("javac", ["-version"], { stdio: "ignore" });
+    execFileSync("java", ["-version"], { stdio: "ignore" });
   } catch {
     t.skip("javac/java are not available");
     return;

--- a/tests/browser/document-grounding.test.js
+++ b/tests/browser/document-grounding.test.js
@@ -4,6 +4,7 @@ import {
   consumeGroundingPacket, groundingStorageKey, maxGroundingFileBytes, maxGroundingPacketBytes,
   parseGroundingFile, selectedGroundingPacket, storeGroundingPacket,
 } from "../../web/document-grounding.js";
+import { memoryStorage } from "./source.js";
 
 const file = (name, type, bytes) => ({ name, type, size: bytes.length, arrayBuffer: async () => Uint8Array.from(bytes).buffer });
 const txt = (text, name = "input.txt", type = "text/plain") => file(name, type, new TextEncoder().encode(text));
@@ -53,11 +54,6 @@ test("hostile text remains inert data and storage failure is explicit", async ()
   assert.doesNotThrow(() => storeGroundingPacket({ removeItem() { throw new Error("private mode"); } }, null));
   assert.equal(consumeGroundingPacket({ getItem() { throw new Error("disabled"); }, removeItem() {} }), null);
 });
-
-function memoryStorage() {
-  const data = new Map();
-  return { getItem: (key) => data.get(key) || null, setItem: (key, value) => data.set(key, value), removeItem: (key) => data.delete(key) };
-}
 
 test("the packet holds what the server will store, so the budget counts one string", () => {
   const packet = (text) => selectedGroundingPacket(

--- a/tests/browser/lobby.test.js
+++ b/tests/browser/lobby.test.js
@@ -44,6 +44,7 @@ let holdReports = null;
 /// while a start is mid-flight holds that request open rather than guessing a
 /// latency long enough to win the race.
 let holdLogin = null;
+let deleteRequests = 0;
 
 const type = (file) =>
   file.endsWith(".js") ? "text/javascript" : file.endsWith(".css") ? "text/css" : "text/html";
@@ -63,12 +64,21 @@ before(async () => {
       response.end(JSON.stringify(body));
     };
 
+    if (request.method === "DELETE" && url.pathname === "/api/reports") {
+      deleteRequests += 1;
+    }
+
     if (failing.has(url.pathname)) {
       response.statusCode = 500;
       return response.end("nope");
     }
     if (url.pathname === "/api/session") return json(session);
     if (url.pathname === "/api/reports") {
+      if (request.method === "DELETE") {
+        const deleted = reports.length;
+        reports = [];
+        return json({ deleted });
+      }
       return holdReports ? holdReports.then(() => json({ reports })) : json({ reports });
     }
     if (url.pathname === "/api/login") {
@@ -106,6 +116,7 @@ beforeEach(() => {
   failing = new Set();
   holdReports = null;
   holdLogin = null;
+  deleteRequests = 0;
 });
 
 /// Hold `/api/reports` open and hand back the release. Everything between the
@@ -183,6 +194,14 @@ const markupDuration = () =>
 
 const hired = (problemId) => ({ problemId, payload: { report: { decision: "HIRE" } } });
 const missed = (problemId) => ({ problemId, payload: { report: { decision: "NO_HIRE" } } });
+const savedAttempt = (problemId) => ({
+  problemId,
+  payload: {
+    problemId,
+    date: "2026-01-01T00:00:00Z",
+    report: { decision: "HIRE" },
+  },
+});
 
 /// Ids from the real bank, so these break if the bank stops carrying them
 /// rather than testing against problems that do not exist.
@@ -621,7 +640,7 @@ lobbyTest("widening the filter keeps a problem the candidate picked by hand", as
 });
 
 lobbyTest("a restore in flight is not a history a difficulty change may read", async (page) => {
-  reports = [hired(MEDIUM[0])];
+  reports = [savedAttempt(MEDIUM[0])];
   await lobby(page);
 
   // Restored from cache, so the reports in hand are the ones from before the
@@ -636,6 +655,7 @@ lobbyTest("a restore in flight is not a history a difficulty change may read", a
   const midflight = await snapshot(page);
   assert.equal(midflight.card, null, "a problem was chosen from the history being replaced");
   assert.equal(midflight.startDisabled, true, "start went live on a history already known stale");
+  assert.equal(await page.locator("#delete-reports").isDisabled(), true);
 
   release();
   await awaitReady(page);
@@ -828,6 +848,173 @@ lobbyTest("a server that can record every length on offer disables nothing", asy
   assert.deepEqual(state.durationsOff, []);
   assert.equal(state.durationNote, "", "a lobby with nothing capped explained a cap anyway");
   assert.equal(state.duration, markupDuration());
+});
+
+lobbyTest("saved reports require confirmation and clear the progress panel", async (page) => {
+  reports = [savedAttempt(EASY[0]), savedAttempt(EASY[1])];
+  await lobby(page);
+  assert.match(await page.locator("#recommendation").textContent(), /passed your last two Easy problems/);
+
+  page.once("dialog", (dialog) => dialog.dismiss());
+  await page.click("#delete-reports");
+  assert.equal(deleteRequests, 0);
+  assert.equal(await page.locator("#history").isHidden(), false);
+
+  page.once("dialog", (dialog) => {
+    assert.match(dialog.message(), /reports and progress/);
+    assert.match(dialog.message(), /Recording files follow their separate retention policy/);
+    return dialog.accept();
+  });
+  await page.click("#delete-reports");
+  await settles(page, () => document.querySelector("#history").hidden);
+  assert.equal(deleteRequests, 1);
+  assert.deepEqual(reports, []);
+  assert.equal(await page.locator("#history").isHidden(), true);
+  assert.equal(await page.locator("#delete-reports").isHidden(), true);
+  assert.doesNotMatch(await page.locator("#recommendation").textContent(), /passed your last two/);
+  assert.equal(await page.locator("#report-delete-status").textContent(), "Saved reports and progress were deleted.");
+  assert.equal(await page.evaluate(() => document.activeElement.id), "report-delete-status");
+});
+
+lobbyTest("a failed report deletion retains the current progress", async (page) => {
+  reports = [savedAttempt(EASY[0])];
+  await lobby(page);
+  failing.add("/api/reports");
+  page.once("dialog", (dialog) => dialog.accept());
+
+  await page.click("#delete-reports");
+  await settles(page, () => document.querySelector("#report-delete-status").textContent !== "");
+
+  assert.equal(deleteRequests, 1);
+  assert.equal(await page.locator("#history").isHidden(), false);
+  assert.match(await page.locator("#progress-summary").textContent(), /1 of 1 attempts shown/);
+  assert.equal(
+    await page.locator("#report-delete-status").textContent(),
+    "Could not delete saved reports. Your reports may not have been removed.",
+  );
+});
+
+lobbyTest("a signed-in account can erase reports saved only on this device", async (page) => {
+  await page.addInitScript((entry) => {
+    localStorage.setItem("codetrial_history", JSON.stringify([entry]));
+  }, {
+    problemId: EASY[0],
+    date: "2026-01-03T00:00:00Z",
+    report: { decision: "HIRE" },
+  });
+  await lobby(page);
+  assert.equal(await page.locator("#history").isHidden(), true);
+  assert.equal(await page.locator("#delete-reports").isVisible(), true);
+  page.once("dialog", (dialog) => dialog.accept());
+
+  await page.click("#delete-reports");
+  await settles(page, () => document.querySelector("#report-delete-status").textContent !== "");
+
+  assert.equal(await page.evaluate(() => localStorage.getItem("codetrial_history")), null);
+  assert.equal(await page.locator("#delete-reports").isHidden(), true);
+});
+
+lobbyTest("an unavailable account check retains visible local reports", async (page) => {
+  await page.addInitScript((entry) => {
+    localStorage.setItem("codetrial_history", JSON.stringify([entry]));
+  }, {
+    problemId: EASY[0],
+    date: "2026-01-04T00:00:00Z",
+    report: { decision: "HIRE" },
+  });
+  failing.add("/api/session");
+  await lobby(page);
+  page.once("dialog", (dialog) => dialog.accept());
+
+  await page.click("#delete-reports");
+  await settles(page, () => document.querySelector("#report-delete-status").textContent !== "");
+
+  assert.notEqual(await page.evaluate(() => localStorage.getItem("codetrial_history")), null);
+  assert.equal(
+    await page.locator("#report-delete-status").textContent(),
+    "Could not delete saved reports. Your reports may not have been removed.",
+  );
+});
+
+lobbyTest("a partial clear stays visible when local storage cannot be read", async (page) => {
+  reports = [savedAttempt(EASY[0])];
+  await page.addInitScript(() => {
+    const getItem = Storage.prototype.getItem;
+    const removeItem = Storage.prototype.removeItem;
+    Storage.prototype.getItem = function readHistory(key) {
+      if (key === "codetrial_history") throw new Error("blocked");
+      return getItem.call(this, key);
+    };
+    Storage.prototype.removeItem = function removeHistory(key) {
+      if (key === "codetrial_history") throw new Error("blocked");
+      return removeItem.call(this, key);
+    };
+  });
+  await lobby(page);
+  page.once("dialog", (dialog) => dialog.accept());
+
+  await page.click("#delete-reports");
+  await settles(page, () => document.querySelector("#report-delete-status").textContent !== "");
+
+  assert.equal(await page.locator("#history").isHidden(), true);
+  assert.equal(await page.locator("#report-delete-status").isVisible(), true);
+  assert.equal(
+    await page.locator("#report-delete-status").textContent(),
+    "Account reports were deleted, but reports saved on this device could not be deleted.",
+  );
+});
+
+lobbyTest("blocked local storage does not prevent account deletion", async (page) => {
+  reports = [savedAttempt(EASY[0])];
+  await page.addInitScript(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() { throw new DOMException("blocked", "SecurityError"); },
+    });
+  });
+  await lobby(page);
+  page.once("dialog", (dialog) => dialog.accept());
+
+  await page.click("#delete-reports");
+  await settles(page, () => document.querySelector("#report-delete-status").textContent !== "");
+
+  assert.equal(deleteRequests, 1);
+  assert.deepEqual(reports, []);
+  assert.equal(
+    await page.locator("#report-delete-status").textContent(),
+    "Account reports were deleted, but reports saved on this device could not be deleted.",
+  );
+  assert.equal(await page.evaluate(() => document.activeElement.id), "report-delete-status");
+});
+
+lobbyTest("a partial clear reloads local reports and states what remains", async (page) => {
+  reports = [savedAttempt(EASY[0])];
+  await page.addInitScript((entry) => {
+    localStorage.setItem("codetrial_history", JSON.stringify([entry]));
+    const removeItem = Storage.prototype.removeItem;
+    Storage.prototype.removeItem = function removeHistory(key) {
+      if (key === "codetrial_history") throw new Error("blocked");
+      return removeItem.call(this, key);
+    };
+  }, {
+    problemId: EASY[1],
+    date: "2026-01-02T00:00:00Z",
+    report: { decision: "HIRE" },
+  });
+  await lobby(page);
+  page.once("dialog", (dialog) => dialog.accept());
+
+  await page.click("#delete-reports");
+  await settles(page, () => document.querySelector("#report-delete-status").textContent !== "");
+
+  assert.equal(deleteRequests, 1);
+  assert.deepEqual(reports, []);
+  assert.match(await page.locator("#progress-summary").textContent(), /saved on this device/);
+  assert.equal(
+    await page.locator("#report-delete-status").textContent(),
+    "Account reports were deleted, but reports saved on this device could not be deleted.",
+  );
+  assert.equal(await page.evaluate(() => document.activeElement.id), "report-delete-status");
 });
 
 lobbyTest("a cap under every length on offer leaves the row alone", async (page) => {

--- a/tests/browser/render.test.js
+++ b/tests/browser/render.test.js
@@ -16,6 +16,7 @@ import {
   problemMarkup,
   reportMarkdown,
   reportMarkup,
+  reportSaveStatus,
   resultsMarkup,
   runnerStatusMarkup,
 } from "../../web/render.js";
@@ -340,6 +341,48 @@ test("report markup renders scores, verdict, and escaped feedback", () => {
   assert.match(body, /<pre>print\(1\)<\/pre>/, "trailing blank lines are trimmed");
   assert.match(body, /id="download-report"/);
   assert.match(body, /id="done"/);
+});
+
+test("report markup states every save outcome without hiding Download", () => {
+  const session = {
+    report: { incomplete: true, summary: "Done", hintsUsed: 0 },
+    problemTitle: "Two Sum",
+    language: "python",
+    code: "pass",
+  };
+  for (const [saveResult, message] of [
+    [{ local: "saved", account: "saved" }, "Saved to your account"],
+    [{ local: "saved", account: "failed" }, "Saved on this device only"],
+    [{ local: "saved", account: "skipped" }, "Saved on this device only"],
+    [{ local: "failed", account: "saved" }, "Saved to your account"],
+    [{ local: "failed", account: "failed" }, "Report was not saved"],
+    [{ local: "failed", account: "skipped" }, "Report was not saved"],
+  ]) {
+    const body = reportMarkup({ ...session, saveResult });
+    assert.match(body, new RegExp(`<p id="report-save-status"[^>]*>${message}</p>`));
+    assert.match(body, /id="download-report"/);
+  }
+  const saving = reportMarkup({ ...session, saveResult: null });
+  assert.match(saving, /role="status">Saving report\.\.\.<\/p>/);
+  assert.match(saving, /id="done"[^>]*disabled/);
+  assert.doesNotMatch(saving, /id="download-report"[^>]*disabled/);
+  assert.doesNotMatch(reportMarkup(session), /report-save-status/);
+  assert.deepEqual(reportSaveStatus(null), {
+    message: "Saving report...",
+    className: "muted small",
+  });
+  assert.deepEqual(reportSaveStatus({ local: "saved", account: "saved" }), {
+    message: "Saved to your account",
+    className: "muted small",
+  });
+  assert.deepEqual(reportSaveStatus({ local: "failed", account: "failed" }), {
+    message: "Report was not saved",
+    className: "critical small",
+  });
+  assert.deepEqual(reportSaveStatus({ local: "saved", account: "failed" }), {
+    message: "Saved on this device only",
+    className: "muted small",
+  });
 });
 
 test("practice-next drills render accessibly in HTML and Markdown", () => {

--- a/tests/browser/source.js
+++ b/tests/browser/source.js
@@ -96,6 +96,22 @@ export function failFetchWith(handler) {
   };
 }
 
+/// A `localStorage` stand-in backed by a Map. Shared for the same reason as the
+/// fetch stub above: two copies had appeared and they had drifted apart. One of
+/// them read a stored empty string back as `null` and did not stringify what it
+/// was given, so a test could pass against a stub that behaves as the real
+/// storage does not.
+/// `getItem` answers `null` only for a key that is absent, and `setItem`
+/// stringifies, because that is what the browser does.
+export function memoryStorage() {
+  const data = new Map();
+  return {
+    getItem: (key) => data.get(key) ?? null,
+    removeItem: (key) => data.delete(key),
+    setItem: (key, value) => data.set(key, String(value)),
+  };
+}
+
 /// The browser, or null when there is no browser to be had. Shared so that
 /// every file launching one agrees on what a missing Playwright or an
 /// undownloaded Chromium means. `make check` installs neither, so a null here

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -2586,6 +2586,12 @@ async fn account_routes_record_interviewee_github_login() {
         .await
         .unwrap();
     assert_eq!(save_report.status(), 401);
+    let delete_reports = client
+        .delete(format!("{base}/api/reports"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(delete_reports.status(), 401);
 
     server.abort();
     remove_database(path);
@@ -3172,6 +3178,29 @@ async fn account_reports_are_scoped_to_the_signed_in_user() {
         .await
         .unwrap();
     assert_eq!(blocked.status(), 409);
+
+    let deleted = client
+        .delete(format!("{base}/api/reports"))
+        .header("cookie", &user_one_cookie)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(deleted.status(), 200);
+    assert_eq!(
+        deleted.json::<Value>().await.unwrap(),
+        json!({ "deleted": 2 })
+    );
+
+    let user_one_reports = client
+        .get(format!("{base}/api/reports"))
+        .header("cookie", &user_one_cookie)
+        .send()
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap();
+    assert!(user_one_reports["reports"].as_array().unwrap().is_empty());
 
     let user_two_reports = client
         .get(format!("{base}/api/reports"))
@@ -7344,6 +7373,7 @@ async fn every_owner_scoped_route_refuses_an_anonymous_request() {
     let owner_scoped = [
         (reqwest::Method::GET, "/api/reports"),
         (reqwest::Method::POST, "/api/reports"),
+        (reqwest::Method::DELETE, "/api/reports"),
         (reqwest::Method::POST, "/api/interviews"),
         (reqwest::Method::DELETE, "/api/interviews/{id}/consent"),
         (reqwest::Method::POST, "/api/interviews/{id}/recording"),

--- a/web/app.js
+++ b/web/app.js
@@ -1,5 +1,5 @@
 import { FRAMEWORKS, codingLoop } from "./lib.js";
-import { readLocalHistory } from "./history.js";
+import { clearReportHistory, readLocalHistory } from "./history.js";
 import { pickProblem, suggestDifficulty } from "./problem-picker.js";
 import { buildProgressModel, unwrapEntry } from "./progress.js";
 import { parseGroundingFile, selectedGroundingPacket, storeGroundingPacket } from "./document-grounding.js";
@@ -36,7 +36,10 @@ const nodes = {
   githubLogin: document.querySelector("#github-login"),
   loginLink: document.querySelector("#login-link"),
   logout: document.querySelector("#logout"),
+  historyHeader: document.querySelector("#history-header"),
   history: document.querySelector("#history"),
+  deleteReports: document.querySelector("#delete-reports"),
+  reportDeleteStatus: document.querySelector("#report-delete-status"),
   recommendation: document.querySelector("#recommendation"),
   progressSummary: document.querySelector("#progress-summary"),
   progressTrends: document.querySelector("#progress-trends"),
@@ -118,10 +121,15 @@ nodes.groundingClear.addEventListener("click", clearGrounding);
 
 let progressEntries = [];
 let progressSuffix = "saved";
+/// Whether the history on screen came from an account: null until /api/session
+/// answers, and never assumed false, because a browser that cannot ask is not a
+/// browser that knows there is nothing on the server.
+let accountHistory = null;
 
 for (const filter of [nodes.progressDifficulty, nodes.progressLanguage, nodes.progressDuration]) {
   filter.addEventListener("change", renderProgress);
 }
+nodes.deleteReports.addEventListener("click", deleteSavedReports);
 
 const durations = [...document.querySelectorAll("[data-duration]")];
 for (const button of durations) {
@@ -273,6 +281,9 @@ window.addEventListener("pageshow", (event) => {
   historyReady = false;
   starting = false;
   start.disabled = true;
+  nodes.deleteReports.disabled = true;
+  nodes.reportDeleteStatus.textContent = "";
+  accountHistory = null;
   loadAccount().finally(settle);
 });
 
@@ -326,13 +337,17 @@ function settle() {
   // still stands, so the button the restore below held down needs releasing
   // here rather than there.
   start.disabled = !problem || starting;
+  nodes.deleteReports.disabled = false;
 }
 
 async function loadAccount() {
+  accountHistory = null;
   try {
     const session = await fetchJson("/api/session");
+    accountHistory = false;
     applyDurationCeiling(session.maxDurationMin);
     if (session.signedIn) {
+      accountHistory = true;
       nodes.accountStatus.textContent = `Signed in as ${session.user.login}`;
       nodes.githubLogin.hidden = true;
       nodes.loginLink.hidden = true;
@@ -411,6 +426,47 @@ function renderLocalHistory() {
   }
 }
 
+const deleteFailedMessage = "Could not delete saved reports. Your reports may not have been removed.";
+
+async function deleteSavedReports() {
+  const confirmed = window.confirm(
+    "Delete saved reports and progress? Recording files follow their separate retention policy. This cannot be undone.",
+  );
+  if (!confirmed) return;
+  nodes.deleteReports.disabled = true;
+  nodes.reportDeleteStatus.textContent = "";
+  try {
+    const result = await clearReportHistory({ account: accountHistory });
+    if (result === "cleared") {
+      showReportDeleteStatus("Saved reports and progress were deleted.", "good small");
+      reports = [];
+      showProgress([], "saved");
+      settle();
+      return;
+    }
+    if (result === "account-cleared-local-failed") {
+      showReportDeleteStatus(
+        "Account reports were deleted, but reports saved on this device could not be deleted.",
+      );
+      renderLocalHistory();
+      settle();
+      return;
+    }
+    showReportDeleteStatus(deleteFailedMessage);
+  } catch {
+    if (!nodes.reportDeleteStatus.textContent) showReportDeleteStatus(deleteFailedMessage);
+    nodes.reportDeleteStatus.focus();
+  } finally {
+    nodes.deleteReports.disabled = false;
+  }
+}
+
+function showReportDeleteStatus(message, className = "critical small") {
+  nodes.reportDeleteStatus.className = className;
+  nodes.reportDeleteStatus.textContent = message;
+  nodes.reportDeleteStatus.focus();
+}
+
 function selectedDifficulties() {
   return new Set(levels.filter((input) => input.checked).map((input) => input.value));
 }
@@ -454,7 +510,11 @@ function recommend(note = "") {
 /// markup's default standing.
 function applySuggestedLevel() {
   const suggestion = suggestDifficulty(cards, reports);
-  if (!suggestion) return "";
+  if (!suggestion) {
+    for (const input of levels) input.checked = input.defaultChecked;
+    applyDifficulties();
+    return "";
+  }
   for (const input of levels) input.checked = input.value === suggestion.difficulty;
   applyDifficulties();
   // Named after the level just finished, not the one being suggested: those
@@ -568,6 +628,7 @@ function showProgressError(message) {
   // history it had last managed to load.
   reports = [];
   progressEntries = [];
+  nodes.historyHeader.hidden = false;
   nodes.history.hidden = false;
   nodes.progressSummary.textContent = message;
   nodes.progressTrends.replaceChildren();
@@ -577,6 +638,8 @@ function showProgressError(message) {
 function showProgress(entries, suffix) {
   progressEntries = entries;
   progressSuffix = suffix;
+  const erasable = entries.length > 0 || readLocalHistory().length > 0;
+  nodes.historyHeader.hidden = !erasable;
   nodes.history.hidden = false;
   const model = buildProgressModel(progressEntries);
   syncFilter(nodes.progressDifficulty, model.options.difficulty, (value) => value);

--- a/web/compiler-explorer.js
+++ b/web/compiler-explorer.js
@@ -415,6 +415,13 @@ function cppPrefixGuard(spec, lengthName) {
   return `if (${lengthName} < 0 || ${lengthName} > (int)${name}.size()) throw runtime_error("Return value must be an integer length for the kept prefix.");`;
 }
 
+/// The Java harnesses below stay on Java 8 syntax, which is why `jsonAny` tests
+/// types with a plain `instanceof` and a cast rather than the pattern matching
+/// that reads better. Compiler Explorer runs a current JDK, so the modern form
+/// worked there, but it needs javac 16 to compile and every machine with an
+/// older one skipped the harness test instead of running it. The generated code
+/// is never read by a candidate, so the plainer form costs nothing and keeps
+/// the test runnable wherever a JDK exists.
 function javaHarness(spec, candidateCode) {
   candidateCode = candidateCode.replace(/\bpublic\s+class\s+Solution\b/g, "class Solution");
   return `import java.util.*;
@@ -435,7 +442,7 @@ class Main {
   static String json(char[][] values) { StringJoiner out = new StringJoiner(",", "[", "]"); for (char[] row : values) { StringJoiner inner = new StringJoiner(",", "[", "]"); for (char value : row) inner.add(json(String.valueOf(value))); out.add(inner.toString()); } return out.toString(); }
   static String json(int[][] values) { StringJoiner out = new StringJoiner(",", "[", "]"); for (int[] row : values) out.add(json(row)); return out.toString(); }
   static String json(List<?> values) { StringJoiner out = new StringJoiner(",", "[", "]"); for (Object value : values) out.add(jsonAny(value)); return out.toString(); }
-  static String jsonAny(Object value) { if (value == null) return "null"; if (value instanceof String s) return json(s); if (value instanceof Integer i) return json(i); if (value instanceof Double d) return json(d); if (value instanceof Boolean b) return json(b); if (value instanceof int[] a) return json(a); if (value instanceof double[] a) return json(a); if (value instanceof String[] a) return json(a); if (value instanceof char[][] a) return json(a); if (value instanceof int[][] a) return json(a); if (value instanceof List<?> l) return json(l); if (value instanceof ListNode n) return json(n); if (value instanceof TreeNode n) return json(n); return json(String.valueOf(value)); }
+  static String jsonAny(Object value) { if (value == null) return "null"; if (value instanceof String) return json((String) value); if (value instanceof Integer) return json((Integer) value); if (value instanceof Double) return json((Double) value); if (value instanceof Boolean) return json((Boolean) value); if (value instanceof int[]) return json((int[]) value); if (value instanceof double[]) return json((double[]) value); if (value instanceof String[]) return json((String[]) value); if (value instanceof char[][]) return json((char[][]) value); if (value instanceof int[][]) return json((int[][]) value); if (value instanceof List<?>) return json((List<?>) value); if (value instanceof ListNode) return json((ListNode) value); if (value instanceof TreeNode) return json((TreeNode) value); return json(String.valueOf(value)); }
   static String json(ListNode node) { ArrayList<Integer> values = new ArrayList<>(); HashSet<ListNode> seen = new HashSet<>(); while (node != null && !seen.contains(node)) { seen.add(node); values.add(node.val); node = node.next; } return json(values); }
   static String json(TreeNode root) { if (root == null) return "[]"; ArrayList<String> values = new ArrayList<>(); LinkedList<TreeNode> q = new LinkedList<>(); q.add(root); while (!q.isEmpty()) { TreeNode node = q.remove(); if (node == null) { values.add("null"); continue; } values.add(String.valueOf(node.val)); q.add(node.left); q.add(node.right); } while (!values.isEmpty() && values.get(values.size() - 1).equals("null")) values.remove(values.size() - 1); return "[" + String.join(",", values) + "]"; }
   static ListNode listNode(int[] values) { ListNode dummy = new ListNode(0), tail = dummy; for (int value : values) { tail.next = new ListNode(value); tail = tail.next; } return dummy.next; }
@@ -469,7 +476,7 @@ class Main {
   static String json(boolean value) { return value ? "true" : "false"; }
   static String json(int value) { return String.valueOf(value); }
   static String json(double value) { return Double.isFinite(value) ? String.valueOf(value) : "null"; }
-  static String jsonAny(Object value) { if (value == null) return "null"; if (value instanceof String s) return json(s); if (value instanceof Integer i) return json(i); if (value instanceof Double d) return json(d); if (value instanceof Boolean b) return json(b); return json(String.valueOf(value)); }
+  static String jsonAny(Object value) { if (value == null) return "null"; if (value instanceof String) return json((String) value); if (value instanceof Integer) return json((Integer) value); if (value instanceof Double) return json((Double) value); if (value instanceof Boolean) return json((Boolean) value); return json(String.valueOf(value)); }
   static TreeNode treeNode(Integer[] values) { if (values.length == 0 || values[0] == null) return null; TreeNode root = new TreeNode(values[0]); ArrayDeque<TreeNode> q = new ArrayDeque<>(); q.add(root); int i = 1; while (!q.isEmpty() && i < values.length) { TreeNode node = q.remove(); if (i < values.length && values[i] != null) { node.left = new TreeNode(values[i]); q.add(node.left); } i++; if (i < values.length && values[i] != null) { node.right = new TreeNode(values[i]); q.add(node.right); } i++; } return root; }
   public static void main(String[] args) {
     ArrayList<String> results = new ArrayList<>();

--- a/web/history.js
+++ b/web/history.js
@@ -1,5 +1,12 @@
 export const historyKey = "codetrial_history";
 
+/// Every request here is a small same-origin call, and every one of them is
+/// awaited by something the candidate is looking at: a stalled save leaves the
+/// report page saying "Saving report..." with no end, and a stalled clear leaves
+/// the Delete button disabled, because the finally that re-enables it never runs.
+/// A deadline turns both into the failure they already know how to report.
+const requestTimeoutMs = 10_000;
+
 /// Always a list. The key sits in the origin's local storage, which an older
 /// build, another tab, or anyone with devtools open can write, so what it holds
 /// is input rather than something this module chose. Unparseable JSON was
@@ -35,7 +42,10 @@ export async function clearReportHistory({ account = false, fetcher = fetch, sto
     const session = await sessionState(fetcher);
     if (session === "failed") return "failed";
     if (session === "in") {
-      const deleted = await fetcher("/api/reports", { method: "DELETE" });
+      const deleted = await fetcher("/api/reports", {
+        method: "DELETE",
+        signal: AbortSignal.timeout(requestTimeoutMs),
+      });
       if (!deleted.ok) return "failed";
     } else if (account !== false) {
       return "failed";
@@ -72,6 +82,7 @@ async function saveAccountReport(entry, fetcher) {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(entry),
+      signal: AbortSignal.timeout(requestTimeoutMs),
     });
     return saved.ok ? "saved" : "failed";
   } catch {
@@ -81,7 +92,7 @@ async function saveAccountReport(entry, fetcher) {
 
 async function sessionState(fetcher) {
   try {
-    const response = await fetcher("/api/session");
+    const response = await fetcher("/api/session", { signal: AbortSignal.timeout(requestTimeoutMs) });
     if (!response.ok) return "failed";
     const session = await response.json();
     if (session.signedIn === true) return "in";

--- a/web/history.js
+++ b/web/history.js
@@ -23,6 +23,35 @@ export async function saveReportHistory(entry, { fetcher = fetch, storage } = {}
   return { local, account };
 }
 
+/// `account` is what the page knows: whether the history it is showing came
+/// from an account. The session is still rechecked here rather than trusted
+/// from page load, because signing in from another tab has to reach the
+/// account copy. The pair matters in the other direction too: signing out from
+/// another tab leaves a copy this browser can no longer authenticate a delete
+/// for, and clearing the local half of that would report an erasure that only
+/// happened on this device.
+export async function clearReportHistory({ account = false, fetcher = fetch, storage } = {}) {
+  try {
+    const session = await sessionState(fetcher);
+    if (session === "failed") return "failed";
+    if (session === "in") {
+      const deleted = await fetcher("/api/reports", { method: "DELETE" });
+      if (!deleted.ok) return "failed";
+    } else if (account !== false) {
+      return "failed";
+    }
+    try {
+      storage ||= localStorage;
+      storage.removeItem(historyKey);
+      return "cleared";
+    } catch {
+      return session === "in" ? "account-cleared-local-failed" : "failed";
+    }
+  } catch {
+    return "failed";
+  }
+}
+
 function saveLocalReport(entry, storage) {
   try {
     storage ||= localStorage;

--- a/web/history.js
+++ b/web/history.js
@@ -5,8 +5,9 @@ export const historyKey = "codetrial_history";
 /// is input rather than something this module chose. Unparseable JSON was
 /// already answered with an empty list, but parseable JSON that is not one went
 /// straight through to callers that all treat it as an array.
-export function readLocalHistory(storage = localStorage) {
+export function readLocalHistory(storage) {
   try {
+    storage ||= localStorage;
     // No fallback for a missing key: `JSON.parse(null)` answers null, which is
     // not a list, and the shape check below already turns that into one.
     const stored = JSON.parse(storage.getItem(historyKey));
@@ -16,40 +17,48 @@ export function readLocalHistory(storage = localStorage) {
   }
 }
 
-export async function saveReportHistory(entry, { fetcher = fetch, storage = localStorage } = {}) {
-  saveLocalReport(entry, storage);
-  if (!(await signedIn(fetcher))) return false;
-  return syncReport(entry, fetcher);
+export async function saveReportHistory(entry, { fetcher = fetch, storage } = {}) {
+  const local = saveLocalReport(entry, storage);
+  const account = await saveAccountReport(entry, fetcher);
+  return { local, account };
 }
 
 function saveLocalReport(entry, storage) {
   try {
+    storage ||= localStorage;
     const previous = readLocalHistory(storage);
     storage.setItem(historyKey, JSON.stringify([entry, ...previous].slice(0, 20)));
+    return "saved";
   } catch {
+    return "failed";
   }
 }
 
-async function signedIn(fetcher) {
+async function saveAccountReport(entry, fetcher) {
+  const session = await sessionState(fetcher);
+  if (session === "out") return "skipped";
+  if (session === "failed") return "failed";
   try {
-    const response = await fetcher("/api/session");
-    if (!response.ok) return false;
-    const session = await response.json();
-    return session.signedIn === true;
-  } catch {
-    return false;
-  }
-}
-
-async function syncReport(entry, fetcher) {
-  try {
-    const response = await fetcher("/api/reports", {
+    const saved = await fetcher("/api/reports", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(entry),
     });
-    return response.ok;
+    return saved.ok ? "saved" : "failed";
   } catch {
-    return false;
+    return "failed";
+  }
+}
+
+async function sessionState(fetcher) {
+  try {
+    const response = await fetcher("/api/session");
+    if (!response.ok) return "failed";
+    const session = await response.json();
+    if (session.signedIn === true) return "in";
+    if (session.signedIn === false) return "out";
+    return "failed";
+  } catch {
+    return "failed";
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -699,8 +699,11 @@
         <button id="start" class="start-button" type="button" disabled>Start interview</button>
       </section>
 
-      <section id="history" class="history" aria-labelledby="progress-title" hidden>
+      <div id="history-header" class="history-header" hidden>
         <h2 id="progress-title">Interview progress</h2>
+        <button id="delete-reports" class="pill-button danger" type="button" disabled>Delete saved reports</button>
+      </div>
+      <section id="history" class="history" aria-labelledby="progress-title" hidden>
         <fieldset class="progress-filters">
           <legend>Filter attempts</legend>
           <label>Difficulty <select id="progress-difficulty"><option value="all">All</option></select></label>
@@ -714,6 +717,7 @@
           <ol id="progress-weaknesses"></ol>
         </section>
       </section>
+      <p id="report-delete-status" class="small" tabindex="-1"></p>
 
       <!-- The interviewer model's own metadata sets "creditNotation":
            "required", so naming its author is a license term rather than a

--- a/web/interview.js
+++ b/web/interview.js
@@ -17,6 +17,7 @@ import {
   problemMarkup,
   reportMarkdown,
   reportMarkup,
+  reportSaveStatus,
   resultsMarkup,
   runnerStatusMarkup,
 } from "./render.js";
@@ -1036,13 +1037,14 @@ async function receiveReport(room, payload) {
     void flushReplay();
     state.phase = "report";
     setLocalAudioEnabled(false);
-    await saveHistory();
+    const saving = saveHistory();
     // renderReport releases the devices for every report path, so there is no
     // separate stopLocalMedia here.
     renderReport();
     void room.disconnect().catch(() => {});
     state.room = null;
     state.connected = false;
+    renderReportSaveStatus(await saving);
   } catch (error) {
     // A malformed report is not worth tearing the session down over, but it is
     // worth saying so: this catch also covers saveHistory and renderReport, so
@@ -1487,7 +1489,6 @@ function leaveRoom() {
 async function showReport() {
   if (state.phase === "report") return;
   state.phase = "report";
-  nodes.ending.hidden = true;
   const passed = state.latestSummary?.passed || 0;
   const total = state.latestSummary?.total || 0;
   // Only the candidate's own turns count as having communicated. Jim's greeting
@@ -1512,8 +1513,9 @@ async function showReport() {
     { kind: "coding", budgetMin: codingMinutes, status: total > 0 && passed === total ? "complete" : "incomplete" },
     { kind: "behavioral", budgetMin: behavioralMinutes, status: interviewLoop === "coding_only" ? "not_configured" : "skipped" },
   ] };
-  await saveHistory();
+  const saving = saveHistory();
   renderReport();
+  renderReportSaveStatus(await saving);
 }
 
 function renderReport() {
@@ -1525,14 +1527,24 @@ function renderReport() {
   // candidate was looking at a screen telling them the interview had ended.
   stopAvatar();
   stopLocalMedia();
+  nodes.ending.hidden = true;
   nodes.report.hidden = false;
   nodes.report.innerHTML = reportMarkup({
     report: state.report,
     problemTitle: problem.title,
     language: state.language,
     code: currentCode(),
+    saveResult: null,
   });
   mountBehavioralReview(nodes.report, state.transcript.values());
+}
+
+function renderReportSaveStatus(result) {
+  const node = nodes.report.querySelector("#report-save-status");
+  const status = reportSaveStatus(result);
+  node.textContent = status.message;
+  node.className = status.className;
+  nodes.report.querySelector("#done").disabled = false;
 }
 
 function saveHistory() {

--- a/web/render.js
+++ b/web/render.js
@@ -113,6 +113,13 @@ export function problemMarkup(problem) {
   `;
 }
 
+export function reportSaveStatus(result) {
+  if (result === null) return { message: "Saving report...", className: "muted small" };
+  if (result.account === "saved") return { message: "Saved to your account", className: "muted small" };
+  if (result.local === "saved") return { message: "Saved on this device only", className: "muted small" };
+  return { message: "Report was not saved", className: "critical small" };
+}
+
 /// Only the verdict and the scores differ between an evaluated session and one
 /// that produced nothing. Forking the whole card duplicated the header, the
 /// evidence section, the code block and the actions row, including the
@@ -120,7 +127,7 @@ export function problemMarkup(problem) {
 /// Exactly one expression in this file emits `/ 100`, and it sits behind the
 /// guard, so "no scores in an incomplete report" is structural rather than
 /// something a test has to catch after the fact.
-export function reportMarkup({ report, problemTitle, language, code }) {
+export function reportMarkup({ report, problemTitle, language, code, saveResult }) {
   const hire = report.decision === "HIRE";
   const heading = report.incomplete ? "No evaluation" : "Your performance packet";
   const badge = report.incomplete
@@ -155,6 +162,9 @@ export function reportMarkup({ report, problemTitle, language, code }) {
   const contract = report.interviewContract
     ? `Contract bundle ${report.interviewContract.bundleVersion} · rubric ${report.interviewContract.rubricVersion} · report schema ${report.interviewContract.reportSchemaVersion}`
     : "Legacy/unversioned contract";
+  // Replay renders reports it did not create, so only the interview caller
+  // supplies this field and mounts a live region for the pending save.
+  const saveStatus = saveResult === undefined ? null : reportSaveStatus(saveResult);
 
   return `
     <div class="report-card">
@@ -170,7 +180,8 @@ export function reportMarkup({ report, problemTitle, language, code }) {
       ${frameworkTimeline}
       ${integrityEvidenceMarkup(report)}
       <details><summary>Your final code (${escapeHtml(language)})</summary><pre>${escapeHtml(code.trimEnd() || "(editor was empty)")}</pre></details>
-      <div class="report-actions"><button id="download-report" type="button">Download report (.md)</button><button id="done" type="button">Done - back to lobby</button></div>
+      ${saveStatus ? `<p id="report-save-status" class="${saveStatus.className}" role="status">${saveStatus.message}</p>` : ""}
+      <div class="report-actions"><button id="download-report" type="button">Download report (.md)</button><button id="done" type="button"${saveResult === null ? " disabled" : ""}>Done - back to lobby</button></div>
     </div>
   `;
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -414,7 +414,8 @@ p {
 .editor-toolbar,
 .language-tabs,
 .report-header,
-.report-actions {
+.report-actions,
+.history-header {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -987,7 +988,14 @@ p {
   justify-content: space-between;
 }
 
-.report-header h2 {
+.history-header {
+  margin-top: 1rem;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.report-header h2,
+.history-header h2 {
   margin: 0;
 }
 


### PR DESCRIPTION
Report persistence was silent and one way. `saveReportHistory` returned a single boolean that no caller rendered, so a local quota failure, a signed-out skip and an account error all looked the same to the candidate: nothing on screen either way. The per-account report quota had no erase path either, so a candidate who filled it could not clear their history, and new reports were refused until they overwrote one of their own by id.

The save now reports its local and account outcomes separately and shows them under the report. Done is held until the save settles, because that button navigates to the lobby and would abort the request behind it. An owner-scoped bulk delete sits behind a lobby confirmation and leaves interviews, replays and recordings to their separate lifecycles. Clearing rechecks the session rather than trusting what the lobby knew at page load, so a candidate who signed in from another tab still has the account copy erased, and local history survives a delete that cannot be proven to have happened. Every request in that module carries a deadline now, because each one is awaited by something the candidate is looking at and none of them could previously give up.

Three commits are unrelated housekeeping this turned up. eslint was walking an untracked `externals` directory and failing the gate on somebody else's JSX. Two copies of a `localStorage` test stub had drifted apart, one of them reading a stored empty string back as null and neither stringifying what it was given. The generated Java harness tested types with `instanceof` pattern matching, which needs javac 16 to compile, so every machine with an older JDK skipped the harness test instead of running it; it uses a plain `instanceof` and a cast now, and the test runs wherever a JDK exists.

Verified with `make check`: 392 browser tests and 563 Rust tests pass with nothing skipped, and every commit in the series builds, lints and passes on its own. Beyond the gate, the owner scoping was mutation tested, since widening the delete to an unscoped predicate fails the test by taking the other account's report with it; the generated harness was compiled and run under `javac --release 8` and matched the expected judge output; and a full interview against the release binary saved its report to the account store.

Nothing here changes the single guarded SQLite connection, whose ceiling is documented where it lives. Worth knowing separately: `tests/cli.rs` carries a pre-existing flake on memory-constrained machines, where a spawned server is killed with SIGKILL and the test reports it as the behavior under test failing. This branch does not touch that suite.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Saved report history was silent and one-way. It now shows the save outcome on the report page and gives candidates a way to erase saved reports and progress.

**New Features**
- Report page shows "Saved to your account", "Saved on this device only", or "Report was not saved"; Done stays disabled until the save settles.
- Lobby adds a Delete saved reports button, disabled until the lobby settles, that requires confirmation and clears the account's reports and local history even when the per-account quota is full; interviews, replays, and recordings keep their separate lifecycles.
- Deleting rechecks the session so signing in from another tab still erases the account copy; local history is kept when account deletion cannot be confirmed.
- All history requests have a 10-second deadline so a stalled save or clear reports failure instead of hanging.

**Bug Fixes**
- `eslint` no longer lints the untracked `externals/` directory.
- Browser tests share a `localStorage` stub that matches browser behavior.
- Generated Java harness uses Java 8 syntax so the harness test runs on older JDKs.

<sup>Written for commit bed6f7bca1402e6f91df392b633cafa8e88c2fc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/codetrial/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

